### PR TITLE
Updated the font-manager dependency to prevent compilation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bezier": "^0.1.0",
     "canvas-fontstyle": "^1.0.1",
     "es6-promise": "^3.0.2",
-    "font-manager": "^0.2.0",
+    "font-manager": "^0.3.0",
     "freetype2": "^0.3.0",
     "gaussian-convolution-kernel": "^1.0.0",
     "keysym": "0.0.6",


### PR DESCRIPTION
Compilation of version `0.2.0` of the [`font-manager`](https://www.npmjs.com/package/font-manager) package, which is a dependency of this package, fails on NodeJS 9+, making it impossible to use `ntk` with these versions.
The maintainer [published version 0.3.0](https://github.com/devongovett/font-manager/issues/24#issuecomment-392576727) to fix that problem and now it works again.

This PR just updates the version of the dependency.