### PR TITLE
feat: vector text path (#45), KaTeX math widget, highlighted markdown fences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,14 +41,18 @@ lib/renderingcontext_x11.js     raw core-X drawing context
 lib/picture.js             XRender Picture wrapper (+ blur filter)
 lib/glyphset.js            XRender GlyphSet wrapper
 lib/rasterize.js           pure-JS glyph outline -> a8 bitmap rasterizer
+lib/trapezoid.js           polygon -> XRender trapezoids (vector text path)
 lib/fontconfig.js          font matching + fallback chain via fc-match CLI
 lib/text/font.js           Font: fontkit face — metrics, coverage, shaping
 lib/text/fontmanager.js    FontManager (app.fonts): match/load/fallback
 lib/text/shape.js          bidi (UAX#9) + itemization + shaping pipeline
 lib/text/layout.js         TextLayout: UAX#14 wrapping, alignment, spans
-lib/text/glyphs.js         glyph pages (compact ids) + CompositeGlyphs encoder
-lib/widgets/markdown.js    dependency-free markdown parser
-lib/widgets/markdownview.js  MarkdownView widget
+lib/text/glyphs.js         glyph pages (compact ids) + CompositeGlyphs encoder,
+                           bitmap/vector routing policy, glyph-page LRU
+lib/widgets/markdown.js    markdown parsing (adapter over marked)
+lib/widgets/markdownview.js  MarkdownView widget (highlighted + math fences)
+lib/widgets/highlight.js   fence syntax highlighting (adapter over highlight.js)
+lib/widgets/tex.js         KaTeX-based TexView widget / layoutTex
 test/                      node:test suite (see below)
 docs/                      public API documentation
 examples/                  runnable examples (own package.json, ESM)
@@ -60,12 +64,18 @@ their side effects.
 
 ## Hard constraints
 
-- **Pure-JS dependencies only.** No node-gyp/native modules. If a capability
-  seems to need a compiled module, find a JS implementation, shell out to a
-  universally-available CLI (like `fc-match`), or implement it in `lib/`
-  (like `rasterize.js`). This is why weak-napi (→ `FinalizationRegistry`),
-  freetype2 (→ fontkit + own rasterizer), harfbuzz (→ fontkit shaping),
-  fribidi (→ bidi-js) and font-scanner (→ fc-match) were removed/avoided.
+- **Dependencies:** use external dependencies if they are maintained, easy
+  to install, portable and don't add too much weight. Native (node-gyp)
+  modules fail the easy-to-install/portable bar — for those capabilities
+  find a JS implementation, shell out to a universally-available CLI (like
+  `fc-match`), or implement it in `lib/` (like `rasterize.js`); this is why
+  weak-napi (→ `FinalizationRegistry`), freetype2 (→ fontkit + own
+  rasterizer), harfbuzz (→ fontkit shaping), fribidi (→ bidi-js) and
+  font-scanner (→ fc-match) were removed/avoided. The flip side: don't
+  hand-roll what a maintained library does better — the original in-repo
+  markdown parser and syntax highlighter were subtly wrong (e.g. intra-word
+  `_` emphasis) and are now thin adapters over `marked` and `highlight.js`,
+  the same way math rendering uses `katex`.
 - **ESM**, Node >= 20.19. No TypeScript for now (a possible later migration —
   keep JSDoc accurate instead).
 - Server-side resources (windows, pixmaps, pictures, glyphsets) must offer

--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ pure JS — OpenType kerning/ligatures and complex scripts (fontkit), bidi
 (bidi-js), automatic font fallback — rasterized by a built-in scanline
 rasterizer and cached server-side as XRender glyphs, so drawing a line of
 text costs about a byte per glyph on the wire. Font names resolve through
-fontconfig (`fc-match`). A `TextLayout` engine wraps styled text to a target
-width, and a `MarkdownView` widget renders markdown on top of it — see
-[docs/text.md](docs/text.md).
+fontconfig (`fc-match`). Very large and continuously animated sizes render
+as server-side trapezoids instead of cached bitmaps. A `TextLayout` engine
+wraps styled text to a target width, a `MarkdownView` widget renders
+markdown (with syntax-highlighted code fences) on top of it, and a
+KaTeX-backed `TexView` renders TeX math — see [docs/text.md](docs/text.md)
+and [docs/tex.md](docs/tex.md).
 
 ```js
 import { createClient } from 'ntk';

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,9 @@ matching file here (see AGENTS.md).
 - [2d rendering context](context-2d.md) — canvas-like drawing API over XRender
 - [Fonts](fonts.md) — font lookup, loading, rasterization pipeline
 - [Text](text.md) — shaping (kerning/bidi/fallback), TextLayout, MarkdownView,
-  wire-efficiency design
+  wire-efficiency design, the vector (trapezoid) path for large/animated sizes
+- [TeX / math](tex.md) — KaTeX-based formula rendering: `layoutTex`, `TexView`,
+  markdown math fences
 - [OpenGL rendering context](context-opengl.md) — indirect GLX / OpenGL 1.4 API
 - [Raw X11 rendering context](context-x11.md) — core X drawing requests
 - [Resource management](resource-management.md) — `using` / `Symbol.dispose`, GC-based cleanup

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -73,7 +73,11 @@ pictures on GC.
 Text is fully shaped: OpenType kerning and ligatures, contextual forms for
 complex scripts (e.g. Arabic), bidi reordering and automatic font fallback
 all apply. Glyphs upload to the server once per (face, size); drawing costs
-about a byte per glyph afterwards.
+about a byte per glyph afterwards. Very large (>256px by default),
+fractional or frame-to-frame-varying sizes render as trapezoids instead —
+no per-size server cache — see
+[text.md](text.md#the-vector-trapezoid-text-path); tune via
+`app.textPolicy`.
 
 - `fillText(text, x, y)` — draws with the current `font` and `fillStyle`,
   honoring `textAlign` / `textBaseline`

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -15,11 +15,14 @@ The pipeline is pure JavaScript — no compiled modules:
    postscript name).
 3. **Rasterization** (`lib/rasterize.js`): glyph outlines are rasterized to
    8-bit alpha bitmaps by a small built-in scanline rasterizer (non-zero
-   winding, 4x4 supersampled antialiasing).
+   winding, 4x4 supersampled antialiasing; 2x2 above 96px where the extra
+   samples are invisible).
 4. **Upload**: bitmaps go to the X server as XRender glyphs (`AddGlyphs`) —
    once per glyph per (face, size), shared across all windows of the
    connection. Drawing afterwards is a cheap server-side `CompositeGlyphs`
-   (~1 byte per glyph).
+   (~1 byte per glyph). Very large or animated sizes skip this cache and
+   render as trapezoids instead — see
+   [text.md](text.md#the-vector-trapezoid-text-path).
 
 Glyphs are rasterized and uploaded **lazily**, as text is drawn — never a
 whole font up front.

--- a/docs/tex.md
+++ b/docs/tex.md
@@ -1,0 +1,110 @@
+# TeX math rendering
+
+ntk renders TeX formulas with [KaTeX](https://katex.org) (a pure-JS
+dependency, in line with the no-native-modules rule). KaTeX parses the TeX
+and produces its DOM tree; `lib/widgets/tex.js` lays that tree out directly
+in pixel space — reimplementing the small CSS subset KaTeX output actually
+uses (inline flow with em margins, vertical lists, border rules,
+font-size/font-family classes) — and draws through the normal ntk text
+stack using the KaTeX `.ttf` fonts bundled with the package. No browser, no
+DOM, no fontconfig involvement.
+
+```js
+import { createClient, TexView, layoutTex } from 'ntk';
+
+// widget: one formula in a window, centered, re-rendered on expose
+const app = await createClient();
+const wnd = app.createWindow({ width: 480, height: 160, title: 'math' });
+new TexView(wnd, { tex: '\\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2}', size: 32 });
+wnd.map();
+
+// headless: measure and draw anywhere
+const box = layoutTex('e^{i\\pi} + 1 = 0', { size: 24, color: '#222' });
+console.log(box.width, box.height, box.baseline);
+box.draw(ctx, 40, 40);
+```
+
+## `layoutTex(tex, options)` → `TexBox`
+
+Parses and lays out a formula. Headless — needs no X connection; the
+result can be measured and drawn any number of times.
+
+Options:
+
+- `size` — base font size in px (the formula's em), default 16
+- `displayMode` — KaTeX display mode (`\displaystyle`, block layout),
+  default false
+- `color` — default ink color; `\color{...}` spans override it
+- `katex` — extra options passed to KaTeX verbatim (`macros`, `strict`, …)
+
+KaTeX parse errors throw (`katex.ParseError`) — callers choose the
+fallback. `MarkdownView` falls back to rendering the source as a plain
+code block.
+
+## `TexBox`
+
+- `width`, `height` — layout box in px (`height` includes the depth below
+  the baseline)
+- `baseline` — px from the top of the box to the alphabetic baseline;
+  align formulas to surrounding text with `y = textBaseline - box.baseline`
+- `draw(ctx, x, y)` — draw with the top-left corner at (x, y). The context
+  `fillStyle` is used for items without an explicit color and left
+  untouched.
+
+## `TexView`
+
+A widget owning a window: clears the background, centers the formula and
+redraws on expose.
+
+```js
+const view = new TexView(wnd, {
+  tex: '\\frac{a}{b}', // initial formula (optional)
+  size: 24,            // px em
+  color: '#222222',
+  background: 'white',
+  displayMode: true,   // default for the widget
+  padding: 16,
+  katex: { macros: { '\\R': '\\mathbb{R}' } }
+});
+view.setTex('\\R^n');  // update + re-render
+view.box;              // current TexBox (metrics)
+```
+
+## Markdown integration
+
+Fenced blocks tagged `math`, `tex`, `latex` or `katex` inside a
+`MarkdownView` render as centered display-mode formulas at 1.21× the base
+text size (matching katex.css's `.katex` font-size):
+
+    ```math
+    \sum_{i=0}^{n} i = \frac{n(n+1)}{2}
+    ```
+
+## Wire efficiency
+
+The renderer follows the same philosophy as the rest of the text stack
+(see [text.md](text.md)):
+
+- Adjacent symbols resolving to the same font/size/color are concatenated
+  and shaped as **single runs** (KaTeX's own metrics come from the same
+  font files, so positions agree). A formula does not become one Composite
+  per character.
+- Drawing batches **all runs of a color into one `CompositeGlyphs`
+  request** — a typical formula is one composite for the glyphs plus a
+  `FillRectangles`-style composite per fraction/overline rule.
+- Radical surds and stretchy SVG fills are flattened client-side and
+  rendered server-side as trapezoids through the same batched `AddTraps`
+  scratch mask the vector text path uses.
+- Glyphs go through the standard per-(face, size) glyph pages: formula
+  redraws hit the server cache, and the LRU budget applies.
+
+## Coverage and limits
+
+Supported KaTeX output constructs: symbols across all KaTeX fonts
+(Main/Math/AMS/Caligraphic/Fraktur/Script/SansSerif/Typewriter/Size1–4),
+sub/superscripts, fractions and binomials, radicals (with indices), big
+operators with limits, big/stacked delimiters, accents, matrices and
+environments, `\color`, sizing commands, spacing/kerns, `\rule`,
+over/underlines, `\llap`/`\rlap`/`\clap`. Unhandled constructs degrade
+gracefully (extension-specific spans render their text content; unknown
+boxes take zero space). `\hdashline` renders solid rather than dashed.

--- a/docs/text.md
+++ b/docs/text.md
@@ -12,7 +12,7 @@ lib/text/fontmanager.js  FontManager (`app.fonts`): matching, custom fonts,
 lib/text/shape.js        bidi (UAX#9) → font itemization → OpenType shaping
 lib/text/layout.js       TextLayout: UAX#14 line breaking, wrapping, alignment
 lib/text/glyphs.js       server glyph cache + CompositeGlyphs encoder
-lib/widgets/markdown.js  markdown parser (no dependencies)
+lib/widgets/markdown.js  markdown parsing (adapter over `marked`)
 lib/widgets/markdownview.js  MarkdownView widget
 ```
 
@@ -53,9 +53,14 @@ layout.draw(ctx, 16, 60);
    scripts (Arabic joining etc.). RTL runs come back in visual order.
 5. **Rasterize + upload** — new glyphs are rasterized by the built-in
    scanline rasterizer (`lib/rasterize.js`) and uploaded once per
-   (face, size) with a single batched `AddGlyphs` request.
+   (face, size) with a single batched `AddGlyphs` request. (Above 96px the
+   supersampling drops from 4×4 to 2×2 — indistinguishable at that size and
+   4× cheaper.)
 6. **Composite** — drawing sends one `CompositeGlyphs` request; the server
    does all the actual blending.
+
+Very large or continuously animated sizes take a different route — see
+[the vector text path](#the-vector-trapezoid-text-path) below.
 
 ## Wire efficiency
 
@@ -73,13 +78,54 @@ XRender glyph ids are client-assigned, and ntk exploits that:
 - Mixed faces/sizes in one draw (font fallback, styled spans) use in-request
   **glyphset switch** entries (12 bytes) instead of separate requests.
 - Uploaded bitmaps are cached per app connection (`app._glyphPages`) and
-  shared by every window and pixmap; re-drawing text costs no uploads.
+  shared by every window and pixmap; re-drawing text costs no uploads. The
+  cache is LRU-bounded (default 8MB of uploaded bitmap bytes): when the
+  budget is exceeded, the least-recently-drawn (face, size) page is freed
+  server-side with `FreeGlyphSet`, so transient sizes don't accumulate.
 - `TextLayout` memoizes shaping per word, so re-wrapping on window resize
   re-uses shaped glyphs and sends only composition requests.
 
 For scale: a 60-character line of 16px Latin text is ~70 bytes of
 `CompositeGlyphs` after warm-up. The one-time glyph upload for a full
 Latin face at 16px is a few kilobytes.
+
+## The vector (trapezoid) text path
+
+Bitmap glyph uploads scale with size² while outline complexity scales with
+roughly √size: measured on a serif face, the wire-size crossover is at
+≈96–128px for Latin and ≈130–190px for dense CJK, and at 256px a full Latin
+set costs ~2.4MB of server-side cache per face. Uploads amortize for text
+that is drawn repeatedly — but never for *continuously animated* sizes
+(zoom/pinch), where every frame is a new (face, size) page.
+
+So `drawGlyphRuns` routes each run (issue #45):
+
+- **size ≤ 128px** — cached bitmap glyphs, unconditionally (status quo);
+- **size > 256px** — trapezoids by default: the glyph outline is flattened
+  at the exact size, decomposed into trapezoids (`lib/trapezoid.js`) and
+  rendered server-side with one batched `AddTraps` + `Composite` through a
+  shared scratch a8 mask per draw. Nothing is cached server-side;
+- **in between** — bitmaps, unless the size is fractional or a small
+  per-face ring of recently drawn sizes shows no reuse (an animation in
+  flight). Both signals route to vector, and an animation that settles
+  flips back to bitmaps on the next frame.
+
+Vector-path positioning is *not* rounded to whole pixels, so fractional
+sizes and fractional pen positions animate smoothly (the bitmap path rounds
+both, which is correct for static UI text).
+
+The thresholds and the cache budget are per-app configurable:
+
+```js
+app.textPolicy = {
+  bitmapMax: 128,        // ≤ this: always bitmaps
+  vectorFrom: 256,       // > this: always trapezoids (Infinity to opt out)
+  cacheBytes: 8 << 20    // LRU budget for uploaded glyph bitmaps
+};
+```
+
+Partial objects are fine — unset keys keep their defaults
+(`DEFAULT_TEXT_POLICY` in `lib/text/glyphs.js`).
 
 ## API
 
@@ -168,14 +214,46 @@ view.setMarkdown('# Hello\n\nSome *markdown*.');
 wnd.map(); // renders on expose, re-wraps on resize
 ```
 
-Blocks: headings, paragraphs, fenced code, blockquotes, nested
-ordered/unordered lists, `---` rules. Inlines: `**strong**`, `*em*`,
-`` `code` `` (with background), `[links](url)` (colored + underlined).
+Parsing is CommonMark + GFM via [marked](https://marked.js.org). Rendered
+blocks: headings, paragraphs, fenced code, blockquotes, nested
+ordered/unordered lists, `---` rules (tables fall back to their monospaced
+source for now). Inlines: `**strong**`, `*em*`, `` `code` `` (with
+background), `[links](url)` (colored + underlined); images render as links
+to their source.
 All layout — wrapping, font selection per style, spacing — runs through
 `TextLayout`; drawing batches glyphs per color.
 
+Fenced code blocks are **syntax highlighted** through
+[highlight.js](https://highlightjs.org) (the `common` build: ~36 languages
+plus their aliases — `js`/`ts`, `json`, `python`, `shell`, `c`/`cpp`,
+`java`, `go`, `rust`, `css`, `sql`, `html`/`xml`, …), adapted to flat
+tokens by `lib/widgets/highlight.js` (exported as `highlightCode`).
+Unknown tags render plain. Colors come from `theme.codeTheme`, a map from
+token kind (`keyword`, `literal`, `string`, `number`, `comment`, `tag`,
+`attr`, `function`) to color — partial overrides merge with the defaults.
+
+Fences tagged `math`, `tex`, `latex` or `katex` render as **display-mode
+formulas** via KaTeX (centered, at 1.21× the base size like katex.css);
+a formula that fails to parse falls back to a plain code block. See
+[tex.md](tex.md).
+
+Links are clickable. Every `draw()` records the device-space rectangles of
+rendered links; `view.linkAt(x, y)` returns the href under a point (or
+null). In window mode a left-button `mousedown` is resolved automatically
+and forwarded to `view.onLink(href, event)` — set it via the `onLink`
+constructor option or assign the property; standalone embedders call
+`linkAt` from their own event handlers. Navigation semantics (opening
+files, browsers, history) are the embedder's job —
+[examples/markdown.js](../examples/markdown.js) is a small documentation
+browser built this way.
+
 Headless/embedded use: `new MarkdownView(null, { fonts })`, then
 `view.layout(width)` → content height, `view.draw(ctx, x, y)`.
+
+`TextLayout` note for widget authors: spans keep unknown fields through
+layout normalization, and line runs expose their span (`run.span`), so
+markers attached to spans (like MarkdownView's `_href`) can be read back
+per positioned run after layout.
 
 ![the markdown widget rendering examples/markdown.js](img/markdown-widget.png)
 
@@ -200,15 +278,11 @@ resolved in 2026:
   `fontkit.hasGlyphForCodePoint` confirms before use.
 - **#16 custom fonts api** — `app.fonts.load(path)`, mirroring
   node-canvas's `registerFont`.
-- **#14/#25/#34 vector outlines for large sizes** — **not implemented,
-  deliberately.** The premise (glyph upload too slow for large sizes) is
-  much weaker under this design: bitmaps upload once per face/size and are
-  shared connection-wide, so even a 100px glyph (~10KB once) beats
-  re-sending trapezoids (~1KB+ per *draw*) after the second use. Trapezoid
-  text would also lose server-side glyph caching and antialiasing
-  consistency. If one-shot huge display text ever becomes a bottleneck, the
-  `fill()` path (pnltri trapezoids) can render `Font.rasterize`'s source
-  outlines directly — the outline data is already available via
-  `font.fk.getGlyph(id).path`.
+- **#14/#25/#34 vector outlines for large sizes** — superseded by **#45**,
+  which replaced the old premise with measured crossovers and is now
+  implemented: bitmaps stay the default where reuse amortizes uploads
+  (≤128px, and any size that repeats), trapezoids take over for very large
+  and continuously animated sizes. See
+  [the vector text path](#the-vector-trapezoid-text-path).
 
 x11 dependency: already at the latest published release (2.3.0).

--- a/examples/markdown.js
+++ b/examples/markdown.js
@@ -1,13 +1,22 @@
-// Markdown rendering: full client-side layout (shaping, wrapping, styles)
-// drawn with batched server-side glyph composition. Resize the window to
-// watch it re-wrap.
+// Markdown documentation browser: full client-side layout (shaping,
+// wrapping, styles, highlighted + math fences) with clickable local links.
+//
+// The start page links to the ntk documentation in docs/; clicking a local
+// .md link navigates (Backspace or the "back" link returns), http(s) links
+// open in the system browser, the wheel / arrow keys scroll. Resize the
+// window to watch everything re-wrap.
+import { readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { createClient, MarkdownView } from '../lib/index.js';
 
-const app = await createClient();
-const wnd = app.createWindow({ width: 640, height: 720, title: 'ntk markdown' });
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-const view = new MarkdownView(wnd);
-view.setMarkdown(`# ntk text rendering
+const HOME = `# ntk text rendering
+
+**[View ntk documentation](docs/README.md)**
 
 The text pipeline is **pure JavaScript**: fonts are parsed with *fontkit*,
 shaped with OpenType \`GSUB\`/\`GPOS\` (kerning, ligatures, contextual forms),
@@ -19,8 +28,17 @@ Glyphs upload to the X server *once* per face and size; after that a line of
 text costs about **1 byte per glyph** on the wire:
 
 \`\`\`js
+// fences are syntax highlighted (dependency-free tokenizer)
 const layout = ctx.layoutText(text, { maxWidth: wnd.width - 32 });
 layout.draw(ctx, 16, 16);
+\`\`\`
+
+## Math
+
+Fences tagged \`math\`/\`latex\` render with KaTeX:
+
+\`\`\`math
+\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}
 \`\`\`
 
 ## Things that just work
@@ -37,6 +55,97 @@ layout.draw(ctx, 16, 16);
 
 ---
 
-*That's all, folks.*`);
+*That's all, folks.*`;
 
+const app = await createClient();
+const wnd = app.createWindow({ width: 640, height: 720, title: 'ntk markdown' });
+const ctx = wnd.getContext('2d');
+const view = new MarkdownView(null, { fonts: app.fonts });
+
+let currentPath = null; // null = home page, else absolute path of the .md
+const history = [];
+let scroll = 0;
+let layoutWidth = -1;
+
+function show(path) {
+  currentPath = path;
+  scroll = 0;
+  layoutWidth = -1;
+  let md;
+  if (!path) {
+    md = HOME;
+    wnd.setTitle('ntk markdown');
+  } else {
+    try {
+      md = `[← back](ntk:back)\n\n${readFileSync(path, 'utf8')}`;
+    } catch (err) {
+      md = `[← back](ntk:back)\n\n# Cannot open\n\n\`${path}\`\n\n${err.message}`;
+    }
+    wnd.setTitle(`ntk docs — ${relative(repoRoot, path)}`);
+  }
+  view.setMarkdown(md);
+  render();
+}
+
+function render() {
+  if (layoutWidth !== wnd.width) {
+    view.layout(wnd.width);
+    layoutWidth = wnd.width;
+  }
+  scroll = Math.max(0, Math.min(scroll, view.contentHeight - wnd.height));
+  ctx.fillStyle = view.theme.background;
+  ctx.fillRect(0, 0, wnd.width, wnd.height);
+  view.draw(ctx, 0, view.theme.padding - scroll);
+}
+
+function navigate(href) {
+  if (href === 'ntk:back') {
+    show(history.pop() ?? null);
+    return;
+  }
+  if (/^https?:/.test(href)) {
+    const opener = process.platform === 'darwin' ? 'open' : 'xdg-open';
+    spawn(opener, [href], { detached: true, stdio: 'ignore' }).unref();
+    return;
+  }
+  const clean = href.replace(/#.*$/, '');
+  if (!clean.endsWith('.md')) return; // images etc.
+  const base = currentPath ? dirname(currentPath) : repoRoot;
+  const target = resolve(base, clean);
+  if (!target.startsWith(repoRoot)) return; // stay inside the repo
+  history.push(currentPath);
+  show(target);
+}
+
+wnd.on('expose', render);
+wnd.on('resize', render);
+
+wnd.on('mousedown', (ev) => {
+  if (ev.keycode === 4 || ev.keycode === 5) {
+    scroll += ev.keycode === 4 ? -60 : 60; // wheel
+    render();
+    return;
+  }
+  if (ev.keycode !== 1) return; // left click
+  const href = view.linkAt(ev.x, ev.y);
+  if (href) navigate(href);
+});
+
+const KEY = { up: 0xff52, down: 0xff54, pageUp: 0xff55, pageDown: 0xff56, home: 0xff50, end: 0xff57, backspace: 0xff08 };
+wnd.on('keydown', (ev) => {
+  const sym = wnd.X.keycode2keysyms[ev.keycode]?.[0];
+  const page = wnd.height - 40;
+  if (sym === KEY.up) scroll -= 40;
+  else if (sym === KEY.down) scroll += 40;
+  else if (sym === KEY.pageUp) scroll -= page;
+  else if (sym === KEY.pageDown) scroll += page;
+  else if (sym === KEY.home) scroll = 0;
+  else if (sym === KEY.end) scroll = Infinity;
+  else if (sym === KEY.backspace) return navigate('ntk:back');
+  else return;
+  render();
+});
+
+show(null);
 wnd.map();
+console.log('click "View ntk documentation" — wheel/arrows scroll, Backspace goes back');

--- a/examples/tex.js
+++ b/examples/tex.js
@@ -1,0 +1,50 @@
+// KaTeX formula rendering + the vector text path.
+//
+// Formulas are laid out with layoutTex (KaTeX tree -> batched glyph
+// composition). The headline below zooms continuously: fractional,
+// never-repeating sizes route to the trapezoid path (issue #45), so no
+// glyph bitmaps are uploaded or cached for the animation.
+import { createClient, layoutTex } from '../lib/index.js';
+
+const app = await createClient();
+const wnd = app.createWindow({ width: 720, height: 420, title: 'ntk tex' });
+const ctx = wnd.getContext('2d');
+
+const formulas = [
+  '\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}',
+  '\\sum_{i=0}^{n} i = \\frac{n(n+1)}{2}',
+  'e^{i\\pi} + 1 = 0',
+  'A = \\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}',
+  '\\varphi = \\frac{1+\\sqrt{5}}{2}'
+];
+let current = 0;
+
+let t = 0;
+function draw() {
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, wnd.width, wnd.height);
+
+  const box = layoutTex(formulas[current], { size: 36, displayMode: true, color: '#222' });
+  box.draw(ctx, (wnd.width - box.width) / 2, 60);
+
+  // continuously animated fractional size -> vector (trapezoid) rendering
+  const size = 170 + 40 * Math.sin(t / 30);
+  ctx.font = `${size}px serif`;
+  ctx.fillStyle = '#1b4b91';
+  ctx.textAlign = 'center';
+  ctx.fillText('Aa', wnd.width / 2, 340);
+  ctx.textAlign = 'start';
+}
+
+wnd.on('expose', draw);
+wnd.on('mousedown', () => {
+  current = (current + 1) % formulas.length; // click: next formula
+  draw();
+});
+setInterval(() => {
+  t++;
+  draw();
+}, 1000 / 30);
+
+wnd.map();
+console.log('click the window to cycle formulas');

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ import Font from './text/font.js';
 import FontManager from './text/fontmanager.js';
 import { TextLayout } from './text/layout.js';
 import MarkdownView from './widgets/markdownview.js';
+import TexView, { layoutTex, TexBox } from './widgets/tex.js';
+import { tokenize as highlightCode } from './widgets/highlight.js';
 
 // rendering context modules register themselves on Drawable
 import './renderingcontext_x11.js';
@@ -79,5 +81,18 @@ export function createClient(options, callback) {
   return promise;
 }
 
-export { App, Window, Pixmap, Picture, Font, FontManager, TextLayout, MarkdownView };
+export {
+  App,
+  Window,
+  Pixmap,
+  Picture,
+  Font,
+  FontManager,
+  TextLayout,
+  MarkdownView,
+  TexView,
+  TexBox,
+  layoutTex,
+  highlightCode
+};
 export default { createClient };

--- a/lib/rasterize.js
+++ b/lib/rasterize.js
@@ -5,16 +5,19 @@
 // produces an antialiased 8-bit alpha bitmap suitable for XRender
 // AddGlyphs. Non-zero winding rule, 4x4 supersampling.
 
-const SS = 4; // supersampling factor per axis
+const DEFAULT_SS = 4; // supersampling factor per axis
 
 /**
  * @param {Array} commands path commands ({type: M|L|Q|C|Z, x, y, x1, y1, x2, y2})
+ * @param {number} [ss] supersampling factor per axis (large glyphs pass 2 —
+ *   AA quality is indistinguishable above ~96px and rasterization is 4x cheaper)
  * @returns {{width, height, left, top, data: Buffer}|null}
  *   left/top are offsets of the bitmap's top-left corner relative to the
  *   glyph origin (left is typically small, top is typically negative —
  *   above the baseline). Returns null for empty outlines (e.g. space).
  */
-export function rasterizePath(commands) {
+export function rasterizePath(commands, ss = DEFAULT_SS) {
+  const SS = ss;
   const polys = flatten(commands);
   if (polys.length === 0) return null;
 
@@ -95,7 +98,8 @@ export function rasterizePath(commands) {
 }
 
 // flatten M/L/Q/C/Z commands into closed polygons [x0,y0, x1,y1, ...]
-function flatten(commands) {
+// (shared with the vector/trapezoid glyph path — see lib/trapezoid.js)
+export function flatten(commands) {
   const polys = [];
   let cur = null;
   let x = 0;

--- a/lib/text/font.js
+++ b/lib/text/font.js
@@ -1,6 +1,6 @@
 import * as fontkit from 'fontkit';
 
-import { rasterizePath } from '../rasterize.js';
+import { flatten, rasterizePath } from '../rasterize.js';
 
 /**
  * A single font face (one entry of a .ttc collection, or a whole .ttf/.otf),
@@ -120,9 +120,24 @@ export default class Font {
   /**
    * Rasterize a glyph to an 8-bit alpha bitmap (or null for blank glyphs).
    * Converts fontkit's y-up font-unit path to the y-down pixel commands the
-   * scanline rasterizer expects.
+   * scanline rasterizer expects. Above 96px supersampling drops from 4x4 to
+   * 2x2 — visually indistinguishable at that size, 4x cheaper to rasterize.
    */
   rasterize(glyphId, size) {
+    return rasterizePath(this._pathCommands(glyphId, size), size > 96 ? 2 : 4);
+  }
+
+  /**
+   * Glyph outline as flattened closed polygons in y-down pixel space
+   * relative to the baseline origin — input for the vector (trapezoid)
+   * glyph path. Empty array for blank glyphs.
+   */
+  outline(glyphId, size) {
+    return flatten(this._pathCommands(glyphId, size));
+  }
+
+  /** fontkit y-up font-unit path -> y-down pixel-space M/L/Q/C/Z commands */
+  _pathCommands(glyphId, size) {
     const s = this.scale(size);
     const commands = [];
     for (const c of this.fk.getGlyph(glyphId).path.commands) {
@@ -153,6 +168,6 @@ export default class Font {
           break;
       }
     }
-    return rasterizePath(commands);
+    return commands;
   }
 }

--- a/lib/text/glyphs.js
+++ b/lib/text/glyphs.js
@@ -1,4 +1,35 @@
 import GlyphSet from '../glyphset.js';
+import Picture from '../picture.js';
+import Pixmap from '../pixmap.js';
+import { trapezoidize } from '../trapezoid.js';
+
+/**
+ * Text rendering policy — the bitmap/vector routing thresholds and the
+ * server-side glyph cache budget. Override per app via `app.textPolicy`
+ * (partial objects are fine, e.g. `app.textPolicy = { vectorFrom: Infinity }`
+ * to opt out of the vector path entirely). See docs/text.md.
+ *
+ * - `bitmapMax` — at or below this pixel size glyphs always render through
+ *   cached server-side bitmaps (upload once, ~1 byte per glyph per draw).
+ * - `vectorFrom` — above this size glyphs render as trapezoids every draw:
+ *   bitmap uploads scale with size² (a full Latin set at 256px is ~2.4MB of
+ *   server cache per face) while outlines scale with ~√size.
+ * - Between the two, bitmaps are used unless the size is fractional or the
+ *   face shows no size reuse across recent draws (continuous zoom/pinch
+ *   animation) — the cases where per-size caches never amortize.
+ * - `cacheBytes` — LRU budget for uploaded glyph bitmaps per connection;
+ *   least-recently-drawn (face, size) pages are freed server-side
+ *   (FreeGlyphSet) so transient sizes don't accumulate.
+ */
+export const DEFAULT_TEXT_POLICY = {
+  bitmapMax: 128,
+  vectorFrom: 256,
+  cacheBytes: 8 << 20
+};
+
+function policyOf(app) {
+  return app.textPolicy ? { ...DEFAULT_TEXT_POLICY, ...app.textPolicy } : DEFAULT_TEXT_POLICY;
+}
 
 /**
  * Server-side glyph cache for one (font face, pixel size) pair.
@@ -23,6 +54,7 @@ export class GlyphPage {
     this.size = size;
     this.glyphset = new GlyphSet(app);
     this.entries = new Map(); // font glyph id -> { lid, adv }
+    this.bytes = 0; // uploaded bitmap bytes, for the LRU budget
   }
 
   /** number of bits per glyph needed to address this page's ids */
@@ -62,6 +94,7 @@ export class GlyphPage {
         offY: 0,
         image: bitmap ? bitmap.data : Buffer.alloc(0)
       });
+      this.bytes += bitmap ? bitmap.data.length : 0;
     }
     if (batch) this.glyphset.addGlyphs(batch);
   }
@@ -69,19 +102,49 @@ export class GlyphPage {
   entry(fontGlyphId) {
     return this.entries.get(fontGlyphId);
   }
+
+  /** free the server-side glyphset (LRU eviction / shutdown) */
+  destroy() {
+    this.glyphset.destroy();
+    this.entries.clear();
+    this.bytes = 0;
+  }
 }
 
 /** per-app page cache: pages (and their server glyphsets) are shared by all
- *  windows/pixmaps of a connection */
+ *  windows/pixmaps of a connection. Access refreshes LRU order. */
 export function getGlyphPage(app, font, size) {
   if (!app._glyphPages) app._glyphPages = new Map();
   const key = `${font.key}@${size}`;
   let page = app._glyphPages.get(key);
-  if (!page) {
+  if (page) {
+    // Map iteration order is insertion order — re-insert to mark recent
+    app._glyphPages.delete(key);
+  } else {
     page = new GlyphPage(app, font, size);
-    app._glyphPages.set(key, page);
   }
+  app._glyphPages.set(key, page);
   return page;
+}
+
+/**
+ * Evict least-recently-used glyph pages until uploaded bitmaps fit the
+ * policy budget. `inUse` pages (referenced by requests queued this draw)
+ * are never evicted. Freeing is safe request-ordering-wise: FreeGlyphSet is
+ * queued after any CompositeGlyphs already issued on this connection.
+ */
+export function trimGlyphPages(app, policy = policyOf(app), inUse = null) {
+  const pages = app._glyphPages;
+  if (!pages) return;
+  let total = 0;
+  for (const page of pages.values()) total += page.bytes;
+  for (const [key, page] of pages) {
+    if (total <= policy.cacheBytes) break;
+    if (inUse && inUse.has(page)) continue;
+    pages.delete(key);
+    total -= page.bytes;
+    page.destroy();
+  }
 }
 
 const MAX_ELT_GLYPHS = 254; // 255 is the glyphset-switch marker
@@ -157,9 +220,42 @@ export function positionGlyphs(positioned) {
 }
 
 /**
- * Draw shaped runs. Uploads any missing glyphs, then issues a single
- * CompositeGlyphs request (with in-request glyphset switches when runs use
- * different faces/sizes).
+ * Decide how a (face, size) renders: cached bitmap glyphs or per-draw
+ * trapezoids. See DEFAULT_TEXT_POLICY for the reasoning; the middle band
+ * additionally watches a small ring of recently drawn sizes per face — a
+ * continuously animated size (zoom/pinch) never repeats, so it routes to
+ * vector where per-size caches would leak a glyphset every frame.
+ *
+ * @returns {'bitmap'|'vector'}
+ */
+export function routeGlyphSize(app, font, size, policy = policyOf(app)) {
+  if (size <= policy.bitmapMax) return 'bitmap';
+  if (size > policy.vectorFrom) return 'vector';
+
+  if (!app._sizeRings) app._sizeRings = new Map();
+  let ring = app._sizeRings.get(font.key);
+  if (!ring) {
+    ring = [];
+    app._sizeRings.set(font.key, ring);
+  }
+  const reused = ring.includes(size);
+  // dedupe consecutive entries so one frame drawing many runs at one size
+  // occupies a single slot — the ring then spans ~8 distinct frames
+  if (ring[ring.length - 1] !== size) {
+    ring.push(size);
+    if (ring.length > 8) ring.shift();
+  }
+
+  if (!Number.isInteger(size)) return 'vector';
+  if (!reused && new Set(ring).size >= 6) return 'vector'; // size churn: animating
+  return 'bitmap';
+}
+
+/**
+ * Draw shaped runs. Routes each run through the bitmap path (cached
+ * server-side glyphs, one CompositeGlyphs request) or the vector path
+ * (one AddTraps + Composite through a shared scratch a8 mask) according to
+ * `routeGlyphSize`.
  *
  * @param {App} app
  * @param {number} op Render.PictOp
@@ -168,6 +264,26 @@ export function positionGlyphs(positioned) {
  * @param {Array<{run, x, y}>} positioned visual-order runs with baseline origins
  */
 export function drawGlyphRuns(app, op, srcId, dstId, positioned) {
+  const policy = policyOf(app);
+  let bitmap = positioned;
+  let vector = null;
+  for (let i = 0; i < positioned.length; i++) {
+    const { run } = positioned[i];
+    if (routeGlyphSize(app, run.font, run.size, policy) === 'vector') {
+      if (!vector) {
+        vector = [];
+        bitmap = positioned.slice(0, i);
+      }
+      vector.push(positioned[i]);
+    } else if (vector) {
+      bitmap.push(positioned[i]);
+    }
+  }
+  if (bitmap.length) drawBitmapGlyphRuns(app, op, srcId, dstId, bitmap, policy);
+  if (vector) drawVectorGlyphRuns(app, op, srcId, dstId, vector);
+}
+
+function drawBitmapGlyphRuns(app, op, srcId, dstId, positioned, policy) {
   const Render = app.display.Render;
   const items = [];
   let bits = 8;
@@ -201,4 +317,140 @@ export function drawGlyphRuns(app, op, srcId, dstId, positioned) {
     items[0].y,
     encoded.elts
   );
+  trimGlyphPages(app, policy, new Set(pages.values()));
+}
+
+// AddTraps length field is a plain 16-bit request length (no BigReq in
+// node-x11's encoder): stay well under 65535 4-byte units per request
+const MAX_TRAPS_PER_REQUEST = 6000;
+
+/**
+ * Vector glyph path (issue #45): flatten outlines at the exact (fractional)
+ * size, trapezoidate, accumulate every glyph of the draw into one scratch a8
+ * mask with a single batched AddTraps, then one Composite to the target.
+ * Nothing is cached server-side, so continuously animated sizes cost no
+ * cache memory; wire bytes scale with outline complexity (~√size), which
+ * beats size²-scaling bitmap uploads above ~128-256px.
+ *
+ * Positions are intentionally NOT rounded to whole pixels — fractional
+ * advances and origins keep zoom animations smooth.
+ */
+function drawVectorGlyphRuns(app, op, srcId, dstId, positioned) {
+  // unrounded glyph origins + ink bounding box
+  const placed = [];
+  let minX = Infinity;
+  let minY = Infinity;
+  for (const { run, x, y } of positioned) {
+    let cursor = x;
+    for (const g of run.glyphs) {
+      const gx = cursor + g.dx;
+      const gy = y - g.dy;
+      cursor += g.ax;
+      const e = run.font.glyphExtents(g.id, run.size);
+      if (!Number.isFinite(e.minX) || e.maxX <= e.minX) continue; // blank glyph
+      placed.push({ run, glyph: g, x: gx, y: gy });
+      if (gx + e.minX < minX) minX = gx + e.minX;
+      if (gy + e.minY < minY) minY = gy + e.minY;
+    }
+  }
+  if (placed.length === 0) return;
+
+  const bx = Math.floor(minX) - 1;
+  const by = Math.floor(minY) - 1;
+
+  const traps = [];
+  for (const p of placed) {
+    trapezoidize(p.run.font.outline(p.glyph.id, p.run.size), p.x - bx, p.y - by, traps);
+  }
+  compositeTraps(app, op, srcId, dstId, traps, bx, by);
+}
+
+/**
+ * Rasterize trapezoids (relative to (bx, by) device coordinates) into the
+ * shared scratch a8 mask with batched AddTraps requests, then Composite the
+ * source through it onto the destination. Shared by the vector glyph path
+ * and by widgets that fill arbitrary outlines (e.g. TeX radicals).
+ *
+ * When bx/by are omitted they are derived from the trapezoid bounds (the
+ * trap coordinates are then treated as absolute device coordinates).
+ */
+export function compositeTraps(app, op, srcId, dstId, traps, bx, by) {
+  if (traps.length === 0) return;
+  const Render = app.display.Render;
+
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  if (bx === undefined) {
+    let minX = Infinity;
+    let minY = Infinity;
+    for (let i = 0; i < traps.length; i += 6) {
+      if (traps[i] < minX) minX = traps[i];
+      if (traps[i + 3] < minX) minX = traps[i + 3];
+      if (traps[i + 1] > maxX) maxX = traps[i + 1];
+      if (traps[i + 4] > maxX) maxX = traps[i + 4];
+      if (traps[i + 2] < minY) minY = traps[i + 2];
+      if (traps[i + 5] > maxY) maxY = traps[i + 5];
+    }
+    bx = Math.floor(minX);
+    by = Math.floor(minY);
+    const shifted = new Array(traps.length);
+    for (let i = 0; i < traps.length; i += 6) {
+      shifted[i] = traps[i] - bx;
+      shifted[i + 1] = traps[i + 1] - bx;
+      shifted[i + 2] = traps[i + 2] - by;
+      shifted[i + 3] = traps[i + 3] - bx;
+      shifted[i + 4] = traps[i + 4] - bx;
+      shifted[i + 5] = traps[i + 5] - by;
+    }
+    traps = shifted;
+    maxX -= bx;
+    maxY -= by;
+  } else {
+    for (let i = 0; i < traps.length; i += 6) {
+      if (traps[i + 1] > maxX) maxX = traps[i + 1];
+      if (traps[i + 4] > maxX) maxX = traps[i + 4];
+      if (traps[i + 5] > maxY) maxY = traps[i + 5];
+    }
+  }
+  const bw = Math.max(1, Math.ceil(maxX));
+  const bh = Math.max(1, Math.ceil(maxY));
+
+  const mask = scratchMask(app, bw, bh);
+  Render.FillRectangles(Render.PictOp.Src, mask.picture.id, [0, 0, 0, 0], [0, 0, bw, bh]);
+  for (let i = 0; i < traps.length; i += MAX_TRAPS_PER_REQUEST * 6) {
+    Render.AddTraps(mask.picture.id, 0, 0, traps.slice(i, i + MAX_TRAPS_PER_REQUEST * 6));
+  }
+  // src coords = dst coords (see drawBitmapGlyphRuns) so gradients line up
+  Render.Composite(op, srcId, mask.picture.id, dstId, bx, by, 0, 0, bx, by, bw, bh);
+  releaseScratchMask(app);
+}
+
+// One connection-wide scratch a8 pixmap for trap masks, grown as needed and
+// dropped again when a huge draw would otherwise pin megabytes server-side.
+const SCRATCH_KEEP_AREA = 1 << 21; // ~2MB of a8
+
+function scratchMask(app, w, h) {
+  let s = app._trapScratch;
+  if (!s || s.width < w || s.height < h) {
+    if (s) {
+      s.picture.destroy();
+      s.pixmap.destroy();
+    }
+    const width = Math.max(w, s ? s.width : 0);
+    const height = Math.max(h, s ? s.height : 0);
+    const pixmap = new Pixmap(app, { depth: 8, width, height });
+    const picture = new Picture(app, { drawable: pixmap, format: app.display.Render.a8 });
+    s = { pixmap, picture, width, height };
+    app._trapScratch = s;
+  }
+  return s;
+}
+
+function releaseScratchMask(app) {
+  const s = app._trapScratch;
+  if (s && s.width * s.height > SCRATCH_KEEP_AREA) {
+    s.picture.destroy();
+    s.pixmap.destroy();
+    app._trapScratch = null;
+  }
 }

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -40,8 +40,11 @@ export class TextLayout {
     const maxWidth = options.maxWidth ?? Infinity;
 
     // ---- normalize spans, resolve fonts eagerly ----
+    // unknown span fields ride along untouched (widgets attach markers like
+    // MarkdownView's _deco/_href and read them back from line runs)
     const spans = (typeof content === 'string' ? [{ text: content }] : content).map((s) => {
       const merged = {
+        ...s,
         text: String(s.text ?? ''),
         family: s.family ?? style.family ?? 'sans-serif',
         size: s.size ?? style.size ?? 16,

--- a/lib/trapezoid.js
+++ b/lib/trapezoid.js
@@ -1,0 +1,125 @@
+// Trapezoidal decomposition of flattened closed polygons (non-zero winding),
+// producing XRender AddTraps data.
+//
+// A horizontal slab sweep: slab boundaries are the sorted unique vertex y
+// coordinates, so edges never cross inside a slab (self-intersecting input —
+// e.g. overlapping composite-glyph contours — degrades gracefully to a
+// near-correct fill instead of failing). Spans where the winding number is
+// non-zero become trapezoids; a span whose left/right edges continue through
+// consecutive slabs is merged into a single tall trapezoid, which is what
+// keeps the output at roughly one trapezoid per outline edge.
+//
+// Output is the flat number list node-x11's Render.AddTraps expects:
+// 6 values per trapezoid — top spanfix (left x, right x, y) then bottom
+// spanfix (left x, right x, y), y-down, top.y < bottom.y.
+
+/**
+ * @param {Array<Array<number>>} polys closed polygons as flat [x0,y0,x1,y1,…]
+ * @param {number} [dx] translation applied to every x
+ * @param {number} [dy] translation applied to every y
+ * @param {Array<number>} [out] existing array to append trapezoid data to
+ * @returns {Array<number>} `out`
+ */
+export function trapezoidize(polys, dx = 0, dy = 0, out = []) {
+  // collect non-horizontal edges, normalized to y0 < y1 with winding dir
+  const edges = [];
+  const ys = [];
+  for (const poly of polys) {
+    const n = poly.length / 2;
+    for (let i = 0; i < n; ++i) {
+      const j = (i + 1) % n;
+      const ax = poly[i * 2] + dx;
+      const ay = poly[i * 2 + 1] + dy;
+      const bx = poly[j * 2] + dx;
+      const by = poly[j * 2 + 1] + dy;
+      if (ay === by) continue;
+      edges.push(
+        ay < by
+          ? { x0: ax, y0: ay, x1: bx, y1: by, dir: 1, xa: 0, xb: 0 }
+          : { x0: bx, y0: by, x1: ax, y1: ay, dir: -1, xa: 0, xb: 0 }
+      );
+      ys.push(ay, by);
+    }
+  }
+  if (edges.length === 0) return out;
+
+  ys.sort((a, b) => a - b);
+  edges.sort((a, b) => a.y0 - b.y0);
+
+  const active = [];
+  let nextEdge = 0;
+  // spans open from the previous slab, for vertical merging:
+  // { l: leftEdge, r: rightEdge, at: index of the trap in `out` }
+  let prevSpans = [];
+
+  for (let yi = 0; yi < ys.length - 1; ++yi) {
+    const ya = ys[yi];
+    const yb = ys[yi + 1];
+    if (yb === ya) continue;
+
+    // update the active edge list for this slab
+    for (let i = active.length - 1; i >= 0; --i) {
+      if (active[i].y1 <= ya) active.splice(i, 1);
+    }
+    while (nextEdge < edges.length && edges[nextEdge].y0 <= ya) {
+      if (edges[nextEdge].y1 > ya) active.push(edges[nextEdge]);
+      nextEdge++;
+    }
+    if (active.length === 0) {
+      prevSpans = [];
+      continue;
+    }
+
+    // x at slab top/bottom for each active edge; sort left-to-right
+    for (const e of active) {
+      const inv = (e.x1 - e.x0) / (e.y1 - e.y0);
+      e.xa = e.x0 + (ya - e.y0) * inv;
+      e.xb = e.x0 + (yb - e.y0) * inv;
+    }
+    active.sort((a, b) => a.xa + a.xb - (b.xa + b.xb));
+
+    // non-zero winding: emit a span per maximal interior interval
+    const spans = [];
+    let winding = 0;
+    let left = null;
+    for (const e of active) {
+      const was = winding;
+      winding += e.dir;
+      if (was === 0 && winding !== 0) {
+        left = e;
+      } else if (was !== 0 && winding === 0 && left) {
+        // merge with a span from the previous slab bounded by the same edges
+        let merged = false;
+        for (const p of prevSpans) {
+          if (p.l === left && p.r === e && out[p.at + 5] === ya) {
+            out[p.at + 3] = left.xb;
+            out[p.at + 4] = e.xb;
+            out[p.at + 5] = yb;
+            spans.push(p);
+            merged = true;
+            break;
+          }
+        }
+        if (!merged && (e.xa > left.xa || e.xb > left.xb)) {
+          spans.push({ l: left, r: e, at: out.length });
+          out.push(left.xa, e.xa, ya, left.xb, e.xb, yb);
+        }
+        left = null;
+      }
+    }
+    prevSpans = spans;
+  }
+  return out;
+}
+
+/** area covered by a trapezoid list (useful for tests/diagnostics) */
+export function trapArea(traps) {
+  let area = 0;
+  for (let i = 0; i < traps.length; i += 6) {
+    const [tl, tr, ty, bl, br, by] = [
+      traps[i], traps[i + 1], traps[i + 2], traps[i + 3], traps[i + 4], traps[i + 5]
+    ];
+    area += ((tr - tl + (br - bl)) / 2) * (by - ty);
+  }
+  return area;
+}

--- a/lib/widgets/highlight.js
+++ b/lib/widgets/highlight.js
@@ -1,0 +1,97 @@
+// Fence syntax highlighting for MarkdownView — a thin adapter over
+// highlight.js (the `common` build: ~36 languages plus their aliases),
+// mapping its output onto flat { text, kind } tokens. The tokenizer used
+// to be hand-rolled here; highlight.js is maintained, pure JS and far more
+// accurate.
+//
+// tokenize(code, lang) returns [{ text, kind }] with kinds:
+//   'keyword' | 'literal' | 'string' | 'number' | 'comment' | 'tag'
+//   | 'attr' | 'function' | 'plain'
+// Token texts concatenate back to the exact input.
+
+import hljs from 'highlight.js/lib/common';
+
+// highlight.js scope -> token kind; unlisted scopes inherit the enclosing
+// span's kind (nested spans) or fall back to 'plain'
+const SCOPE_KINDS = {
+  keyword: 'keyword',
+  built_in: 'keyword',
+  type: 'keyword',
+  section: 'keyword',
+  meta: 'keyword',
+  'selector-tag': 'keyword',
+  literal: 'literal',
+  symbol: 'literal',
+  string: 'string',
+  regexp: 'string',
+  addition: 'string',
+  number: 'number',
+  comment: 'comment',
+  quote: 'comment',
+  doctag: 'comment',
+  deletion: 'comment',
+  name: 'tag',
+  tag: 'tag',
+  'selector-id': 'tag',
+  'selector-class': 'tag',
+  attr: 'attr',
+  attribute: 'attr',
+  property: 'attr',
+  variable: 'attr',
+  'template-variable': 'attr',
+  title: 'function'
+};
+
+const ENTITIES = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#x27;': "'", '&#39;': "'" };
+
+function unescapeHtml(text) {
+  return text.replace(/&(?:amp|lt|gt|quot|#x27|#39);/g, (m) => ENTITIES[m]);
+}
+
+/**
+ * Tokenize source code for a fence language tag. Unknown languages fall
+ * back to a single plain token, so callers can highlight unconditionally.
+ *
+ * @param {string} code
+ * @param {string} [lang] fence tag, e.g. 'js', 'python'; hljs aliases work
+ * @returns {Array<{text: string, kind: string}>}
+ */
+export function tokenize(code, lang) {
+  code = String(code ?? '');
+  if (!code) return [];
+  const name = String(lang ?? '').toLowerCase();
+  if (!name || !hljs.getLanguage(name)) return [{ text: code, kind: 'plain' }];
+
+  let html;
+  try {
+    html = hljs.highlight(code, { language: name, ignoreIllegals: true }).value;
+  } catch {
+    return [{ text: code, kind: 'plain' }];
+  }
+
+  // flatten the emitted <span class="hljs-scope"> tree, tracking nesting
+  const tokens = [];
+  const stack = ['plain'];
+  const emit = (text, kind) => {
+    if (!text) return;
+    const last = tokens[tokens.length - 1];
+    if (last && last.kind === kind) last.text += text;
+    else tokens.push({ text, kind });
+  };
+  const re = /<span class="([^"]*)">|<\/span>|([^<]+)|</g;
+  let m;
+  while ((m = re.exec(html))) {
+    if (m[1] !== undefined) {
+      const scope = m[1]
+        .split(/\s+/)
+        .map((c) => (c.startsWith('hljs-') ? c.slice(5) : null))
+        .find(Boolean);
+      stack.push(SCOPE_KINDS[scope] ?? stack[stack.length - 1]);
+    } else if (m[0] === '</span>') {
+      if (stack.length > 1) stack.pop();
+    } else {
+      emit(unescapeHtml(m[0]), stack[stack.length - 1]);
+    }
+  }
+  return tokens;
+}

--- a/lib/widgets/markdown.js
+++ b/lib/widgets/markdown.js
@@ -1,12 +1,9 @@
-// Minimal CommonMark-ish markdown parser — pure JS, no dependencies.
+// Markdown parsing for MarkdownView — a thin adapter over the `marked`
+// lexer (CommonMark + GFM), mapping its token stream onto the small block /
+// inline AST the widget renders. The parser used to be hand-rolled here;
+// it was replaced after subtle divergences from CommonMark surfaced
+// (e.g. intra-word `WM_DELETE_WINDOW` sprouting emphasis).
 //
-// Supported blocks: ATX headings (# .. ######), paragraphs, fenced code
-// blocks (```), blockquotes (>), unordered (-/*/+) and ordered (1.) lists
-// with nesting by indentation, and thematic breaks (---).
-// Supported inlines: **strong**, *em*/_em_, `code`, [links](url) and
-// backslash escapes.
-//
-// The output is a small AST consumed by MarkdownView:
 //   block: { type: 'heading', level, children }
 //        | { type: 'paragraph', children }
 //        | { type: 'code', text, lang }
@@ -18,209 +15,129 @@
 //         | { type: 'code', text }
 //         | { type: 'link', children, href }
 
+import { Lexer } from 'marked';
+
 export function parseMarkdown(src) {
-  return parseBlocks(String(src ?? '').replace(/\r\n?/g, '\n').split('\n'));
+  return mapBlocks(new Lexer({ gfm: true }).lex(String(src ?? '')));
 }
 
-const FENCE = /^(\s*)(`{3,}|~{3,})\s*(\S*)\s*$/;
-const HEADING = /^(#{1,6})\s+(.*?)\s*#*\s*$/;
-const HR = /^\s{0,3}([-*_])\s*(?:\1\s*){2,}$/;
-const QUOTE = /^\s{0,3}>\s?(.*)$/;
-const UL_ITEM = /^(\s*)([-*+])\s+(.*)$/;
-const OL_ITEM = /^(\s*)(\d{1,9})[.)]\s+(.*)$/;
+/** inline-only parsing (exported for tests / embedders) */
+export function parseInline(text) {
+  return mapInline(Lexer.lexInline(String(text ?? '')));
+}
 
-function parseBlocks(lines) {
+function mapBlocks(tokens) {
   const blocks = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    if (line.trim() === '') {
-      i++;
-      continue;
-    }
-
-    let m = FENCE.exec(line);
-    if (m) {
-      const fence = m[2][0];
-      const lang = m[3];
-      const body = [];
-      i++;
-      while (i < lines.length && !new RegExp(`^\\s*${fence}{3,}\\s*$`).test(lines[i])) {
-        body.push(lines[i]);
-        i++;
-      }
-      i++; // closing fence (or EOF)
-      blocks.push({ type: 'code', text: body.join('\n'), lang });
-      continue;
-    }
-
-    m = HEADING.exec(line);
-    if (m) {
-      blocks.push({ type: 'heading', level: m[1].length, children: parseInline(m[2]) });
-      i++;
-      continue;
-    }
-
-    if (HR.test(line)) {
-      blocks.push({ type: 'hr' });
-      i++;
-      continue;
-    }
-
-    m = QUOTE.exec(line);
-    if (m) {
-      const inner = [];
-      while (i < lines.length) {
-        const q = QUOTE.exec(lines[i]);
-        if (q) inner.push(q[1]);
-        else if (lines[i].trim() !== '' && inner.length) inner.push(lines[i]); // lazy continuation
-        else break;
-        i++;
-      }
-      blocks.push({ type: 'blockquote', blocks: parseBlocks(inner) });
-      continue;
-    }
-
-    m = UL_ITEM.exec(line) || OL_ITEM.exec(line);
-    if (m) {
-      const ordered = /\d/.test(m[2]);
-      const start = ordered ? parseInt(m[2], 10) : 1;
-      const baseIndent = m[1].length;
-      const items = [];
-      let itemLines = null;
-      const flush = () => {
-        if (itemLines) items.push(parseBlocks(itemLines));
-        itemLines = null;
-      };
-      while (i < lines.length) {
-        const l = lines[i];
-        const im = UL_ITEM.exec(l) || OL_ITEM.exec(l);
-        if (im && im[1].length === baseIndent && /\d/.test(im[2]) === ordered) {
-          flush();
-          itemLines = [im[3]];
-          i++;
-        } else if (im && im[1].length > baseIndent) {
-          // nested list line: keep, dedent by the parent marker width
-          itemLines.push(l.slice(baseIndent + 2));
-          i++;
-        } else if (l.trim() === '') {
-          // blank line ends the list unless the next line continues it
-          const next = lines[i + 1];
-          if (next !== undefined && (UL_ITEM.test(next) || OL_ITEM.test(next) || /^\s{2,}\S/.test(next))) {
-            itemLines.push('');
-            i++;
-          } else {
-            break;
-          }
-        } else if (/^\s{2,}\S/.test(l) && itemLines) {
-          itemLines.push(l.slice(baseIndent + 2));
-          i++;
-        } else {
-          break;
-        }
-      }
-      flush();
-      blocks.push({ type: 'list', ordered, start, items });
-      continue;
-    }
-
-    // paragraph: consecutive plain lines soft-wrapped into one
-    const para = [];
-    while (i < lines.length) {
-      const l = lines[i];
-      if (
-        l.trim() === '' ||
-        FENCE.test(l) ||
-        HEADING.test(l) ||
-        HR.test(l) ||
-        QUOTE.test(l) ||
-        UL_ITEM.test(l) ||
-        OL_ITEM.test(l)
-      ) {
+  for (const t of tokens) {
+    switch (t.type) {
+      case 'heading':
+        blocks.push({ type: 'heading', level: t.depth, children: mapInline(t.tokens) });
+        break;
+      case 'paragraph':
+      // tight list items carry their inline content in a block-level 'text'
+      case 'text':
+        blocks.push({ type: 'paragraph', children: mapInline(t.tokens ?? [t]) });
+        break;
+      case 'code':
+        blocks.push({
+          type: 'code',
+          text: t.text,
+          lang: (t.lang || '').split(/\s+/)[0]
+        });
+        break;
+      case 'blockquote':
+        blocks.push({ type: 'blockquote', blocks: mapBlocks(t.tokens) });
+        break;
+      case 'list':
+        blocks.push({
+          type: 'list',
+          ordered: !!t.ordered,
+          start: typeof t.start === 'number' ? t.start : 1,
+          items: t.items.map((item) => mapBlocks(item.tokens))
+        });
+        break;
+      case 'hr':
+        blocks.push({ type: 'hr' });
+        break;
+      case 'table': {
+        // no table layout in the widget (yet): show the source, monospaced
+        blocks.push({ type: 'code', text: t.raw.trim(), lang: '' });
         break;
       }
-      para.push(l.trim());
-      i++;
+      case 'html':
+        blocks.push({ type: 'paragraph', children: [{ type: 'text', text: t.text.trim() }] });
+        break;
+      case 'space':
+      case 'def':
+        break;
+      default:
+        if (t.tokens) blocks.push({ type: 'paragraph', children: mapInline(t.tokens) });
+        else if (t.text) blocks.push({ type: 'paragraph', children: [{ type: 'text', text: t.text }] });
+        break;
     }
-    blocks.push({ type: 'paragraph', children: parseInline(para.join(' ')) });
   }
-
   return blocks;
 }
 
-export function parseInline(text) {
+function mapInline(tokens) {
   const nodes = [];
-  let plain = '';
-  const flush = () => {
-    if (plain) nodes.push({ type: 'text', text: plain });
-    plain = '';
+  const pushText = (text) => {
+    // soft line breaks inside a paragraph render as spaces (the layout
+    // engine treats \n as a hard break)
+    text = text.replace(/\n/g, ' ');
+    const last = nodes[nodes.length - 1];
+    if (last && last.type === 'text') last.text += text;
+    else nodes.push({ type: 'text', text });
   };
-
-  let i = 0;
-  while (i < text.length) {
-    const ch = text[i];
-
-    if (ch === '\\' && i + 1 < text.length) {
-      plain += text[i + 1];
-      i += 2;
-      continue;
+  for (const t of tokens ?? []) {
+    switch (t.type) {
+      case 'text':
+        if (t.tokens) nodes.push(...mapInline(t.tokens));
+        else pushText(t.escaped ? unescapeHtml(t.text) : t.text);
+        break;
+      case 'escape':
+        pushText(t.text);
+        break;
+      case 'strong':
+        nodes.push({ type: 'strong', children: mapInline(t.tokens) });
+        break;
+      case 'em':
+        nodes.push({ type: 'em', children: mapInline(t.tokens) });
+        break;
+      case 'del':
+        // no strikethrough decoration (yet): render the content plainly
+        nodes.push(...mapInline(t.tokens));
+        break;
+      case 'codespan':
+        nodes.push({ type: 'code', text: t.text });
+        break;
+      case 'link':
+        nodes.push({ type: 'link', children: mapInline(t.tokens), href: t.href });
+        break;
+      case 'image':
+        // no image rendering: alt text as a link to the source
+        nodes.push({
+          type: 'link',
+          children: [{ type: 'text', text: t.text || t.href }],
+          href: t.href
+        });
+        break;
+      case 'br':
+        pushText(' ');
+        break;
+      case 'html':
+        pushText(t.raw);
+        break;
+      default:
+        if (t.text) pushText(t.text);
+        break;
     }
-
-    if (ch === '`') {
-      let fence = 1;
-      while (text[i + fence] === '`') fence++;
-      const close = text.indexOf('`'.repeat(fence), i + fence);
-      if (close !== -1) {
-        flush();
-        nodes.push({ type: 'code', text: text.slice(i + fence, close).trim() });
-        i = close + fence;
-        continue;
-      }
-    }
-
-    if (text.startsWith('**', i) || text.startsWith('__', i)) {
-      const marker = text.slice(i, i + 2);
-      const close = text.indexOf(marker, i + 2);
-      if (close !== -1 && close > i + 2) {
-        flush();
-        nodes.push({ type: 'strong', children: parseInline(text.slice(i + 2, close)) });
-        i = close + 2;
-        continue;
-      }
-    }
-
-    if ((ch === '*' || ch === '_') && text[i + 1] !== ch) {
-      const close = text.indexOf(ch, i + 1);
-      if (close !== -1 && close > i + 1) {
-        flush();
-        nodes.push({ type: 'em', children: parseInline(text.slice(i + 1, close)) });
-        i = close + 1;
-        continue;
-      }
-    }
-
-    if (ch === '[') {
-      const closeBracket = text.indexOf(']', i + 1);
-      if (closeBracket !== -1 && text[closeBracket + 1] === '(') {
-        const closeParen = text.indexOf(')', closeBracket + 2);
-        if (closeParen !== -1) {
-          flush();
-          nodes.push({
-            type: 'link',
-            children: parseInline(text.slice(i + 1, closeBracket)),
-            href: text.slice(closeBracket + 2, closeParen)
-          });
-          i = closeParen + 1;
-          continue;
-        }
-      }
-    }
-
-    plain += ch;
-    i++;
   }
-  flush();
   return nodes;
+}
+
+const ENTITIES = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'" };
+
+function unescapeHtml(text) {
+  return text.replace(/&(?:amp|lt|gt|quot|#39);/g, (m) => ENTITIES[m]);
 }

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -1,5 +1,9 @@
 import { TextLayout } from '../text/layout.js';
+import { tokenize } from './highlight.js';
 import { parseMarkdown } from './markdown.js';
+import { layoutTex } from './tex.js';
+
+const MATH_LANGS = new Set(['math', 'tex', 'latex', 'katex']);
 
 const DEFAULT_THEME = {
   family: 'sans-serif',
@@ -16,7 +20,19 @@ const DEFAULT_THEME = {
   quoteBar: '#d8d8d8',
   hrColor: '#dddddd',
   blockSpacing: 0.7, // em (of base size) between blocks
-  padding: 16
+  padding: 16,
+  // fence syntax highlighting (lib/widgets/highlight.js token kinds);
+  // unlisted kinds (incl. 'plain') fall back to the base text color
+  codeTheme: {
+    keyword: '#a626a4',
+    literal: '#0184bc',
+    string: '#50a14f',
+    number: '#986801',
+    comment: '#a0a1a7',
+    tag: '#e45649',
+    attr: '#986801',
+    function: '#4078f2'
+  }
 };
 
 /**
@@ -39,11 +55,18 @@ export default class MarkdownView {
     this.window = window ?? null;
     this._standaloneFonts = opts.fonts ?? null; // for headless layout without a window
     this.theme = { ...DEFAULT_THEME, ...(opts.theme || {}) };
+    if (opts.theme?.codeTheme) {
+      this.theme.codeTheme = { ...DEFAULT_THEME.codeTheme, ...opts.theme.codeTheme };
+    }
     if (opts.padding !== undefined) this.theme.padding = opts.padding;
     this._blocks = [];
     this._items = []; // placed draw items from the last layout()
+    this._links = []; // clickable link rects from the last draw()
     this._layoutWidth = -1;
     this.contentHeight = 0;
+    /** called with (href, event) when a rendered link is clicked (window
+     *  mode wires mousedown automatically; standalone callers use linkAt) */
+    this.onLink = opts.onLink ?? null;
 
     if (this.window) {
       this._ctx = this.window.getContext('2d');
@@ -51,7 +74,23 @@ export default class MarkdownView {
       this.window.on('resize', () => {
         this._layoutWidth = -1; // invalidate
       });
+      this.window.on('mousedown', (ev) => {
+        if (ev.keycode !== 1 || !this.onLink) return; // left button only
+        const href = this.linkAt(ev.x, ev.y);
+        if (href) this.onLink(href, ev);
+      });
     }
+  }
+
+  /**
+   * The link href under a point, or null. Coordinates are in the same
+   * device space as the last `draw()` (window mode: window coordinates).
+   */
+  linkAt(x, y) {
+    for (const l of this._links) {
+      if (x >= l.x && x < l.x + l.w && y >= l.y && y < l.y + l.h) return l.href;
+    }
+    return null;
   }
 
   setMarkdown(src) {
@@ -129,9 +168,33 @@ export default class MarkdownView {
         }
 
         case 'code': {
+          // ```math / ```latex fences render as display-mode formulas
+          if (MATH_LANGS.has((block.lang || '').toLowerCase())) {
+            let box = null;
+            try {
+              // 1.21 mirrors katex.css's font-size on .katex in body text
+              box = layoutTex(block.text, {
+                size: t.size * 1.21,
+                displayMode: true,
+                color: t.color
+              });
+            } catch {
+              // KaTeX parse error: fall through to the plain code block
+            }
+            if (box) {
+              const bx = x + Math.max(0, (width - box.width) / 2);
+              this._items.push({ kind: 'tex', x: bx, y, box });
+              y += box.height;
+              break;
+            }
+          }
           const pad = t.size * 0.5;
           const style = { ...styles.mono, color: t.color };
-          const layout = new TextLayout(fonts, block.text, style, {
+          const spans = tokenize(block.text, block.lang).map((tok) => ({
+            text: tok.text,
+            color: t.codeTheme?.[tok.kind] ?? style.color
+          }));
+          const layout = new TextLayout(fonts, spans.length ? spans : '', style, {
             maxWidth: width - pad * 2,
             lineHeight: 1.25
           });
@@ -205,7 +268,8 @@ export default class MarkdownView {
             weight: state.bold ? 700 : base.weight,
             style: state.italic ? 'italic' : base.style,
             color: state.code ? t.codeColor : state.link ? t.linkColor : base.color,
-            _deco: state.code ? { bg: t.codeBg } : state.link ? { underline: t.linkColor } : null
+            _deco: state.code ? { bg: t.codeBg } : state.link ? { underline: t.linkColor } : null,
+            _href: state.link ? state.href : null
           });
           break;
         case 'code':
@@ -218,7 +282,7 @@ export default class MarkdownView {
           this._spans(node.children, base, { ...state, italic: true }, out);
           break;
         case 'link':
-          this._spans(node.children, base, { ...state, link: true }, out);
+          this._spans(node.children, base, { ...state, link: true, href: node.href }, out);
           break;
       }
     }
@@ -227,6 +291,7 @@ export default class MarkdownView {
 
   /** draw the last layout()'s items onto a 2d context */
   draw(ctx, ox = 0, oy = 0) {
+    this._links = [];
     for (const item of this._items) {
       if (item.kind === 'rect') {
         ctx.fillStyle = item.color;
@@ -234,12 +299,27 @@ export default class MarkdownView {
       }
     }
     for (const item of this._items) {
+      if (item.kind === 'tex') {
+        item.box.draw(ctx, ox + item.x, oy + item.y);
+        continue;
+      }
       if (item.kind !== 'text') continue;
       const x = ox + item.x;
       const y = oy + item.y;
       // span decorations (inline-code background, link underline) first
       for (const line of item.layout.lines) {
         for (const r of line.runs) {
+          if (r.span._href) {
+            // clickable region in the device coordinates of this draw
+            const m = r.run.font.metrics(r.run.size);
+            this._links.push({
+              x: x + line.x + r.x,
+              y: y + line.baseline - m.ascent,
+              w: r.width,
+              h: m.ascent + m.descent,
+              href: r.span._href
+            });
+          }
           const deco = r.span._deco;
           if (!deco) continue;
           if (deco.bg) {

--- a/lib/widgets/tex.js
+++ b/lib/widgets/tex.js
@@ -1,0 +1,786 @@
+// TeX math rendering on top of KaTeX (pure JS) and the ntk text stack.
+//
+// KaTeX parses TeX and produces a DOM-like tree (spans, vertical lists,
+// symbol nodes, rules, SVG surds) that browsers lay out with CSS. This
+// module reimplements the small CSS subset that tree actually uses —
+// inline flow with em margins, vlist absolute positioning, border-bottom
+// rules, font-size/font-family classes — directly in pixel space, using
+// the bundled KaTeX .ttf fonts for glyphs and metrics.
+//
+// Wire efficiency: adjacent symbols that resolve to the same font/size/color
+// are concatenated and shaped as single runs, and drawing routes every run
+// of a formula into ONE batched CompositeGlyphs request per color (via
+// drawGlyphRuns) — not one placement per character. Radical/stretchy SVG
+// paths are filled server-side as trapezoids through the same scratch mask
+// as the vector text path.
+//
+//   const box = layoutTex('\\frac{a+b}{2}', { size: 24 });
+//   box.draw(ctx, x, y);        // x, y = top-left; box.width/height/baseline
+//
+// or as a widget: new TexView(wnd, { tex: '...', size: 32 }).
+import { createRequire } from 'node:module';
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { flatten } from '../rasterize.js';
+import { trapezoidize } from '../trapezoid.js';
+import Font from '../text/font.js';
+import { compositeTraps, drawGlyphRuns } from '../text/glyphs.js';
+
+const require = createRequire(import.meta.url);
+
+// katex is sizable — load it on first formula, not on package import
+let katex = null;
+function loadKatex() {
+  if (!katex) katex = require('katex');
+  return katex;
+}
+
+// ---------------------------------------------------------------------------
+// KaTeX font files
+
+let fontDir = null;
+let fontFiles = null;
+
+function katexFontDir() {
+  if (!fontDir) {
+    fontDir = join(dirname(require.resolve('katex/package.json')), 'dist', 'fonts');
+    fontFiles = new Set(readdirSync(fontDir).filter((f) => f.endsWith('.ttf')));
+  }
+  return fontDir;
+}
+
+const fontCache = new Map(); // file name -> Font
+
+/** resolve a KaTeX family/weight/style to a bundled Font, with graceful
+ *  degradation when the exact variant does not exist (e.g. Math-Regular) */
+function katexFont(family, bold, italic) {
+  const dir = katexFontDir();
+  const variants = [
+    bold && italic ? 'BoldItalic' : null,
+    bold ? 'Bold' : null,
+    italic ? 'Italic' : null,
+    'Regular',
+    'Italic' // KaTeX_Math ships italic faces only
+  ];
+  for (const variant of variants) {
+    if (!variant) continue;
+    const file = `KaTeX_${family}-${variant}.ttf`;
+    if (!fontFiles.has(file)) continue;
+    let font = fontCache.get(file);
+    if (!font) {
+      font = Font.loadSync(join(dir, file));
+      fontCache.set(file, font);
+    }
+    return font;
+  }
+  throw new Error(`no KaTeX font for family ${family}`);
+}
+
+// ---------------------------------------------------------------------------
+// class / style interpretation (mirrors katex.css)
+
+// KaTeX size multipliers, sizes 1..11 (src/Options.js)
+const SIZE_MULT = [0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.44, 1.728, 2.074, 2.488];
+
+const FONT_CLASSES = {
+  mathnormal: { family: 'Math', italic: true },
+  mathit: { family: 'Main', italic: true },
+  mathrm: { italic: false },
+  mathbf: { family: 'Main', bold: true },
+  boldsymbol: { family: 'Math', bold: true, italic: true },
+  amsrm: { family: 'AMS' },
+  mathbb: { family: 'AMS' },
+  textbb: { family: 'AMS' },
+  mathcal: { family: 'Caligraphic' },
+  mathfrak: { family: 'Fraktur' },
+  textfrak: { family: 'Fraktur' },
+  mathboldfrak: { family: 'Fraktur', bold: true },
+  textboldfrak: { family: 'Fraktur', bold: true },
+  mathtt: { family: 'Typewriter' },
+  texttt: { family: 'Typewriter' },
+  mathscr: { family: 'Script' },
+  textscr: { family: 'Script' },
+  mathsf: { family: 'SansSerif' },
+  textsf: { family: 'SansSerif' },
+  mathboldsf: { family: 'SansSerif', bold: true },
+  textboldsf: { family: 'SansSerif', bold: true },
+  mathsfit: { family: 'SansSerif', italic: true },
+  mathitsf: { family: 'SansSerif', italic: true },
+  textitsf: { family: 'SansSerif', italic: true },
+  mainrm: { family: 'Main', italic: false },
+  textrm: { family: 'Main' },
+  textbf: { bold: true },
+  textit: { italic: true }
+};
+
+// css lengths on domTree nodes are 'Xem' (occasionally 'Xpx'); px stays px
+function parseLen(value, em) {
+  if (!value) return 0;
+  const n = parseFloat(value);
+  if (Number.isNaN(n)) return 0;
+  return String(value).endsWith('px') ? n : n * em;
+}
+
+/** apply a node's classes and inline style to the inherited state */
+function applyState(node, st) {
+  const classes = node.classes || [];
+  let out = st;
+  const own = () => (out === st ? (out = { ...st }) : out);
+
+  const sizing =
+    classes.includes('katex-sizing') ||
+    classes.includes('sizing') ||
+    classes.includes('fontsize-ensurer');
+  const delimsizing = classes.includes('delimsizing');
+
+  let resetSize = null;
+  let toSize = null;
+  for (const c of classes) {
+    const font = FONT_CLASSES[c];
+    if (font) Object.assign(own(), font);
+    let m;
+    if ((m = /^reset-size(\d+)$/.exec(c))) {
+      resetSize = +m[1];
+    } else if (sizing && (m = /^size(\d+)$/.exec(c))) {
+      toSize = +m[1];
+    } else if (delimsizing && (m = /^size(\d+)$/.exec(c))) {
+      own().family = `Size${m[1]}`;
+      own().italic = false;
+      own().bold = false;
+    } else if ((m = /^delim-size(\d+)$/.exec(c))) {
+      own().family = `Size${m[1]}`;
+      own().italic = false;
+      own().bold = false;
+    } else if (c === 'small-op') {
+      own().family = 'Size1';
+    } else if (c === 'large-op') {
+      own().family = 'Size2';
+    }
+  }
+  if (resetSize !== null && toSize !== null) {
+    own().em = st.em * (SIZE_MULT[toSize - 1] / SIZE_MULT[resetSize - 1]);
+  }
+  if (node.style && node.style.color) {
+    own().color = node.style.color;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// svg path data (KaTeX radicals / stretchy fills use M L C Q + h v z subsets)
+
+function parseSvgPath(d) {
+  const commands = [];
+  const re = /([MmLlHhVvCcSsQqTtZz])|(-?\d*\.?\d+(?:e-?\d+)?)/g;
+  const nums = [];
+  let cmd = null;
+  let x = 0;
+  let y = 0;
+  let sx = 0;
+  let sy = 0;
+  let px = null; // previous control point for S/T
+  let py = null;
+
+  const tokens = [];
+  let m;
+  while ((m = re.exec(d))) tokens.push(m[1] ?? parseFloat(m[2]));
+
+  let i = 0;
+  const next = () => tokens[i++];
+  while (i < tokens.length) {
+    const tok = next();
+    if (typeof tok === 'string') {
+      cmd = tok;
+      if (cmd === 'Z' || cmd === 'z') {
+        commands.push({ type: 'Z' });
+        x = sx;
+        y = sy;
+        continue;
+      }
+      nums.length = 0;
+      continue;
+    }
+    // a number: implicit repetition of the current command
+    i--;
+    const rel = cmd === cmd.toLowerCase();
+    const C = cmd.toUpperCase();
+    const take = (n) => {
+      const args = [];
+      for (let k = 0; k < n; k++) args.push(next());
+      return args;
+    };
+    switch (C) {
+      case 'M': {
+        const [ax, ay] = take(2);
+        x = rel ? x + ax : ax;
+        y = rel ? y + ay : ay;
+        sx = x;
+        sy = y;
+        commands.push({ type: 'M', x, y });
+        cmd = rel ? 'l' : 'L'; // subsequent pairs are linetos
+        break;
+      }
+      case 'L': {
+        const [ax, ay] = take(2);
+        x = rel ? x + ax : ax;
+        y = rel ? y + ay : ay;
+        commands.push({ type: 'L', x, y });
+        break;
+      }
+      case 'H': {
+        const [ax] = take(1);
+        x = rel ? x + ax : ax;
+        commands.push({ type: 'L', x, y });
+        break;
+      }
+      case 'V': {
+        const [ay] = take(1);
+        y = rel ? y + ay : ay;
+        commands.push({ type: 'L', x, y });
+        break;
+      }
+      case 'C': {
+        const [x1, y1, x2, y2, ax, ay] = take(6);
+        const c = {
+          type: 'C',
+          x1: rel ? x + x1 : x1,
+          y1: rel ? y + y1 : y1,
+          x2: rel ? x + x2 : x2,
+          y2: rel ? y + y2 : y2,
+          x: rel ? x + ax : ax,
+          y: rel ? y + ay : ay
+        };
+        commands.push(c);
+        px = c.x2;
+        py = c.y2;
+        x = c.x;
+        y = c.y;
+        break;
+      }
+      case 'S': {
+        const [x2, y2, ax, ay] = take(4);
+        const c = {
+          type: 'C',
+          x1: px !== null ? 2 * x - px : x,
+          y1: py !== null ? 2 * y - py : y,
+          x2: rel ? x + x2 : x2,
+          y2: rel ? y + y2 : y2,
+          x: rel ? x + ax : ax,
+          y: rel ? y + ay : ay
+        };
+        commands.push(c);
+        px = c.x2;
+        py = c.y2;
+        x = c.x;
+        y = c.y;
+        break;
+      }
+      case 'Q': {
+        const [x1, y1, ax, ay] = take(4);
+        const c = {
+          type: 'Q',
+          x1: rel ? x + x1 : x1,
+          y1: rel ? y + y1 : y1,
+          x: rel ? x + ax : ax,
+          y: rel ? y + ay : ay
+        };
+        commands.push(c);
+        px = c.x1;
+        py = c.y1;
+        x = c.x;
+        y = c.y;
+        break;
+      }
+      case 'T': {
+        const [ax, ay] = take(2);
+        const c = {
+          type: 'Q',
+          x1: px !== null ? 2 * x - px : x,
+          y1: py !== null ? 2 * y - py : y,
+          x: rel ? x + ax : ax,
+          y: rel ? y + ay : ay
+        };
+        commands.push(c);
+        px = c.x1;
+        py = c.y1;
+        x = c.x;
+        y = c.y;
+        break;
+      }
+      default:
+        // unsupported (A): skip its 7 args
+        take(7);
+        break;
+    }
+    if (C !== 'C' && C !== 'S' && C !== 'Q' && C !== 'T') {
+      px = py = null;
+    }
+  }
+  return commands;
+}
+
+// ---------------------------------------------------------------------------
+// layout walker
+
+const STRETCH = -1; // width placeholder resolved by the containing vlist
+
+function isSymbol(node) {
+  return node.constructor && node.constructor.name === 'SymbolNode';
+}
+
+function isSvg(node) {
+  return node.constructor && node.constructor.name === 'SvgNode';
+}
+
+function classSet(node) {
+  return node.classes || [];
+}
+
+function has(node, cls) {
+  return classSet(node).includes(cls);
+}
+
+class Walker {
+  constructor() {
+    this.warnings = [];
+  }
+
+  /** dispatch any child node -> box { width, items, stretch? } */
+  layoutAny(node, st, align) {
+    if (isSymbol(node)) {
+      // bare symbol outside an hbox (e.g. directly inside a vlist wrap)
+      return this.hbox([node], st, 0);
+    }
+    if (isSvg(node)) return this.svg(node, st, null);
+    if (node.children) return this.span(node, st, align);
+    return { width: 0, items: [] };
+  }
+
+  span(node, st0, align = 'left') {
+    const st = applyState(node, st0);
+    const em = st.em;
+    const cls = classSet(node);
+    const style = node.style || {};
+
+    if (cls.includes('katex-strut') || cls.includes('pstrut') || cls.includes('vlist-s')) {
+      return { width: 0, items: [] };
+    }
+
+    // rules drawn with borders: frac-line, overline/underline-line, hlines
+    if (style.borderBottomWidth !== undefined) {
+      const h = Math.max(parseLen(style.borderBottomWidth, em), 1);
+      return {
+        width: 0,
+        stretch: true,
+        items: [{ type: 'rect', x: 0, y: -h, w: STRETCH, h, color: st.color }]
+      };
+    }
+    // \rule: content-less span sized by borders, lifted by style.bottom
+    if (cls.includes('katex-rule') || cls.includes('rule')) {
+      const w = parseLen(style.borderRightWidth ?? style.width, em);
+      const h = Math.max(parseLen(style.borderTopWidth ?? style.height, em), 1);
+      const shift = parseLen(style.bottom, em);
+      return {
+        width: w,
+        items: w > 0 ? [{ type: 'rect', x: 0, y: -shift - h, w, h, color: st.color }] : []
+      };
+    }
+
+    if (cls.includes('vlist-t')) {
+      return this.vlist(node, st, align);
+    }
+
+    // spans hosting an absolutely-positioned svg (sqrt surds, stretchy fills)
+    const svgChild = (node.children || []).find(isSvg);
+    if (svgChild) {
+      const cssH = parseLen(style.height, em) || parseLen(svgChild.attributes?.height, em);
+      const box = this.svg(svgChild, st, cssH);
+      const minW = parseLen(style.minWidth, em);
+      return {
+        width: Math.max(parseLen(style.width, em), minW),
+        stretch: true, // hide-tail spans are width:100% of their column
+        stretchMin: minW,
+        items: box.items
+      };
+    }
+
+    // generic inline flow
+    const box = this.hbox(node.children || [], st, parseLen(style.paddingLeft, em), align);
+
+    // explicit width overrides (mspace \hspace etc.) and width:0 hacks
+    if (style.width !== undefined) box.width = parseLen(style.width, em);
+    if (cls.includes('nulldelimiter')) box.width = 0.12 * em;
+    if (cls.includes('llap') || cls.includes('clap')) {
+      const shift = cls.includes('llap') ? -box.width : -box.width / 2;
+      for (const item of box.items) item.x += shift;
+      box.width = 0;
+    } else if (cls.includes('rlap')) {
+      box.width = 0;
+    } else if (cls.includes('accent-body') && !cls.includes('accent-full')) {
+      box.width = 0;
+    }
+    return box;
+  }
+
+  /** children in inline flow; merges adjacent same-style symbols into runs */
+  hbox(children, st, x0 = 0, align = 'left') {
+    const items = [];
+    let x = x0;
+    let group = null;
+
+    const flush = () => {
+      if (!group) return;
+      const run = group.font.shape(group.text, group.size);
+      items.push({ type: 'run', run, x: group.x0, y: 0, color: group.color });
+      x = group.x0 + run.width + group.italic;
+      group = null;
+    };
+
+    for (const child of children) {
+      if (isSymbol(child)) {
+        const cst = applyState(child, st);
+        // strip zero-width space / BOM (vlist alignment hacks)
+        const text = child.text.replace(/[\u200b\ufeff]/g, '');
+        if (!text) continue;
+        const style = child.style || {};
+        const ml = parseLen(style.marginLeft, cst.em);
+        const mr = parseLen(style.marginRight, cst.em);
+        if (ml) {
+          flush();
+          x += ml;
+        }
+        const font = katexFont(cst.family, cst.bold, cst.italic);
+        if (
+          group &&
+          (group.font !== font || group.size !== cst.em || group.color !== cst.color)
+        ) {
+          flush();
+        }
+        if (!group) group = { font, size: cst.em, color: cst.color, text: '', x0: x, italic: 0 };
+        group.text += text;
+        group.italic = (child.italic || 0) * cst.em;
+        // italic correction / explicit margin ends the mergeable sequence
+        if (child.italic || mr) {
+          flush();
+          x += mr;
+        }
+        continue;
+      }
+      if (isSvg(child)) {
+        // absolutely positioned inside its span: draws but does not advance
+        flush();
+        const box = this.svg(child, st, null);
+        for (const item of box.items) {
+          item.x += x;
+          items.push(item);
+        }
+        continue;
+      }
+      if (!child.children && !child.style) continue; // text/doc nodes
+      flush();
+      const style = child.style || {};
+      const cem = applyState(child, st).em;
+      x += parseLen(style.marginLeft, cem);
+      const box = this.span(child, st, this.childAlign(child, align));
+      const dy = parseLen(style.top, cem) - parseLen(style.verticalAlign, cem);
+      for (const item of box.items) {
+        item.x += x;
+        item.y += dy;
+        items.push(item);
+      }
+      x += box.width + parseLen(style.marginRight, cem);
+    }
+    flush();
+    return { width: x, items };
+  }
+
+  /** text-align context for a span's children (inherits; a few classes set it) */
+  childAlign(node, inherited) {
+    const cls = classSet(node);
+    if (cls.includes('mfrac') || cls.includes('op-limits') || cls.includes('katex-accent')) {
+      return 'center';
+    }
+    if (cls.includes('col-align-c')) return 'center';
+    if (cls.includes('col-align-r')) return 'right';
+    if (cls.includes('col-align-l') || cls.includes('msupsub') || cls.includes('svg-align')) {
+      return 'left';
+    }
+    return inherited;
+  }
+
+  /** KaTeX vertical list: rows absolutely positioned via pstrut + top */
+  vlist(vtable, st, align) {
+    const em = st.em;
+    const rows = (vtable.children || []).filter((c) => has(c, 'vlist-r'));
+    const column = rows.length ? (rows[0].children || []).find((c) => has(c, 'vlist')) : null;
+    if (!column) return { width: 0, items: [] };
+
+    const entries = [];
+    for (const wrap of column.children || []) {
+      const kids = wrap.children || [];
+      const pstrut = kids.find((k) => has(k, 'pstrut'));
+      const elem = kids.find((k) => k !== pstrut);
+      if (!elem) continue;
+      const style = wrap.style || {};
+      const P = parseLen(pstrut?.style?.height, em);
+      const T = parseLen(style.top, em);
+      const wrapAlign = this.childAlign(wrap, align);
+      // wrapper classes carry state for stacked delimiters (delim-sizeN)
+      const box = this.layoutAny(elem, applyState(wrap, st), wrapAlign);
+      entries.push({
+        box,
+        dy: P + T,
+        ml: parseLen(style.marginLeft, em),
+        mr: parseLen(style.marginRight, em),
+        align: has(wrap, 'svg-align') ? 'left' : wrapAlign
+      });
+    }
+
+    let colWidth = 0;
+    for (const e of entries) {
+      if (e.box.stretch) {
+        if (e.box.stretchMin) colWidth = Math.max(colWidth, e.box.stretchMin);
+        continue;
+      }
+      colWidth = Math.max(colWidth, e.ml + e.box.width + e.mr);
+    }
+
+    const items = [];
+    for (const e of entries) {
+      const w = e.box.stretch ? colWidth : e.box.width;
+      let ox = e.ml;
+      if (!e.box.stretch) {
+        if (e.align === 'center') ox += (colWidth - e.ml - e.box.width - e.mr) / 2;
+        else if (e.align === 'right') ox += colWidth - e.ml - e.box.width - e.mr;
+      }
+      for (const item of e.box.items) {
+        if (item.w === STRETCH) item.w = w;
+        if (item.clipW === STRETCH) item.clipW = w;
+        item.x += ox;
+        item.y += e.dy;
+        items.push(item);
+      }
+    }
+    return { width: colWidth, items };
+  }
+
+  /** SvgNode -> filled path item; box is bottom-aligned to the baseline */
+  svg(node, st, cssH) {
+    const attrs = node.attributes || {};
+    const viewBox = String(attrs.viewBox || '0 0 1 1')
+      .split(/[\s,]+/)
+      .map(Number);
+    const vbH = viewBox[3] || 1;
+    const heightPx = cssH ?? parseLen(attrs.height, st.em);
+    const scale = vbH ? heightPx / vbH : 0;
+
+    const polys = [];
+    for (const child of node.children || []) {
+      let d = child.alternate;
+      if (!d && typeof child.toMarkup === 'function') {
+        const m = / d="([^"]*)"/.exec(child.toMarkup());
+        if (m) d = m[1];
+      }
+      if (!d) continue;
+      for (const poly of flatten(parseSvgPath(d))) {
+        const scaled = new Array(poly.length);
+        for (let i = 0; i < poly.length; i += 2) {
+          scaled[i] = poly[i] * scale;
+          scaled[i + 1] = poly[i + 1] * scale - heightPx; // bottom on the baseline
+        }
+        polys.push(scaled);
+      }
+    }
+    return {
+      width: 0,
+      items: polys.length
+        ? [{ type: 'path', polys, x: 0, y: 0, clipW: STRETCH, color: st.color }]
+        : []
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// public API
+
+/**
+ * Parse and lay out a TeX formula with KaTeX. Fully headless (no X
+ * connection needed) — the result can be measured, then drawn any number of
+ * times onto 2d contexts.
+ *
+ * @param {string} tex
+ * @param {object} [options]
+ *   - size: base font size in px (the em of the formula), default 16
+ *   - displayMode: KaTeX display mode (block, \displaystyle), default false
+ *   - color: default ink color (spans with explicit \color override it)
+ *   - katex: extra options passed through to KaTeX (macros, strict, ...)
+ * @returns {TexBox}
+ */
+export function layoutTex(tex, options = {}) {
+  const em = options.size ?? 16;
+  const tree = loadKatex().__renderToDomTree(String(tex ?? ''), {
+    output: 'html',
+    displayMode: !!options.displayMode,
+    ...options.katex
+  });
+
+  // find the .katex span ( __renderToDomTree may wrap it in .katex-display )
+  let root = tree;
+  if (has(root, 'katex-display')) root = root.children.find((c) => has(c, 'katex'));
+  const html = (root.children || []).find((c) => has(c, 'katex-html')) ?? root;
+
+  const st = {
+    em,
+    family: 'Main',
+    bold: false,
+    italic: false,
+    color: options.color ?? null
+  };
+  const walker = new Walker();
+  const box = walker.hbox(html.children || [], st);
+
+  const height = (root.height || 0) * em;
+  const depth = (root.depth || 0) * em;
+  return new TexBox(box.items, box.width, height, depth, em);
+}
+
+/**
+ * A laid-out formula. Coordinates are relative to the top-left corner;
+ * `baseline` px below the top is the alphabetic baseline.
+ */
+export class TexBox {
+  constructor(items, width, height, depth, em) {
+    this.items = items;
+    this.width = width;
+    this.baseline = height;
+    this.height = height + depth;
+    this.depth = depth;
+    this.em = em;
+  }
+
+  /**
+   * Draw at (x, y) = top-left. Text is batched into one CompositeGlyphs
+   * request per color; rules become FillRectangles; radical strokes become
+   * trapezoids. The context fillStyle is used for items without an explicit
+   * color and is left untouched.
+   */
+  draw(ctx, x = 0, y = 0) {
+    const app = ctx.window.app;
+    const Render = app.display.Render;
+    const base = y + this.baseline;
+
+    for (const item of this.items) {
+      if (item.type !== 'rect') continue;
+      const src = item.color ? ctx._stylePicture(item.color) : ctx._backgroundPicture;
+      Render.Composite(
+        Render.PictOp.Over,
+        src.id,
+        ctx.clipMask ? ctx.clipMask.id : 0,
+        ctx.picture.id,
+        Math.round(x + item.x),
+        Math.round(base + item.y),
+        Math.round(x + item.x),
+        Math.round(base + item.y),
+        Math.round(x + item.x),
+        Math.round(base + item.y),
+        Math.max(1, Math.round(item.w)),
+        Math.max(1, Math.round(item.h))
+      );
+    }
+
+    for (const item of this.items) {
+      if (item.type !== 'path') continue;
+      const src = item.color ? ctx._stylePicture(item.color) : ctx._backgroundPicture;
+      const traps = [];
+      for (const poly of item.polys) {
+        let clipped = poly;
+        if (item.clipW !== STRETCH && item.clipW !== undefined) {
+          clipped = poly.slice();
+          for (let i = 0; i < clipped.length; i += 2) {
+            if (clipped[i] > item.clipW) clipped[i] = item.clipW;
+          }
+        }
+        trapezoidize([clipped], x + item.x, base + item.y, traps);
+      }
+      compositeTraps(app, Render.PictOp.Over, src.id, ctx.picture.id, traps);
+    }
+
+    // batch every run of the same color into a single CompositeGlyphs
+    const byColor = new Map();
+    for (const item of this.items) {
+      if (item.type !== 'run') continue;
+      const key = item.color ?? '';
+      let list = byColor.get(key);
+      if (!list) byColor.set(key, (list = { color: item.color, runs: [] }));
+      list.runs.push({ run: item.run, x: x + item.x, y: base + item.y });
+    }
+    for (const { color, runs } of byColor.values()) {
+      const src = color ? ctx._stylePicture(color) : ctx._backgroundPicture;
+      drawGlyphRuns(app, Render.PictOp.Over, src.id, ctx.picture.id, runs);
+    }
+
+    ctx._markDirty();
+    return this;
+  }
+}
+
+/**
+ * A widget that renders one TeX formula into a window, KaTeX-style.
+ *
+ *   const view = new TexView(wnd, { tex: 'e^{i\\pi} + 1 = 0', size: 40 });
+ *   wnd.map();
+ *
+ * Options: tex, size, color, background, displayMode, padding, katex
+ * (pass-through options). `setTex(tex)` updates and re-renders.
+ */
+export default class TexView {
+  constructor(window, opts = {}) {
+    this.window = window ?? null;
+    this.size = opts.size ?? 24;
+    this.color = opts.color ?? '#222222';
+    this.background = opts.background ?? 'white';
+    this.displayMode = opts.displayMode ?? true;
+    this.padding = opts.padding ?? 16;
+    this.katexOptions = opts.katex;
+    this._box = null;
+    this._tex = '';
+    if (opts.tex) this.setTex(opts.tex);
+
+    if (this.window) {
+      this._ctx = this.window.getContext('2d');
+      this.window.on('expose', () => this.render());
+    }
+  }
+
+  setTex(tex) {
+    this._tex = String(tex ?? '');
+    this._box = layoutTex(this._tex, {
+      size: this.size,
+      color: this.color,
+      displayMode: this.displayMode,
+      katex: this.katexOptions
+    });
+    if (this.window && this.window._mapped) this.render();
+    return this;
+  }
+
+  /** the laid-out TexBox (width/height/baseline) for the current tex */
+  get box() {
+    return this._box;
+  }
+
+  render() {
+    if (!this.window) throw new Error('TexView.render() needs a window');
+    const ctx = this._ctx;
+    ctx.fillStyle = this.background;
+    ctx.fillRect(0, 0, this.window.width, this.window.height);
+    if (!this._box) return this;
+    // centered, like KaTeX display mode
+    const x = Math.max(this.padding, (this.window.width - this._box.width) / 2);
+    const y = Math.max(this.padding, (this.window.height - this._box.height) / 2);
+    ctx.fillStyle = this.color;
+    this._box.draw(ctx, x, y);
+    return this;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,11 @@
         "canvas-fontstyle": "^1.0.1",
         "extrude-polyline": "^1.0.6",
         "fontkit": "^2.0.4",
+        "highlight.js": "^11.11.1",
+        "katex": "^0.18.1",
         "keysym": "0.0.6",
         "linebreak": "^1.1.0",
+        "marked": "^18.0.7",
         "parse-color": "^1.0.0",
         "pnltri": "^2.1.1",
         "x11": "^2.3.0"
@@ -99,6 +102,15 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/dfa": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
@@ -145,6 +157,31 @@
       "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==",
       "license": "zlib"
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.1.tgz",
+      "integrity": "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/keysym": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/keysym/-/keysym-0.0.6.tgz",
@@ -181,6 +218,18 @@
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/os-homedir": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,11 @@
     "canvas-fontstyle": "^1.0.1",
     "extrude-polyline": "^1.0.6",
     "fontkit": "^2.0.4",
+    "highlight.js": "^11.11.1",
+    "katex": "^0.18.1",
     "keysym": "0.0.6",
     "linebreak": "^1.1.0",
+    "marked": "^18.0.7",
     "parse-color": "^1.0.0",
     "pnltri": "^2.1.1",
     "x11": "^2.3.0"

--- a/test/highlight.test.js
+++ b/test/highlight.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { tokenize } from '../lib/widgets/highlight.js';
+
+const rejoin = (tokens) => tokens.map((t) => t.text).join('');
+const kindsOf = (tokens, kind) => tokens.filter((t) => t.kind === kind).map((t) => t.text);
+
+test('tokens always concatenate back to the input', () => {
+  const samples = [
+    ['js', 'const x = "a\\"b" + `t${y}` // done\n/* block */ 0x1f'],
+    ['python', 'def f(x):\n  # comment\n  return "s" if x else None'],
+    ['html', '<div class="a"><!-- c --></div> text & <b>'],
+    ['nosuchlang', 'anything at all'],
+    ['sql', "SELECT * FROM t WHERE a = 'x' -- trailing"],
+    ['json', '{"a": [1, 2.5, true, null], "b": "x"}']
+  ];
+  for (const [lang, code] of samples) {
+    assert.equal(rejoin(tokenize(code, lang)), code, lang);
+  }
+});
+
+test('javascript: keywords, strings, numbers, comments, literals', () => {
+  const toks = tokenize('const n = 42; // count\nlet s = "hi";\nif (n === null) return true;', 'js');
+  assert.deepEqual(kindsOf(toks, 'keyword'), ['const', 'let', 'if', 'return']);
+  assert.deepEqual(kindsOf(toks, 'number'), ['42']);
+  assert.deepEqual(kindsOf(toks, 'string'), ['"hi"']);
+  assert.deepEqual(kindsOf(toks, 'comment'), ['// count']);
+  assert.deepEqual(kindsOf(toks, 'literal'), ['null', 'true']);
+});
+
+test('ts is an alias of typescript', () => {
+  const toks = tokenize('interface A { x: number }', 'ts');
+  assert.ok(kindsOf(toks, 'keyword').includes('interface'));
+});
+
+test('function names get their own kind', () => {
+  const toks = tokenize('function greet(name) { return name; }', 'js');
+  assert.ok(kindsOf(toks, 'function').includes('greet'), JSON.stringify(toks));
+});
+
+test('block comments span lines', () => {
+  const toks = tokenize('before /* one\ntwo */ after', 'c');
+  assert.deepEqual(kindsOf(toks, 'comment'), ['/* one\ntwo */']);
+});
+
+test('python: strings, comments and literals', () => {
+  const toks = tokenize('x = "text"  # note\ny = None', 'py');
+  assert.ok(kindsOf(toks, 'string').includes('"text"'));
+  assert.deepEqual(kindsOf(toks, 'comment'), ['# note']);
+  assert.deepEqual(kindsOf(toks, 'literal'), ['None']);
+});
+
+test('shell: # comments but not inside strings', () => {
+  const toks = tokenize('echo "a # b" # real comment', 'bash');
+  assert.ok(kindsOf(toks, 'string').some((s) => s.includes('a # b')));
+  assert.deepEqual(kindsOf(toks, 'comment'), ['# real comment']);
+});
+
+test('sql keywords are recognized', () => {
+  const toks = tokenize('SELECT id FROM users', 'sql');
+  const kw = kindsOf(toks, 'keyword');
+  assert.ok(kw.includes('SELECT') && kw.includes('FROM'), JSON.stringify(kw));
+});
+
+test('html: tags, attributes, values, comments', () => {
+  const toks = tokenize('<a href="x" disabled>text</a><!-- hi -->', 'html');
+  const tagText = kindsOf(toks, 'tag').join('');
+  assert.ok(tagText.includes('<a') && tagText.includes('</a>'), tagText);
+  assert.deepEqual(kindsOf(toks, 'attr'), ['href', 'disabled']);
+  assert.deepEqual(kindsOf(toks, 'string'), ['"x"']);
+  assert.deepEqual(kindsOf(toks, 'comment'), ['<!-- hi -->']);
+});
+
+test('escaped entities in code round-trip', () => {
+  const code = 'if (a < b && c > "d") { }';
+  assert.equal(rejoin(tokenize(code, 'js')), code);
+});
+
+test('unknown or empty language falls back to a single plain token', () => {
+  assert.deepEqual(tokenize('hello world', 'whatever'), [{ text: 'hello world', kind: 'plain' }]);
+  assert.deepEqual(tokenize('hello', ''), [{ text: 'hello', kind: 'plain' }]);
+  assert.deepEqual(tokenize('', 'js'), []);
+});
+
+test('identifiers containing keyword substrings stay plain', () => {
+  const toks = tokenize('iffy_return = classical', 'js');
+  assert.deepEqual(kindsOf(toks, 'keyword'), []);
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -266,6 +266,250 @@ test('backing store: opt out keeps drawing direct', async (t) => {
   wnd.destroy();
 });
 
+test('vector text: sizes above vectorFrom render via trapezoids', async (t) => {
+  if (skip) return t.skip(skip);
+  try {
+    app.fonts.match('sans-serif');
+  } catch (err) {
+    return t.skip(`no usable font: ${err.message}`);
+  }
+
+  const pixmap = app.createPixmap({ width: 300, height: 300, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, 300, 300);
+  ctx.fillStyle = 'black';
+  ctx.font = '280px sans-serif'; // > vectorFrom (256): routed to AddTraps
+  ctx.fillText('R', 20, 260);
+
+  const image = await readPixels(ctx, 300, 300);
+  const darkPixels = countDark(image);
+  assert.ok(darkPixels > 5000, `expected a filled 280px glyph, got ${darkPixels} dark pixels`);
+  // no glyph page must have been created for the vector size
+  for (const page of app._glyphPages?.values() ?? []) {
+    assert.notEqual(page.size, 280, 'vector draw must not create a glyph page');
+  }
+
+  pixmap.destroy();
+});
+
+test('vector text: bitmap and vector paths draw the same glyphs consistently', async (t) => {
+  if (skip) return t.skip(skip);
+  try {
+    app.fonts.match('sans-serif');
+  } catch (err) {
+    return t.skip(`no usable font: ${err.message}`);
+  }
+
+  const draw = async (policy) => {
+    app.textPolicy = policy;
+    const pixmap = app.createPixmap({ width: 300, height: 260, depth: 24 });
+    const ctx = pixmap.getContext('2d');
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, 300, 260);
+    ctx.fillStyle = 'black';
+    ctx.font = '200px sans-serif';
+    ctx.fillText('Hg', 5, 200);
+    const image = await readPixels(ctx, 300, 260);
+    pixmap.destroy();
+    return countDark(image);
+  };
+
+  const viaBitmap = await draw({ bitmapMax: 1000 });
+  const viaVector = await draw({ bitmapMax: 1, vectorFrom: 2 });
+  app.textPolicy = null;
+
+  assert.ok(viaBitmap > 5000, `bitmap draw coverage ${viaBitmap}`);
+  const ratio = viaVector / viaBitmap;
+  assert.ok(ratio > 0.9 && ratio < 1.1, `coverage should agree, bitmap=${viaBitmap} vector=${viaVector}`);
+});
+
+test('vector text: fractional sizes render without quantizing', async (t) => {
+  if (skip) return t.skip(skip);
+  try {
+    app.fonts.match('sans-serif');
+  } catch (err) {
+    return t.skip(`no usable font: ${err.message}`);
+  }
+
+  const pixmap = app.createPixmap({ width: 260, height: 260, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, 260, 260);
+  ctx.fillStyle = 'black';
+  ctx.font = '200px sans-serif';
+  const style = ctx._resolvedTextStyle();
+  style.size = 200.5; // fractional: canvas shorthand parsing aside, the pipeline supports it
+  ctx.fillText('E', 20, 220);
+
+  const image = await readPixels(ctx, 260, 260);
+  let bottom = -1;
+  for (let y = 0; y < 260; y++) {
+    for (let x = 0; x < 260; x++) {
+      const i = (y * 260 + x) * 4;
+      if (image.data[i] < 128) bottom = y;
+    }
+  }
+  assert.ok(Math.abs(bottom - 220) <= 2, `glyph bottom ${bottom} should sit on the 220 baseline`);
+
+  pixmap.destroy();
+});
+
+test('glyph page LRU: transient sizes are evicted under the cache budget', async (t) => {
+  if (skip) return t.skip(skip);
+  try {
+    app.fonts.match('sans-serif');
+  } catch (err) {
+    return t.skip(`no usable font: ${err.message}`);
+  }
+
+  app.textPolicy = { cacheBytes: 200 * 1024 };
+  const pixmap = app.createPixmap({ width: 220, height: 130, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, 220, 130);
+  ctx.fillStyle = 'black';
+  for (let s = 20; s <= 90; s += 2) {
+    ctx.font = `${s}px sans-serif`;
+    ctx.fillText('Hamburgefonstiv', 2, 110);
+  }
+  let bytes = 0;
+  for (const page of app._glyphPages.values()) bytes += page.bytes;
+  assert.ok(bytes <= 200 * 1024, `cache stayed under budget: ${bytes}`);
+
+  // and drawing with a previously evicted size still works (page recreated)
+  ctx.font = '20px sans-serif';
+  ctx.fillText('Hamburgefonstiv', 2, 40);
+  const darkPixels = countDark(await readPixels(ctx, 220, 130));
+  assert.ok(darkPixels > 100, `redraw after eviction, got ${darkPixels} dark pixels`);
+
+  app.textPolicy = null;
+  pixmap.destroy();
+});
+
+test('tex: formulas draw with batched runs, rules and surd paths', async (t) => {
+  if (skip) return t.skip(skip);
+  const { layoutTex } = await import('../lib/widgets/tex.js');
+
+  const pixmap = app.createPixmap({ width: 260, height: 120, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, 260, 120);
+  ctx.fillStyle = 'black';
+
+  const box = layoutTex('\\sqrt{\\frac{a+b}{2}}', { size: 40, color: 'black' });
+  assert.ok(box.width > 30 && box.height > 40, `box ${box.width}x${box.height}`);
+  box.draw(ctx, 10, 10);
+
+  const image = await readPixels(ctx, 260, 120);
+  const darkPixels = countDark(image);
+  assert.ok(darkPixels > 300, `expected formula ink, got ${darkPixels} dark pixels`);
+
+  // the fraction line must be a solid horizontal dark row inside the box
+  let bestRow = 0;
+  for (let y = 10; y < 10 + box.height; y++) {
+    let run = 0;
+    let best = 0;
+    for (let x = 10; x < 10 + box.width; x++) {
+      const i = (y * 260 + x) * 4;
+      run = image.data[i] < 128 ? run + 1 : 0;
+      if (run > best) best = run;
+    }
+    if (best > bestRow) bestRow = best;
+  }
+  assert.ok(bestRow > box.width * 0.5, `longest dark row ${bestRow} vs width ${box.width}`);
+
+  pixmap.destroy();
+});
+
+test('markdown: highlighted fences and math fences render', async (t) => {
+  if (skip) return t.skip(skip);
+  try {
+    app.fonts.match('sans-serif');
+  } catch (err) {
+    return t.skip(`no usable font: ${err.message}`);
+  }
+
+  const { MarkdownView } = await import('../lib/index.js');
+  const pixmap = app.createPixmap({ width: 320, height: 300, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, 320, 300);
+
+  const view = new MarkdownView(null, { fonts: app.fonts });
+  view.setMarkdown(
+    '```js\nconst x = "str"; // note\n```\n\n```math\n\\frac{a}{b}\n```\n'
+  );
+  view.layout(320);
+  const texItems = view._items.filter((i) => i.kind === 'tex');
+  assert.equal(texItems.length, 1, 'math fence became a formula');
+  view.draw(ctx, 0, 0);
+
+  const image = await readPixels(ctx, 320, 300);
+  // count colored (non-gray) pixels: syntax highlighting produces them
+  let colored = 0;
+  for (let i = 0; i < image.data.length; i += 4) {
+    const [b, g, r] = [image.data[i], image.data[i + 1], image.data[i + 2]];
+    if (Math.max(r, g, b) - Math.min(r, g, b) > 60) colored++;
+  }
+  assert.ok(colored > 50, `expected syntax colors, got ${colored} colored pixels`);
+  assert.ok(countDark(image) > 50, 'formula/code ink present');
+
+  pixmap.destroy();
+});
+
+test('markdown: invalid math falls back to a plain code block', async (t) => {
+  if (skip) return t.skip(skip);
+  try {
+    app.fonts.match('sans-serif');
+  } catch (err) {
+    return t.skip(`no usable font: ${err.message}`);
+  }
+
+  const { MarkdownView } = await import('../lib/index.js');
+  const view = new MarkdownView(null, { fonts: app.fonts });
+  view.setMarkdown('```math\n\\frac{unclosed\n```\n');
+  view.layout(300);
+  assert.equal(view._items.filter((i) => i.kind === 'tex').length, 0);
+  assert.ok(view._items.some((i) => i.kind === 'text'), 'rendered as code text instead');
+});
+
+test('markdown: links record hit rectangles and linkAt resolves them', async (t) => {
+  if (skip) return t.skip(skip);
+  try {
+    app.fonts.match('sans-serif');
+  } catch (err) {
+    return t.skip(`no usable font: ${err.message}`);
+  }
+
+  const { MarkdownView } = await import('../lib/index.js');
+  const pixmap = app.createPixmap({ width: 300, height: 120, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, 300, 120);
+
+  const view = new MarkdownView(null, { fonts: app.fonts });
+  view.setMarkdown('plain [a link](target.md) more **[bold link](other.md)**');
+  view.layout(300);
+  view.draw(ctx, 10, 20);
+
+  const hrefs = new Set(view._links.map((l) => l.href));
+  assert.deepEqual([...hrefs].sort(), ['other.md', 'target.md']);
+  const l = view._links.find((x) => x.href === 'target.md');
+  assert.equal(view.linkAt(l.x + l.w / 2, l.y + l.h / 2), 'target.md');
+  assert.equal(view.linkAt(1, 1), null, 'outside any link');
+
+  // link underlines actually draw (colored pixels under the link baseline)
+  const image = await readPixels(ctx, 300, 120);
+  let blueish = 0;
+  for (let i = 0; i < image.data.length; i += 4) {
+    if (image.data[i] > 140 && image.data[i + 2] < 100) blueish++; // BGRA
+  }
+  assert.ok(blueish > 20, `expected link color/underline pixels, got ${blueish}`);
+
+  pixmap.destroy();
+});
+
 test('markdown widget renders into a window-less pixmap context', async (t) => {
   if (skip) return t.skip(skip);
   try {

--- a/test/tex.test.js
+++ b/test/tex.test.js
@@ -1,0 +1,118 @@
+// Headless KaTeX layout tests — no X server needed (KaTeX bundles its fonts,
+// so nothing depends on fontconfig either).
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { layoutTex } from '../lib/widgets/tex.js';
+
+const runsOf = (box) => box.items.filter((i) => i.type === 'run');
+const glyphCount = (box) => runsOf(box).reduce((n, r) => n + r.run.glyphs.length, 0);
+
+test('simple formula produces a box with sane metrics', () => {
+  const box = layoutTex('x+1', { size: 20 });
+  assert.ok(box.width > 20, `width ${box.width}`);
+  assert.ok(box.height > 10, `height ${box.height}`);
+  assert.ok(box.baseline > 0 && box.baseline <= box.height);
+  assert.ok(glyphCount(box) === 3, `expected 3 glyphs, got ${glyphCount(box)}`);
+});
+
+test('adjacent same-style symbols merge into single shaped runs', () => {
+  // \sin -> s i n in one upright run; digits merge too
+  const box = layoutTex('\\sin 123', { size: 20 });
+  const runs = runsOf(box);
+  assert.equal(glyphCount(box), 6);
+  assert.ok(
+    runs.length <= 2,
+    `expected at most 2 runs (sin | 123), got ${runs.length}`
+  );
+});
+
+test('superscripts are raised and smaller', () => {
+  const box = layoutTex('x^2', { size: 20 });
+  const runs = runsOf(box);
+  assert.equal(runs.length, 2);
+  const [base, sup] = runs[0].run.size >= runs[1].run.size ? runs : [runs[1], runs[0]];
+  assert.ok(sup.run.size < base.run.size, 'superscript uses a smaller size');
+  assert.ok(sup.y < base.y, 'superscript sits above the baseline');
+});
+
+test('subscripts are lowered', () => {
+  const box = layoutTex('x_i', { size: 20 });
+  const runs = runsOf(box);
+  const sub = runs.find((r) => r.run.size < 20);
+  assert.ok(sub, 'subscript run exists');
+  assert.ok(sub.y > 0, 'subscript sits below the baseline');
+});
+
+test('fractions draw a rule between numerator and denominator', () => {
+  const box = layoutTex('\\frac{a}{b}', { size: 20 });
+  const rects = box.items.filter((i) => i.type === 'rect');
+  assert.equal(rects.length, 1, 'one frac-line');
+  const rule = rects[0];
+  const runs = runsOf(box);
+  const above = runs.filter((r) => r.y < rule.y);
+  const below = runs.filter((r) => r.y > rule.y);
+  assert.equal(above.length, 1, 'numerator above the line');
+  assert.equal(below.length, 1, 'denominator below the line');
+  assert.ok(rule.w > 0 && rule.h >= 1, 'rule has resolved extent');
+});
+
+test('fraction numerator and denominator are centered on each other', () => {
+  const box = layoutTex('\\frac{1}{100}', { size: 20 });
+  const runs = runsOf(box);
+  const num = runs.find((r) => r.run.glyphs.length === 1);
+  const den = runs.find((r) => r.run.glyphs.length === 3);
+  const numCenter = num.x + num.run.width / 2;
+  const denCenter = den.x + den.run.width / 2;
+  assert.ok(Math.abs(numCenter - denCenter) < 1, `centers ${numCenter} vs ${denCenter}`);
+});
+
+test('sqrt produces a filled surd path spanning the radicand', () => {
+  const box = layoutTex('\\sqrt{x}', { size: 20 });
+  const paths = box.items.filter((i) => i.type === 'path');
+  assert.equal(paths.length, 1);
+  assert.ok(paths[0].polys.length >= 1, 'surd outline present');
+  const run = runsOf(box)[0];
+  assert.ok(run.x > 5, 'radicand shifted right of the radical sign');
+});
+
+test('display-mode sum places limits above and below', () => {
+  const box = layoutTex('\\sum_{i=0}^{n}', { size: 20, displayMode: true });
+  const runs = runsOf(box);
+  const sum = runs.find((r) => r.run.size === 20);
+  const above = runs.filter((r) => r !== sum && r.y < sum.y);
+  const below = runs.filter((r) => r !== sum && r.y > sum.y);
+  assert.ok(above.length >= 1, 'upper limit present');
+  assert.ok(below.length >= 1, 'lower limit present');
+});
+
+test('colors from \\color reach the draw items', () => {
+  const box = layoutTex('a \\color{red} b', { size: 20 });
+  const colors = new Set(runsOf(box).map((r) => r.color));
+  assert.ok([...colors].some((c) => c === 'red'), `colors: ${[...colors]}`);
+});
+
+test('default color comes from options', () => {
+  const box = layoutTex('a', { size: 20, color: '#123456' });
+  assert.equal(runsOf(box)[0].color, '#123456');
+});
+
+test('size scales the whole layout linearly', () => {
+  const small = layoutTex('\\frac{a+b}{c}', { size: 16 });
+  const big = layoutTex('\\frac{a+b}{c}', { size: 32 });
+  assert.ok(Math.abs(big.width / small.width - 2) < 0.01, `${big.width} vs ${small.width}`);
+  assert.ok(Math.abs(big.height / small.height - 2) < 0.01);
+});
+
+test('parse errors throw (callers decide the fallback)', () => {
+  assert.throws(() => layoutTex('\\frac{1', { size: 16 }));
+});
+
+test('matrix lays out rows and columns without overlap', () => {
+  const box = layoutTex('\\begin{pmatrix} 1 & 22 \\\\ 333 & 4 \\end{pmatrix}', { size: 20 });
+  const runs = runsOf(box);
+  assert.equal(glyphCount(box), 9); // 7 digits + 2 parens
+  // parens (Size fonts) should bracket the columns
+  const xs = runs.map((r) => r.x);
+  assert.ok(Math.max(...xs) > Math.min(...xs) + 20, 'columns spread horizontally');
+});

--- a/test/text-routing.test.js
+++ b/test/text-routing.test.js
@@ -1,0 +1,93 @@
+// Bitmap/vector routing policy and glyph-page LRU — pure unit tests
+// (no X server: fake app object, fake fonts with stable keys).
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { DEFAULT_TEXT_POLICY, routeGlyphSize, trimGlyphPages } from '../lib/text/glyphs.js';
+
+const fakeFont = (key) => ({ key });
+const fakeApp = (policy) => ({ textPolicy: policy });
+
+test('small sizes always use bitmaps', () => {
+  const app = fakeApp();
+  const font = fakeFont('a');
+  for (const size of [8, 16, 64, 128, 12.5, 96.25]) {
+    assert.equal(routeGlyphSize(app, font, size), 'bitmap', `size ${size}`);
+  }
+});
+
+test('sizes above vectorFrom use the vector path', () => {
+  const app = fakeApp();
+  assert.equal(routeGlyphSize(app, fakeFont('a'), 257), 'vector');
+  assert.equal(routeGlyphSize(app, fakeFont('a'), 512), 'vector');
+});
+
+test('vectorFrom: Infinity opts out of the vector path for static sizes', () => {
+  const app = fakeApp({ vectorFrom: Infinity });
+  assert.equal(routeGlyphSize(app, fakeFont('a'), 512), 'bitmap');
+});
+
+test('middle band: fractional sizes go vector, stable integers stay bitmap', () => {
+  const app = fakeApp();
+  const font = fakeFont('a');
+  assert.equal(routeGlyphSize(app, font, 200.5), 'vector');
+  assert.equal(routeGlyphSize(app, font, 200), 'bitmap');
+  assert.equal(routeGlyphSize(app, font, 200), 'bitmap');
+});
+
+test('middle band: size churn (animation) flips to vector, reuse flips back', () => {
+  const app = fakeApp();
+  const font = fakeFont('a');
+  const routes = [];
+  for (let s = 130; s < 142; s++) routes.push(routeGlyphSize(app, font, s));
+  assert.equal(routes[0], 'bitmap', 'first sizes give bitmaps a chance');
+  assert.equal(routes[routes.length - 1], 'vector', 'sustained churn routes to vector');
+  // animation settled: the repeated size is in the recent ring -> bitmap again
+  assert.equal(routeGlyphSize(app, font, 141), 'bitmap');
+});
+
+test('ring buffers are per font face', () => {
+  const app = fakeApp();
+  const a = fakeFont('a');
+  for (let s = 130; s < 140; s++) routeGlyphSize(app, a, s);
+  assert.equal(routeGlyphSize(app, a, 141), 'vector');
+  assert.equal(routeGlyphSize(app, fakeFont('b'), 141), 'bitmap', 'other face unaffected');
+});
+
+test('trimGlyphPages evicts least-recently-used pages down to the budget', () => {
+  const destroyed = [];
+  const page = (name, bytes) => ({ bytes, destroy: () => destroyed.push(name) });
+  const app = {
+    textPolicy: { cacheBytes: 250 },
+    _glyphPages: new Map([
+      ['old', page('old', 100)],
+      ['mid', page('mid', 100)],
+      ['new', page('new', 100)]
+    ])
+  };
+  trimGlyphPages(app);
+  assert.deepEqual(destroyed, ['old'], 'oldest evicted first, stops at budget');
+  assert.deepEqual([...app._glyphPages.keys()], ['mid', 'new']);
+});
+
+test('trimGlyphPages never evicts pages referenced by the current draw', () => {
+  const destroyed = [];
+  const mk = (name, bytes) => ({ bytes, destroy: () => destroyed.push(name) });
+  const inUsePage = mk('inuse', 300);
+  const app = {
+    textPolicy: { cacheBytes: 100 },
+    _glyphPages: new Map([
+      ['inuse', inUsePage],
+      ['other', mk('other', 50)]
+    ])
+  };
+  trimGlyphPages(app, undefined, new Set([inUsePage]));
+  assert.deepEqual(destroyed, ['other']);
+  assert.ok(app._glyphPages.has('inuse'));
+});
+
+test('default policy matches issue #45 thresholds', () => {
+  assert.equal(DEFAULT_TEXT_POLICY.bitmapMax, 128);
+  assert.equal(DEFAULT_TEXT_POLICY.vectorFrom, 256);
+  assert.ok(DEFAULT_TEXT_POLICY.cacheBytes >= 4 << 20);
+});

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -267,3 +267,20 @@ test('parseMarkdown: soft-wrapped paragraph lines join', () => {
   assert.equal(ast.length, 1);
   assert.equal(ast[0].children[0].text, 'line one line two');
 });
+
+test('parseInline: no intra-word underscore emphasis (WM_DELETE_WINDOW)', () => {
+  const nodes = parseInline('set WM_DELETE_WINDOW and _real emphasis_');
+  assert.deepEqual(
+    nodes.map((n) => n.type),
+    ['text', 'em']
+  );
+  assert.equal(nodes[0].text, 'set WM_DELETE_WINDOW and ');
+  assert.equal(nodes[1].children[0].text, 'real emphasis');
+});
+
+test('parseMarkdown: snake_case survives inside styled and plain contexts', () => {
+  const ast = parseMarkdown('`code_name` plus **bold_name_here** plus plain_name_x');
+  const para = ast[0];
+  const flat = JSON.stringify(para);
+  assert.ok(!flat.includes('"em"'), `no emphasis nodes expected: ${flat}`);
+});

--- a/test/trapezoid.test.js
+++ b/test/trapezoid.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { trapArea, trapezoidize } from '../lib/trapezoid.js';
+
+// polygons are flat [x0,y0, x1,y1, ...], y-down
+
+test('rectangle produces a single merged trapezoid with exact area', () => {
+  const traps = trapezoidize([[0, 0, 10, 0, 10, 5, 0, 5]]);
+  assert.equal(traps.length, 6);
+  assert.equal(trapArea(traps), 50);
+  const [tl, tr, ty, bl, br, by] = traps;
+  assert.ok(ty < by, 'top spanfix comes first (y-down)');
+  assert.deepEqual([tl, tr, ty, bl, br, by], [0, 10, 0, 0, 10, 5]);
+});
+
+test('triangle area is exact', () => {
+  const traps = trapezoidize([[0, 0, 10, 0, 5, 10]]);
+  assert.equal(trapArea(traps), 50);
+});
+
+test('donut: hole with opposite winding is subtracted', () => {
+  const traps = trapezoidize([
+    [0, 0, 20, 0, 20, 20, 0, 20], // outer, clockwise
+    [5, 15, 15, 15, 15, 5, 5, 5] // inner, counter-clockwise
+  ]);
+  assert.equal(trapArea(traps), 300); // 400 - 100
+});
+
+test('overlapping same-winding contours fill the union once (non-zero rule)', () => {
+  const traps = trapezoidize([
+    [0, 0, 10, 0, 10, 10, 0, 10],
+    [5, 5, 15, 5, 15, 15, 5, 15]
+  ]);
+  assert.equal(trapArea(traps), 175); // union, not 200
+});
+
+test('translation offsets are applied', () => {
+  const traps = trapezoidize([[0, 0, 4, 0, 4, 4, 0, 4]], 100, 50);
+  assert.deepEqual(traps, [100, 104, 50, 100, 104, 54]);
+});
+
+test('degenerate input yields no trapezoids', () => {
+  assert.deepEqual(trapezoidize([]), []);
+  assert.deepEqual(trapezoidize([[0, 0, 10, 0]]), []); // horizontal line
+  assert.deepEqual(trapezoidize([[0, 0, 0, 10]]), []); // zero-width sliver
+});
+
+test('appends into a provided output array', () => {
+  const out = [1, 2, 3, 4, 5, 6];
+  trapezoidize([[0, 0, 2, 0, 2, 2, 0, 2]], 0, 0, out);
+  assert.equal(out.length, 12);
+});
+
+test('adjacent slabs sharing edges merge (output stays near one trap per edge)', () => {
+  // staircase-free convex polygon: a hexagon has 6 edges, expect few traps
+  const hex = [10, 0, 20, 5, 20, 15, 10, 20, 0, 15, 0, 5];
+  const traps = trapezoidize([hex]);
+  assert.ok(traps.length / 6 <= 4, `expected <=4 traps for a hexagon, got ${traps.length / 6}`);
+  // shoelace area of the hexagon
+  let area = 0;
+  for (let i = 0; i < hex.length; i += 2) {
+    const j = (i + 2) % hex.length;
+    area += hex[i] * hex[j + 1] - hex[j] * hex[i + 1];
+  }
+  area = Math.abs(area) / 2;
+  assert.ok(Math.abs(trapArea(traps) - area) < 1e-9, `${trapArea(traps)} != ${area}`);
+});


### PR DESCRIPTION
Implements #45 and extends the markdown/text stack with math rendering and fence highlighting.

## Vector (trapezoid) text path — closes #45

- **`lib/trapezoid.js`**: slab-sweep trapezoidal decomposition of flattened outlines (non-zero winding, holes/overlaps handled, spans merged across slabs) emitting `AddTraps` wire data.
- **Routing in `drawGlyphRuns`**, per the issue's measured crossovers:
  - ≤128px → cached bitmap glyphs, unconditionally (status quo);
  - \>256px → trapezoids by default (opt-out via `app.textPolicy = { vectorFrom: Infinity }`);
  - in between → vector when the size is fractional or a small per-face ring of recent sizes shows no reuse (zoom/pinch animation in flight); settles back to bitmaps once a size repeats.
- One batched `AddTraps` + `Composite` per draw through a shared scratch a8 mask; vector positions are unrounded so fractional-size animations are smooth.
- Cheap wins from the issue: **glyph page LRU** (uploaded-bitmap byte budget, `FreeGlyphSet` eviction, in-use pages protected) and **supersampling 4×4 → 2×2 above 96px**.
- Pixel-verified: bitmap vs vector coverage of the same text agrees within ~3%; fractional sizes land on the exact baseline.

## KaTeX math widget + math fences

- **`lib/widgets/tex.js`**: `layoutTex()` / `TexBox` / `TexView` — walks KaTeX's DOM tree and lays it out directly in pixel space (inline flow, vlists, rules, sizing/font classes, SVG surds as server-side trapezoids) using the KaTeX-bundled fonts. Headless layout, no browser/DOM.
- Wire efficiency: adjacent same-style symbols merge into single shaped runs, and a formula draws as **one `CompositeGlyphs` per color** — never per-character placements.
- Markdown fences tagged `math`/`tex`/`latex`/`katex` render as centered display-mode formulas, falling back to a plain code block on parse errors. Docs in `docs/tex.md`.

## Markdown improvements

- **Fence syntax highlighting** via highlight.js (`common` build), themed by `theme.codeTheme`.
- **Parser swapped to `marked`** (CommonMark + GFM): fixes intra-word underscore emphasis — `WM_DELETE_WINDOW` no longer renders "DELETE" italic (regression-tested).
- **Clickable links**: `draw()` records link rects, `linkAt(x, y)` resolves them, `onLink` is wired to mousedown in window mode. Fixed a latent `TextLayout` bug where custom span fields were dropped, which had silently disabled link underlines and inline-code backgrounds.
- **`examples/markdown.js` is now a documentation browser**: "View ntk documentation" link on the start page, local `.md` navigation with history/Backspace, external links open in the system browser, wheel/arrow/PageUp/Down scrolling. All 81 local links across the 12 doc pages audited as resolving.

## Dependency policy

AGENTS.md rule relaxed per maintainer direction: *use external dependencies if they are maintained, easy to install, portable and don't add too much weight* (native modules still excluded). New deps — `katex`, `marked`, `highlight.js` — are all pure JS.

## Testing

`npm test`: 107/107, including new unit suites (trapezoid geometry, routing policy + LRU, highlighter, headless TeX layout) and smoke tests with pixel-level assertions against a real X server (vector text, LRU eviction, formula rules, fence colors, link hit rects).