### PR TITLE
feat: render GFM tables in MarkdownView

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -216,8 +216,9 @@ wnd.map(); // renders on expose, re-wraps on resize
 
 Parsing is CommonMark + GFM via [marked](https://marked.js.org). Rendered
 blocks: headings, paragraphs, fenced code, blockquotes, nested
-ordered/unordered lists, `---` rules (tables fall back to their monospaced
-source for now). Inlines: `**strong**`, `*em*`, `` `code` `` (with
+ordered/unordered lists, `---` rules, and GFM tables (natural column
+widths, per-column `:--`/`:-:`/`--:` alignment, shrink-and-wrap when the
+table is wider than the window). Inlines: `**strong**`, `*em*`, `` `code` `` (with
 background), `[links](url)` (colored + underlined); images render as links
 to their source.
 All layout — wrapping, font selection per style, spacing — runs through

--- a/examples/markdown.js
+++ b/examples/markdown.js
@@ -41,6 +41,14 @@ Fences tagged \`math\`/\`latex\` render with KaTeX:
 \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}
 \`\`\`
 
+## Tables
+
+| Stage | What happens | Cost |
+|:------|:------------:|-----:|
+| shape | \`GSUB\`/\`GPOS\`, kerning | *cached* |
+| wrap | UAX#14 breaks | per width |
+| draw | CompositeGlyphs | **~1 byte/glyph** |
+
 ## Things that just work
 
 - Kerning pairs like AV and _To_ — compare with your browser

--- a/lib/widgets/markdown.js
+++ b/lib/widgets/markdown.js
@@ -10,6 +10,8 @@
 //        | { type: 'blockquote', blocks }
 //        | { type: 'list', ordered, start, items: [ blocks ] }
 //        | { type: 'hr' }
+//        | { type: 'table', align: ['left'|'center'|'right'],
+//            header: [ inline[] ], rows: [ [ inline[] ] ] }
 //   inline: { type: 'text', text }
 //         | { type: 'strong'|'em', children }
 //         | { type: 'code', text }
@@ -59,11 +61,14 @@ function mapBlocks(tokens) {
       case 'hr':
         blocks.push({ type: 'hr' });
         break;
-      case 'table': {
-        // no table layout in the widget (yet): show the source, monospaced
-        blocks.push({ type: 'code', text: t.raw.trim(), lang: '' });
+      case 'table':
+        blocks.push({
+          type: 'table',
+          align: t.align.map((a) => a ?? 'left'),
+          header: t.header.map((cell) => mapInline(cell.tokens)),
+          rows: t.rows.map((row) => row.map((cell) => mapInline(cell.tokens)))
+        });
         break;
-      }
       case 'html':
         blocks.push({ type: 'paragraph', children: [{ type: 'text', text: t.text.trim() }] });
         break;

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -19,6 +19,8 @@ const DEFAULT_THEME = {
   quoteColor: '#555555',
   quoteBar: '#d8d8d8',
   hrColor: '#dddddd',
+  tableBorder: '#d8d8d8',
+  tableHeaderBg: '#f7f7f7',
   blockSpacing: 0.7, // em (of base size) between blocks
   padding: 16,
   // fence syntax highlighting (lib/widgets/highlight.js token kinds);
@@ -238,6 +240,11 @@ export default class MarkdownView {
           break;
         }
 
+        case 'table': {
+          y = this._layoutTable(fonts, block, styles, x, y, width);
+          break;
+        }
+
         case 'hr': {
           this._items.push({
             kind: 'rect',
@@ -253,6 +260,80 @@ export default class MarkdownView {
       }
     }
     return y;
+  }
+
+  /**
+   * Table layout: columns take their natural (unwrapped) width when the
+   * table fits, otherwise shrink proportionally (with a floor) and cells
+   * wrap. The grid and header background are emitted as rect items, so the
+   * two-pass draw() paints them under the cell text.
+   */
+  _layoutTable(fonts, block, styles, x, y, width) {
+    const t = this.theme;
+    const hpad = t.size * 0.55;
+    const vpad = t.size * 0.3;
+    const ncols = block.header.length;
+    const allRows = [block.header, ...block.rows];
+
+    // natural width per column: widest unwrapped cell
+    const cellStyle = (isHeader) => (isHeader ? { ...styles.base, weight: 700 } : styles.base);
+    const cellSpans = allRows.map((row, r) =>
+      Array.from({ length: ncols }, (_, c) => this._spans(row[c] ?? [], cellStyle(r === 0)))
+    );
+    const natural = new Array(ncols).fill(0);
+    for (const row of cellSpans) {
+      for (let c = 0; c < ncols; c++) {
+        if (!row[c].length) continue;
+        const measure = new TextLayout(fonts, row[c], styles.base, { lineHeight: t.lineHeight });
+        natural[c] = Math.max(natural[c], measure.width);
+      }
+    }
+
+    const cols = natural.map((w) => w + hpad * 2);
+    const total = cols.reduce((a, b) => a + b, 0);
+    if (total > width) {
+      // proportional shrink; the floor keeps narrow columns readable even
+      // if wide neighbors then push the table slightly past the container
+      const minCol = Math.min(t.size * 2.5 + hpad * 2, width / ncols);
+      for (let c = 0; c < ncols; c++) {
+        cols[c] = Math.max(minCol, (cols[c] / total) * width);
+      }
+    }
+    const tableW = cols.reduce((a, b) => a + b, 0);
+
+    const topY = y;
+    const rowLines = [y];
+    for (let r = 0; r < cellSpans.length; r++) {
+      const layouts = cellSpans[r].map((spans, c) =>
+        new TextLayout(fonts, spans.length ? spans : '', styles.base, {
+          maxWidth: cols[c] - hpad * 2,
+          align: block.align[c] ?? 'left',
+          lineHeight: t.lineHeight
+        })
+      );
+      const rowH = Math.max(...layouts.map((l) => l.height), t.size * t.lineHeight) + vpad * 2;
+      if (r === 0) {
+        this._items.push({ kind: 'rect', x, y, width: tableW, height: rowH, color: t.tableHeaderBg });
+      }
+      let cx = x;
+      for (let c = 0; c < ncols; c++) {
+        this._items.push({ kind: 'text', x: cx + hpad, y: y + vpad, layout: layouts[c] });
+        cx += cols[c];
+      }
+      y += rowH;
+      rowLines.push(y);
+    }
+
+    // grid: horizontal rule per row boundary, vertical per column boundary
+    for (const ly of rowLines) {
+      this._items.push({ kind: 'rect', x, y: ly, width: tableW, height: 1, color: t.tableBorder });
+    }
+    let cx = x;
+    for (let c = 0; c <= ncols; c++) {
+      this._items.push({ kind: 'rect', x: cx, y: topY, width: 1, height: y - topY + 1, color: t.tableBorder });
+      if (c < ncols) cx += cols[c];
+    }
+    return y + 1;
   }
 
   /** inline AST -> styled spans for TextLayout */

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -8,6 +8,7 @@ import { encodeGlyphItems } from '../lib/text/glyphs.js';
 import { TextLayout } from '../lib/text/layout.js';
 import { reorderRuns, shapeText } from '../lib/text/shape.js';
 import { parseInline, parseMarkdown } from '../lib/widgets/markdown.js';
+import MarkdownView from '../lib/widgets/markdownview.js';
 
 let hasFontconfig = true;
 try {
@@ -252,6 +253,19 @@ test('parseMarkdown: nested lists', () => {
   assert.equal(nested.items.length, 2);
 });
 
+test('parseMarkdown: tables', () => {
+  const ast = parseMarkdown('| Name | Score |\n|:-----|------:|\n| **a** | 1 |\n| b | 2 |');
+  assert.equal(ast.length, 1);
+  const table = ast[0];
+  assert.equal(table.type, 'table');
+  assert.deepEqual(table.align, ['left', 'right']);
+  assert.equal(table.header.length, 2);
+  assert.equal(table.header[0][0].text, 'Name');
+  assert.equal(table.rows.length, 2);
+  assert.equal(table.rows[0][0][0].type, 'strong');
+  assert.equal(table.rows[1][1][0].text, '2');
+});
+
 test('parseInline: emphasis, code, links, escapes', () => {
   const nodes = parseInline('a **b** *c* `d` [e](f) \\*g\\*');
   const types = nodes.map((n) => n.type);
@@ -283,4 +297,37 @@ test('parseMarkdown: snake_case survives inside styled and plain contexts', () =
   const para = ast[0];
   const flat = JSON.stringify(para);
   assert.ok(!flat.includes('"em"'), `no emphasis nodes expected: ${flat}`);
+});
+
+test('MarkdownView: table layout places cells and grid', needsFonts, () => {
+  const fonts = new FontManager();
+  const view = new MarkdownView(null, { fonts });
+  view.setMarkdown('| Name | Score |\n|:-----|------:|\n| alpha | 1 |\n| beta | 22 |');
+  const height = view.layout(400);
+  assert.ok(height > 0);
+  const items = view._items;
+  const texts = items.filter((i) => i.kind === 'text');
+  const rects = items.filter((i) => i.kind === 'rect');
+  assert.equal(texts.length, 6, '2 cols x 3 rows of cell text');
+  // header background + 4 horizontal + 3 vertical grid lines
+  assert.equal(rects.length, 8);
+  // header cells are bold
+  const header = texts[0];
+  assert.equal(header.layout.lines[0].runs[0].span.weight, 700);
+  // right-aligned numeric column: the two body cells share a right edge
+  const right = (i) => i.x + i.layout.lines[0].x + i.layout.lines[0].width;
+  assert.ok(Math.abs(right(texts[3]) - right(texts[5])) < 0.5, 'right-aligned column');
+});
+
+test('MarkdownView: wide table shrinks columns to the container', needsFonts, () => {
+  const fonts = new FontManager();
+  const view = new MarkdownView(null, { fonts });
+  const long = 'a very long cell that will definitely not fit unwrapped in a narrow container';
+  view.setMarkdown(`| One | Two |\n|-----|-----|\n| ${long} | ${long} |`);
+  view.layout(300);
+  const gridTop = view._items.filter((i) => i.kind === 'rect' && i.height === 1)[0];
+  assert.ok(gridTop.width <= 300 - 16 * 2 + 1, `table width ${gridTop.width} fits container`);
+  // cells wrapped onto multiple lines
+  const body = view._items.filter((i) => i.kind === 'text');
+  assert.ok(body.some((i) => i.layout.lines.length > 1), 'long cells wrap');
 });


### PR DESCRIPTION
Adds real table rendering to the markdown widget. Previously GFM tables fell back to their raw source shown as a monospaced code block.

## Parser (`lib/widgets/markdown.js`)

`marked` table tokens now map to a table AST node:

```
{ type: 'table', align: ['left'|'center'|'right'], header: [inline[]], rows: [[inline[]]] }
```

Cell contents go through the normal inline mapping, so bold/em/code/links inside cells just work.

## View (`lib/widgets/markdownview.js`)

New `_layoutTable` emits the same rect/text draw items the existing two-pass `draw()` already understands (backgrounds and grid lines paint under cell text, no drawing changes needed):

- Columns take their natural (unwrapped) width when the table fits; otherwise they shrink proportionally with a readability floor and cells wrap.
- Per-column `:--` / `:-:` / `--:` alignment is passed straight to `TextLayout`'s `align` option.
- Header row is bold on a background fill; the 1px grid uses two new theme keys, `tableBorder` and `tableHeaderBg`.
- Links inside cells stay clickable (same span/deco machinery).

Like browsers at min-content, a table that can't fit even at minimum column widths overflows the container slightly rather than truncating.

## Tests / docs

- Parser test for the table AST (alignment, inline styling in cells).
- Headless `MarkdownView` layout tests: cell/grid item counts, bold header spans, shared right edge of a right-aligned column, and shrink-and-wrap for a too-wide table.
- `docs/text.md` updated; the `examples/markdown.js` start page gained a table to exercise it.