### PR TITLE
Fix for correct `require` name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ module.exports.createClient = function(main) {
         });
 
         display.client.require('glx', function(err, GLX) {
-          display.client.require('Render', function(err, Render) {
+          display.client.require('render', function(err, Render) {
             // we prelod Render and GLX
             display.Render = Render;
             display.GLX = GLX;


### PR DESCRIPTION
Because `x11/lib/ext/render.js` lowercase letter `r`