### PR TITLE
feat: coalesce noisy events and pace frames to connection latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ wnd.map();
 canvas as a source — for images with lots of drawing calls it might be more
 efficient to draw locally and transfer pixels to the server when ready.
 
+## Frame pacing & networked displays
+
+Noisy events (`resize`, `mousemove`, `expose`) are coalesced into paced
+frames — the latest state wins, nothing queues up — and each frame is
+fenced with a server round-trip, so rendering automatically slows to the
+connection's real throughput instead of drawing a trail of stale updates
+over ssh-forwarded displays. Animation uses the DOM-style
+`requestAnimationFrame`:
+
+```js
+function frame(now) {
+  // ... draw ...
+  wnd.requestAnimationFrame(frame); // ~60fps locally, RTT-paced remotely
+}
+wnd.requestAnimationFrame(frame);
+```
+
+See [docs/window.md](docs/window.md) for the knobs (`frameInterval`,
+`frameSync`, `coalesceEvents`) and the raw uncoalesced event stream.
+
 ## Resource management
 
 Server-side resources support `using` / `await using` (Node 24+):

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ matching file here (see AGENTS.md).
 
 - [Getting started](getting-started.md) — installation, requirements, first window
 - [App](app.md) — connecting to the X server, the `App` factory object
-- [Window](window.md) — window creation, properties, methods and events
+- [Window](window.md) — window creation, properties, methods, events,
+  frame pacing / event coalescing, `requestAnimationFrame`
 - [Pixmap](pixmap.md) — offscreen drawables
 - [2d rendering context](context-2d.md) — canvas-like drawing API over XRender
 - [Images](images.md) — PNG/JPEG loading (`loadImage`), the `Image` object,

--- a/docs/window.md
+++ b/docs/window.md
@@ -20,6 +20,16 @@ Constructing a window with an existing X window id (`{ id }`) returns a
 (cached) wrapper around that foreign window; its geometry is populated
 asynchronously.
 
+Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
+
+- `backingStore: false` — opt out of double buffering (below)
+- `coalesceEvents: false` — deliver every noisy event individually (see
+  [Frames, coalescing and slow connections](#frames-coalescing-and-slow-connections))
+- `frameSync: false` — don't pace frames with a server round-trip fence
+- `frameInterval: ms` — minimum time between paced frames (default `16`,
+  ~60 fps; `0` disables the timer gate). Also writable later as
+  `wnd.frameInterval`.
+
 ## Double buffering (backing store)
 
 Requesting a 2d context on a window you created enables double buffering
@@ -44,10 +54,74 @@ automatically (opt out with `createWindow({ backingStore: false })`):
 Foreign windows (`{ id }`) and windows drawing via the `'opengl'` or
 `'x11'` contexts are not double-buffered.
 
+## Frames, coalescing and slow connections
+
+Some X events are noisy by nature: an interactive resize is a stream of
+`ConfigureNotify`, the pointer reports `MotionNotify` at device rate, damage
+arrives as bursts of `Expose` rectangles. Reacting to each one queues more
+drawing than the connection can drain, and the window plays back a trail of
+stale intermediate states — most visibly over ssh-forwarded / networked
+displays. ntk therefore delivers noisy events and repaints in **paced
+frames**, gated by two independent mechanisms:
+
+- **a fence** — after each frame the library sends a cheap request with a
+  reply (`GetInputFocus`). X processes requests strictly in order, so the
+  reply confirms the server has consumed everything the frame drew. At most
+  one fence is ever in flight: on a fast local connection this costs
+  nothing, on a slow link frames automatically degrade to one per
+  round-trip — the latest state is always the next thing drawn, and no
+  backlog builds up. Disable with `frameSync: false`.
+- **a timer** — at most one paced frame per `frameInterval` ms (default 16),
+  so a local server isn't asked to redraw at input-device rate.
+
+While a frame is pending, noisy events **coalesce** instead of queueing:
+
+- `resize`, `mousemove` — the newest event wins. Every merged raw event is
+  kept in `ev.coalesced` (oldest first, like the DOM's
+  `getCoalescedEvents()`), for e.g. freehand drawing that wants the full
+  pointer trail. `wnd.width/height/x/y` always track the newest
+  `ConfigureNotify` immediately, even before the event is delivered.
+- `expose` — damage accumulates: `ev.x/y/width/height` is the bounding box
+  of all merged rectangles and `ev.rects` lists each one.
+
+Discrete events (`mousedown`, `keydown`, …) are never coalesced and are
+delivered immediately — any buffered noisy events are flushed first so
+handlers observe them in the order they happened. Blits of an already-drawn
+backing store still respect the fence, but skip the timer for latency.
+
+Escape hatches, from mildest to rawest:
+
+- `frameInterval = 0` — fence-only pacing (fastest delivery that cannot
+  fall behind the server)
+- `frameSync: false` — timer-only pacing
+- `coalesceEvents: false` — per-event delivery, no merging at all
+- `wnd.on('event', ev => ...)` — the raw X event stream for this window,
+  before any name mapping or coalescing
+
+`wnd.frameLatency` reports the last measured fence round-trip in
+milliseconds (`null` until the first frame) — a live estimate of connection
++ server latency, useful for adapting rendering quality or animation rates.
+
+### requestAnimationFrame
+
+For animation and manual render scheduling, windows offer the DOM-style
+
+```js
+const id = wnd.requestAnimationFrame((now) => { /* draw one frame */ });
+wnd.cancelAnimationFrame(id);
+```
+
+The callback runs on the window's next paced frame (`now` is a
+`performance.now()` timestamp). A re-registering animation loop renders at
+~`1000/frameInterval` fps locally and self-throttles to one frame per
+round-trip on slow connections — write the loop once, it behaves everywhere.
+
 ## Properties
 
 - `wnd.id` — X window id
 - `wnd.width`, `wnd.height`, `wnd.x`, `wnd.y` — geometry, kept in sync on `resize`
+- `wnd.frameLatency` — last fence round-trip, ms (`null` before the first frame)
+- `wnd.frameInterval` — minimum ms between paced frames (writable)
 - `wnd.app`, `wnd.X`, `wnd.display` — owning app / raw client shortcuts
 
 ## Methods
@@ -61,6 +135,8 @@ All return `this` unless noted.
   react-renderer use)
 - `setTitle(title)`
 - `getContext(name)` — `'2d'`, `'opengl'` or `'x11'`; see the context docs
+- `requestAnimationFrame(cb)` — returns an id, does not return `this`;
+  `cancelAnimationFrame(id)` (see above)
 - `createWindow(params)` — child window (`parent` preset to this window)
 - `createPixmap(params)` — pixmap defaulting to this window's size, depth 32
 - `queryPointer(cb)`, `grabPointer()`, `setMouseHintOnly(isOn)`
@@ -78,12 +154,12 @@ constructor arg) automatically extends the window's X event mask.
 | event | X event | notes |
 |---|---|---|
 | `mousedown` / `mouseup` | ButtonPress/Release | `ev.x`, `ev.y`, `ev.keycode` (button) |
-| `mousemove` | MotionNotify | |
+| `mousemove` | MotionNotify | coalesced per frame; full trail in `ev.coalesced` |
 | `mouseover` / `mouseout` | Enter/LeaveNotify | |
 | `keydown` / `keyup` | KeyPress/Release | `keydown` carries `ev.codepoint` (unicode) |
-| `expose` | Expose | `ev.x/y/width/height` of the damaged area; on double-buffered windows only emitted when a real repaint is needed (see above) |
+| `expose` | Expose | `ev.x/y/width/height` of the damaged area, coalesced per frame (bounding box; rect list in `ev.rects`); on double-buffered windows only emitted when a real repaint is needed (see above) |
 | `draw` | — | synthetic repaint request on double-buffered windows (same payload as the accompanying `expose`) |
-| `resize` | ConfigureNotify | updates `wnd.width/height/x/y` first |
+| `resize` | ConfigureNotify | coalesced per frame (last state wins); updates `wnd.width/height/x/y` first |
 | `map` / `unmap` | Map/UnmapNotify | |
 | `destroy` | DestroyNotify | wrapper is removed from the cache |
 | `map_request`, `configure_request` | SubstructureRedirect | for window managers |

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -1,0 +1,51 @@
+// requestAnimationFrame demo: a bouncing ball driven by the window's frame
+// clock. Locally this runs at ~60fps; over a slow (e.g. ssh-forwarded)
+// connection it self-throttles to one frame per server round-trip instead
+// of queueing a trail of stale frames. The title shows the measured
+// latency (wnd.frameLatency) and achieved frame rate.
+import { createClient } from '../lib/index.js';
+
+const app = await createClient();
+const wnd = app.createWindow({ title: 'animation', width: 400, height: 300 });
+const ctx = wnd.getContext('2d');
+wnd.map();
+
+const ball = { x: 60, y: 60, dx: 3.2, dy: 2.1, r: 14 };
+let frames = 0;
+let lastNow = performance.now();
+
+setInterval(() => {
+  const latency = wnd.frameLatency == null ? '?' : wnd.frameLatency.toFixed(1);
+  wnd.setTitle(`animation — ${frames} fps, latency ${latency} ms`);
+  frames = 0;
+}, 1000).unref();
+
+function frame(now) {
+  // scale movement by elapsed time so speed survives frame-rate changes
+  const dt = Math.min((now - lastNow) / 16, 8);
+  lastNow = now;
+  frames++;
+
+  ball.x += ball.dx * dt;
+  ball.y += ball.dy * dt;
+  if (ball.x < ball.r || ball.x > wnd.width - ball.r) ball.dx *= -1;
+  if (ball.y < ball.r || ball.y > wnd.height - ball.r) ball.dy *= -1;
+  ball.x = Math.min(Math.max(ball.x, ball.r), wnd.width - ball.r);
+  ball.y = Math.min(Math.max(ball.y, ball.r), wnd.height - ball.r);
+
+  ctx.fillStyle = '#f0f0f8';
+  ctx.fillRect(0, 0, wnd.width, wnd.height);
+  ctx.fillStyle = '#d04030';
+  ctx.beginPath();
+  ctx.moveTo(ball.x + ball.r, ball.y);
+  // approximate a circle with a polygon (canvas arc() is not implemented yet)
+  for (let a = 0; a <= 20; a++) {
+    const t = (a / 20) * Math.PI * 2;
+    ctx.lineTo(ball.x + Math.cos(t) * ball.r, ball.y + Math.sin(t) * ball.r);
+  }
+  ctx.fill();
+
+  wnd.requestAnimationFrame(frame);
+}
+
+wnd.requestAnimationFrame(frame);

--- a/lib/events_map.js
+++ b/lib/events_map.js
@@ -51,6 +51,18 @@ export const mask = {
   message: 0
 };
 
+// events that are noisy by nature: intermediate occurrences carry no
+// information the final one doesn't, so Window merges bursts into a single
+// event per paced frame (see docs/window.md). 'last' — the newest event
+// wins (older ones ride along in ev.coalesced); 'union' — damage
+// rectangles accumulate (bounding box in ev.x/y/width/height, every rect
+// in ev.rects).
+export const coalesce = {
+  mousemove: 'last',
+  resize: 'last',
+  expose: 'union'
+};
+
 export const toSnake = {
   onMouseMove: 'mousemove',
   onMouseOver: 'mouseover',
@@ -77,4 +89,4 @@ export const maskCamelCase = Object.fromEntries(
   Object.entries(toSnake).map(([camel, snake]) => [camel, mask[snake]])
 );
 
-export default { eventName, mask, maskCamelCase, toSnake };
+export default { eventName, mask, maskCamelCase, toSnake, coalesce };

--- a/lib/window.js
+++ b/lib/window.js
@@ -37,6 +37,25 @@ export default class Window extends Drawable {
     this._foreign = !!args.id;
     this._backingOptOut = args.backingStore === false;
     this._backing = null;
+    this._dirty = false;
+    this._presentPending = false;
+
+    // frame clock state: coalesced events, synthetic redraws and
+    // requestAnimationFrame callbacks are delivered in paced frames
+    // (see docs/window.md "Frames, coalescing and slow connections")
+    this._coalesce = args.coalesceEvents !== false;
+    this._frameSyncEnabled = args.frameSync !== false;
+    this.frameInterval = args.frameInterval ?? 16;
+    this.frameLatency = null;
+    this._frame = {
+      pending: new Map(), // coalescible event name -> merged event
+      rafCbs: [],
+      rafId: 0,
+      inFlight: false, // fence round-trip awaiting the server's reply
+      timer: null,
+      scheduled: false,
+      needsRedraw: false
+    };
 
     if (!args.id) {
       this.id = X.AllocID();
@@ -88,6 +107,14 @@ export default class Window extends Drawable {
       ntkev.target = this;
       const eventName = xevents.eventName[ev.type];
       if (!eventName) return;
+      // geometry bookkeeping happens on the raw stream so wnd.x/y/width/height
+      // are current even while a user-facing 'resize' event sits coalesced
+      if (eventName === 'resize') {
+        this.width = ev.width;
+        this.height = ev.height;
+        this.x = ev.x;
+        this.y = ev.y;
+      }
       // double-buffered windows serve expose events from the backing pixmap
       // — user code is only asked to redraw when the content is invalid
       if (eventName === 'expose' && this._backing) {
@@ -107,6 +134,13 @@ export default class Window extends Drawable {
           ev.codepoint = entry.unicode;
         }
       }
+      if (this._coalesce && xevents.coalesce[eventName]) {
+        this._enqueueCoalesced(eventName, ntkev);
+        return;
+      }
+      // deliver buffered state events before a discrete one so handlers see
+      // them in the order they happened (a drag sees the move, then the up)
+      this._flushCoalesced();
       this.emit(eventName, ntkev);
       // anything drawn during the handlers becomes visible in one blit
       if (this._dirty) this._present();
@@ -134,17 +168,11 @@ export default class Window extends Drawable {
       }
     });
 
-    this.on('resize', (ev) => {
-      this.width = ev.width;
-      this.height = ev.height;
-      this.x = ev.x;
-      this.y = ev.y;
-    });
-
     this.on('map', () => (this._mapped = true));
     this.on('unmap', () => (this._mapped = false));
     this.on('destroy', () => {
       this._forget();
+      this._teardownFrame();
       // the server frees window-backed pictures with the window — let
       // contexts drop their wrappers without issuing FreePicture
       this.emit('_destroyed');
@@ -180,7 +208,6 @@ export default class Window extends Drawable {
     this._dirty = false;
     this._backingValid = false;
     this._presentScheduled = false;
-    this._redrawScheduled = false;
     this._backedW = this.width;
     this._backedH = this.height;
 
@@ -242,25 +269,10 @@ export default class Window extends Drawable {
     }
   }
 
-  // ask user code to repaint (full window), at most once per tick
+  // ask user code to repaint (full window), on the next paced frame
   _requestRedraw() {
-    if (this._redrawScheduled) return;
-    this._redrawScheduled = true;
-    setImmediate(() => {
-      this._redrawScheduled = false;
-      const ev = {
-        x: 0,
-        y: 0,
-        width: this.width,
-        height: this.height,
-        synthetic: true,
-        window: this,
-        target: this
-      };
-      this.emit('draw', ev);
-      this.emit('expose', ev);
-      if (this._dirty) this._present();
-    });
+    this._frame.needsRedraw = true;
+    this._scheduleFrame();
   }
 
   // called by rendering contexts after each drawing operation
@@ -277,12 +289,192 @@ export default class Window extends Drawable {
     });
   }
 
+  /*
+   * Frame clock. Noisy events (see events_map coalesce), synthetic redraws
+   * and requestAnimationFrame callbacks are delivered in "frames", paced by
+   * two independent gates:
+   *
+   *  - a fence: a cheap request with a reply (GetInputFocus) sent after each
+   *    frame; X processes requests in order, so its reply confirms the
+   *    server consumed everything the frame drew. At most one fence is in
+   *    flight — on a slow connection frames degrade to one per round-trip
+   *    instead of queueing a trail of stale updates.
+   *  - a timer: at most one paced frame per `frameInterval` ms, so a fast
+   *    local server doesn't get redraws at input-device rate.
+   *
+   * Discrete events (mousedown, keydown, ...) bypass the timer for latency,
+   * but their blits still respect the fence via _present().
+   */
+  _scheduleFrame() {
+    const f = this._frame;
+    if (f.scheduled || f.inFlight || f.timer) return;
+    f.scheduled = true;
+    setImmediate(() => {
+      f.scheduled = false;
+      // gates may have been armed after this got scheduled (work queued
+      // from inside a running frame, e.g. a rAF loop re-registering) —
+      // the fence reply / timer expiry will reschedule then
+      if (f.inFlight || f.timer) return;
+      this._runFrame();
+    });
+  }
+
+  _runFrame() {
+    const f = this._frame;
+    if (!f.pending.size && !f.rafCbs.length && !f.needsRedraw && !this._dirty && !this._presentPending) return;
+    this._flushCoalesced();
+    if (f.needsRedraw) {
+      f.needsRedraw = false;
+      const ev = {
+        x: 0,
+        y: 0,
+        width: this.width,
+        height: this.height,
+        synthetic: true,
+        window: this,
+        target: this
+      };
+      this.emit('draw', ev);
+      this.emit('expose', ev);
+    }
+    if (f.rafCbs.length) {
+      const cbs = f.rafCbs;
+      f.rafCbs = [];
+      const now = performance.now();
+      for (const entry of cbs) entry.cb(now);
+    }
+    if (this._dirty || this._presentPending) this._presentNow();
+    this._armFence();
+    this._armTimer();
+  }
+
+  _enqueueCoalesced(name, ev) {
+    const pending = this._frame.pending;
+    const prev = pending.get(name);
+    if (!prev) {
+      ev.coalesced = [ev];
+      if (xevents.coalesce[name] === 'union') {
+        ev.rects = [{ x: ev.x, y: ev.y, width: ev.width, height: ev.height }];
+      }
+      pending.set(name, ev);
+    } else if (xevents.coalesce[name] === 'union') {
+      prev.coalesced.push(ev);
+      prev.rects.push({ x: ev.x, y: ev.y, width: ev.width, height: ev.height });
+      const x2 = Math.max(prev.x + prev.width, ev.x + ev.width);
+      const y2 = Math.max(prev.y + prev.height, ev.y + ev.height);
+      prev.x = Math.min(prev.x, ev.x);
+      prev.y = Math.min(prev.y, ev.y);
+      prev.width = x2 - prev.x;
+      prev.height = y2 - prev.y;
+    } else {
+      // keep-last: the newest event wins, older ones ride along
+      ev.coalesced = prev.coalesced;
+      ev.coalesced.push(ev);
+      pending.set(name, ev);
+    }
+    this._scheduleFrame();
+  }
+
+  _flushCoalesced() {
+    const pending = this._frame.pending;
+    if (!pending.size) return;
+    this._frame.pending = new Map();
+    // resize first: geometry-dependent handlers (re-layout) run before repaints
+    for (const name of ['resize', 'expose']) {
+      const ev = pending.get(name);
+      if (ev) {
+        pending.delete(name);
+        this.emit(name, ev);
+      }
+    }
+    for (const [name, ev] of pending) this.emit(name, ev);
+  }
+
+  _armFence() {
+    if (!this._frameSyncEnabled) return;
+    const f = this._frame;
+    if (f.inFlight) return;
+    const start = performance.now();
+    safeRelease(this.X, () => {
+      f.inFlight = true;
+      this.X.GetInputFocus(() => {
+        f.inFlight = false;
+        this.frameLatency = performance.now() - start;
+        if (this._presentPending) {
+          // a blit deferred while the fence was in flight: show it now
+          this._presentNow();
+          this._armFence();
+        }
+        if ((f.pending.size || f.rafCbs.length || f.needsRedraw) && !f.timer) this._scheduleFrame();
+      });
+    });
+  }
+
+  _armTimer() {
+    if (!(this.frameInterval > 0)) return;
+    const f = this._frame;
+    if (f.timer) return;
+    f.timer = setTimeout(() => {
+      f.timer = null;
+      if (f.pending.size || f.rafCbs.length || f.needsRedraw) this._scheduleFrame();
+    }, this.frameInterval);
+    if (typeof f.timer.unref === 'function') f.timer.unref();
+  }
+
+  _teardownFrame() {
+    const f = this._frame;
+    if (f.timer) {
+      clearTimeout(f.timer);
+      f.timer = null;
+    }
+    f.pending.clear();
+    f.rafCbs = [];
+    f.needsRedraw = false;
+    this._presentPending = false;
+  }
+
+  /**
+   * DOM-style requestAnimationFrame: `cb(now)` runs on this window's next
+   * paced frame — at most once per `frameInterval` ms and with at most one
+   * frame's requests unacknowledged by the server, so animation loops adapt
+   * to connection latency instead of flooding a slow link.
+   * Returns an id for cancelAnimationFrame().
+   */
+  requestAnimationFrame(cb) {
+    const f = this._frame;
+    const id = ++f.rafId;
+    f.rafCbs.push({ id, cb });
+    this._scheduleFrame();
+    return id;
+  }
+
+  cancelAnimationFrame(id) {
+    const f = this._frame;
+    const idx = f.rafCbs.findIndex((entry) => entry.id === id);
+    if (idx !== -1) f.rafCbs.splice(idx, 1);
+  }
+
   _present() {
+    if (!this._backing) return;
+    if (this._frame.inFlight) {
+      // the server hasn't confirmed the previous frame yet — defer the blit
+      this._presentPending = true;
+      return;
+    }
+    this._presentNow();
+    this._armFence();
+  }
+
+  _presentNow() {
+    this._presentPending = false;
     if (!this._backing) return;
     this._dirty = false;
     const w = Math.min(this.width, this._backing.width);
     const h = Math.min(this.height, this._backing.height);
-    this.X.CopyArea(this._backing.id, this.id, this._presentGc, 0, 0, 0, 0, w, h);
+    // a paced frame can fire after the connection started closing
+    safeRelease(this.X, () => {
+      this.X.CopyArea(this._backing.id, this.id, this._presentGc, 0, 0, 0, 0, w, h);
+    });
   }
 
   map() {
@@ -431,6 +623,7 @@ export default class Window extends Drawable {
 
   destroy() {
     this._forget();
+    this._teardownFrame();
     this.emit('_destroyed');
     if (this._backing) {
       this._backing.destroy();

--- a/test/events-map.test.js
+++ b/test/events-map.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { eventName, mask, maskCamelCase, toSnake } from '../lib/events_map.js';
+import { coalesce, eventName, mask, maskCamelCase, toSnake } from '../lib/events_map.js';
 
 test('every camelCase handler name maps to a snake event with a mask entry', () => {
   for (const [camel, snake] of Object.entries(toSnake)) {
@@ -16,6 +16,17 @@ test('every maskable event name is emitted by some X event type', () => {
     if (name === 'selection_clear') continue;
     assert.ok(emitted.has(name), `${name} never emitted`);
   }
+});
+
+test('coalescible events are known event names with known strategies', () => {
+  const emitted = new Set(eventName.filter(Boolean));
+  for (const [name, strategy] of Object.entries(coalesce)) {
+    assert.ok(emitted.has(name), `${name} never emitted`);
+    assert.ok(['last', 'union'].includes(strategy), `unknown strategy ${strategy}`);
+  }
+  assert.equal(coalesce.mousemove, 'last');
+  assert.equal(coalesce.resize, 'last');
+  assert.equal(coalesce.expose, 'union');
 });
 
 test('core event codes map to browser-like names', () => {

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -1,0 +1,244 @@
+// Event coalescing and frame pacing (lib/window.js) against a mock X
+// client — no server needed. Raw X events are fed straight into the
+// window's 'event' stream; fence replies (GetInputFocus) are released by
+// hand, which lets the tests model an arbitrarily slow connection.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick, setTimeout as sleep } from 'node:timers/promises';
+
+import Window from '../lib/window.js';
+
+// ids must be unique across all mock connections: Window.cache is static
+let nextId = 0xa000;
+
+function makeMockApp() {
+  const calls = { CopyArea: 0 };
+  const fences = []; // pending GetInputFocus callbacks, released by tests
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    atoms: { WM_NAME: 39, STRING: 31 },
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    ChangeProperty() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea() {
+      calls.CopyArea++;
+    },
+    GetInputFocus(cb) {
+      fences.push(cb);
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display }, fences, calls };
+}
+
+const motion = (x, y) => ({ type: 6, x, y });
+const configure = (width, height, x = 0, y = 0) => ({ type: 22, width, height, x, y });
+const expose = (x, y, width, height, count) => ({ type: 12, x, y, width, height, count });
+
+test('a burst of mousemove coalesces into one event carrying the trail', async () => {
+  const { app } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', motion(1, 1));
+  wnd.emit('event', motion(2, 2));
+  wnd.emit('event', motion(3, 3));
+  assert.equal(got.length, 0, 'nothing delivered synchronously');
+
+  await tick();
+  assert.equal(got.length, 1);
+  assert.equal(got[0].x, 3);
+  assert.equal(got[0].y, 3);
+  assert.equal(got[0].coalesced.length, 3);
+  assert.deepEqual(
+    got[0].coalesced.map((ev) => ev.x),
+    [1, 2, 3]
+  );
+  wnd.destroy();
+});
+
+test('expose events merge damage: bounding box + individual rects', async () => {
+  const { app } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('expose', (ev) => got.push(ev));
+
+  wnd.emit('event', expose(10, 10, 20, 20, 1));
+  wnd.emit('event', expose(50, 50, 10, 10, 0));
+
+  await tick();
+  assert.equal(got.length, 1);
+  assert.deepEqual(
+    [got[0].x, got[0].y, got[0].width, got[0].height],
+    [10, 10, 50, 50],
+    'bounding box of both rects'
+  );
+  assert.equal(got[0].rects.length, 2);
+  assert.deepEqual(got[0].rects[1], { x: 50, y: 50, width: 10, height: 10 });
+  wnd.destroy();
+});
+
+test('resize keeps the last state; geometry properties update immediately', async () => {
+  const { app } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  wnd.emit('event', configure(300, 200));
+  wnd.emit('event', configure(640, 480));
+  assert.equal(wnd.width, 640, 'wnd.width is current before the event is delivered');
+  assert.equal(wnd.height, 480);
+
+  await tick();
+  assert.equal(got.length, 1);
+  assert.equal(got[0].width, 640);
+  assert.equal(got[0].coalesced.length, 2);
+  wnd.destroy();
+});
+
+test('a discrete event flushes buffered state events first, preserving order', async () => {
+  const { app } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const order = [];
+  wnd.on('mousemove', (ev) => order.push(`move:${ev.x}`));
+  wnd.on('mousedown', () => order.push('down'));
+
+  wnd.emit('event', motion(1, 1));
+  wnd.emit('event', motion(2, 2));
+  wnd.emit('event', { type: 4, x: 2, y: 2, keycode: 1 });
+  assert.deepEqual(order, ['move:2', 'down'], 'delivered synchronously, moves first');
+
+  await tick();
+  assert.deepEqual(order, ['move:2', 'down'], 'no duplicate delivery');
+  wnd.destroy();
+});
+
+test('coalesceEvents: false restores immediate per-event delivery', async () => {
+  const { app } = makeMockApp();
+  const wnd = new Window(app, { coalesceEvents: false });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev.x));
+
+  wnd.emit('event', motion(1, 1));
+  wnd.emit('event', motion(2, 2));
+  wnd.emit('event', motion(3, 3));
+  assert.deepEqual(got, [1, 2, 3]);
+  assert.equal(got[3], undefined);
+  wnd.destroy();
+});
+
+test('requestAnimationFrame frames wait for the server fence', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  let frames = 0;
+  const loop = () => {
+    frames++;
+    wnd.requestAnimationFrame(loop);
+  };
+  wnd.requestAnimationFrame(loop);
+
+  await tick();
+  assert.equal(frames, 1, 'first frame runs right away');
+  assert.equal(fences.length, 1, 'fence sent after the frame');
+
+  await tick();
+  await tick();
+  assert.equal(frames, 1, 'next frame gated on the unanswered fence');
+
+  fences.shift()(null); // server ack
+  await tick();
+  await tick();
+  assert.equal(frames, 2, 'frame runs once the server caught up');
+  assert.ok(typeof wnd.frameLatency === 'number' && wnd.frameLatency >= 0);
+
+  wnd.cancelAnimationFrame(wnd.requestAnimationFrame(() => frames++));
+  fences.shift()(null);
+  await tick();
+  await tick();
+  assert.equal(frames, 3, 'only the still-registered callback ran');
+  wnd.destroy();
+});
+
+test('presents defer while a fence is in flight, blit on ack', async () => {
+  const { app, fences, calls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  wnd._enableBackingStore();
+
+  wnd._markDirty();
+  await tick();
+  assert.equal(calls.CopyArea, 1, 'first present goes out immediately');
+  assert.equal(fences.length, 1);
+
+  wnd._markDirty();
+  await tick();
+  await tick();
+  assert.equal(calls.CopyArea, 1, 'second blit held back by the fence');
+
+  fences.shift()(null);
+  assert.equal(calls.CopyArea, 2, 'deferred blit sent on the ack');
+  wnd.destroy();
+});
+
+test('frameInterval paces flushes when the fence is disabled', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { frameSync: false, frameInterval: 25 });
+  let count = 0;
+  wnd.on('mousemove', () => count++);
+
+  wnd.emit('event', motion(1, 1));
+  await tick();
+  assert.equal(count, 1, 'first flush is immediate');
+
+  wnd.emit('event', motion(2, 2));
+  wnd.emit('event', motion(3, 3));
+  await tick();
+  assert.equal(count, 1, 'second flush waits for the frame interval');
+
+  await sleep(60);
+  assert.equal(count, 2);
+  assert.equal(fences.length, 0, 'frameSync: false sends no fence requests');
+  wnd.destroy();
+});
+
+test('interactive resize drives one paced draw per frame', async () => {
+  const { app, fences, calls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0, width: 100, height: 100 });
+  wnd._enableBackingStore();
+  let draws = 0;
+  wnd.on('draw', () => {
+    draws++;
+    wnd._markDirty(); // as a rendering context would
+  });
+
+  wnd.emit('event', configure(120, 120));
+  wnd.emit('event', configure(140, 140));
+  await tick();
+  await tick();
+  assert.equal(draws, 1, 'one redraw for the burst');
+  assert.equal(calls.CopyArea, 1, 'one blit for the burst');
+
+  // more resizes stream in while the server is behind
+  wnd.emit('event', configure(160, 160));
+  wnd.emit('event', configure(180, 180));
+  await tick();
+  await tick();
+  assert.equal(draws, 1, 'held back by the fence');
+
+  fences.shift()(null);
+  await tick();
+  await tick();
+  assert.equal(draws, 2, 'one catch-up redraw at the final size');
+  assert.equal(wnd.width, 180);
+  wnd.destroy();
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -50,6 +50,27 @@ test('creates, maps and destroys a window', async (t) => {
   wnd.destroy();
 });
 
+test('requestAnimationFrame paces frames against the server', async (t) => {
+  if (skip) return t.skip(skip);
+  const wnd = app.createWindow({ width: 60, height: 40, frameInterval: 0 });
+  const stamps = [];
+  await withTimeout(
+    new Promise((resolve) => {
+      const loop = (now) => {
+        stamps.push(now);
+        if (stamps.length >= 3) return resolve();
+        wnd.requestAnimationFrame(loop);
+      };
+      wnd.requestAnimationFrame(loop);
+    }),
+    5000,
+    'three animation frames'
+  );
+  assert.ok(stamps[0] <= stamps[1] && stamps[1] <= stamps[2], 'monotonic frame timestamps');
+  assert.ok(typeof wnd.frameLatency === 'number' && wnd.frameLatency >= 0, 'fence round-trip measured');
+  wnd.destroy();
+});
+
 test('2d context: fillRect pixels round-trip through the server', async (t) => {
   if (skip) return t.skip(skip);
   const pixmap = app.createPixmap({ width: 64, height: 64, depth: 24 });
@@ -246,11 +267,13 @@ test('backing store: resize invalidates and requests one coalesced redraw', asyn
     draws.push([ev.width, ev.height]);
     ctx.fillRect(0, 0, wnd.width, wnd.height);
   });
-  // a storm of ConfigureNotify events in one tick → a single redraw
+  // a storm of ConfigureNotify events in one tick → a single redraw on the
+  // next paced frame (which waits out the fence of the initial present)
+  const redrawn = withTimeout(once(wnd, 'expose'), 5000, 'coalesced redraw');
   wnd.emit('event', { type: 22, x: 0, y: 0, width: 100, height: 80 });
   wnd.emit('event', { type: 22, x: 0, y: 0, width: 120, height: 90 });
   wnd.emit('event', { type: 22, x: 0, y: 0, width: 140, height: 100 });
-  await new Promise((resolve) => setImmediate(resolve));
+  await redrawn;
   assert.deepEqual(draws, [[140, 100]], 'one redraw at the final size');
   assert.ok(wnd._backing.width >= 140 && wnd._backing.height >= 100, 'backing grew');
 


### PR DESCRIPTION
## Problem

Noisy-by-nature events (interactive `resize`, `mousemove`, `expose` damage) triggered a redraw per event. The client can queue drawing faster than the connection + server drain it, so windows played back a *trail of stale intermediate states* catching up to reality — most visible on ssh-forwarded / networked displays.

## Design

Two orthogonal mechanisms, both default-on, both with escape hatches:

**Event coalescing** (`lib/events_map.js` `coalesce` table): while a frame is pending, noisy events merge instead of queueing.
- `resize`, `mousemove` — newest event wins; every merged raw event is kept in `ev.coalesced` (same semantics as the DOM's `getCoalescedEvents()`), so e.g. freehand drawing still sees the full pointer trail. `wnd.width/height/x/y` track the raw stream immediately.
- `expose` — compound damage: `ev.x/y/width/height` is the bounding box, `ev.rects` lists each merged rect.
- Discrete events (`mousedown`, `keydown`, …) are never coalesced and flush buffered state events first, preserving observed order.

**Frame pacing** (`Window` frame clock): frames are gated by
- a **fence** — one cheap request-with-reply (`GetInputFocus`) after each frame; X processes requests in order, so the reply proves the server consumed everything drawn. At most one fence in flight → on a slow link rendering degrades to one frame per round-trip and no backlog can form. Measured RTT is exposed as `wnd.frameLatency`.
- a **timer** — at most one paced frame per `frameInterval` ms (default 16), so local servers aren't redrawn at input-device rate.

**`requestAnimationFrame` / `cancelAnimationFrame`** — DOM names reused since semantics match exactly: callback runs on the next paced frame. An animation loop renders ~60fps locally and self-throttles to RTT pace remotely, unchanged.

**Low level stays available**: `frameInterval: 0` (fence-only), `frameSync: false` (timer-only), `coalesceEvents: false` (per-event delivery), and the raw `wnd.on('event')` stream.

## Measured

Against XQuartz: 56 fps at default interval; with `frameInterval: 0` the fence alone paced frames and adapted live as the server saturated (latency 1.4 ms → 14 ms).

## Tests

- `test/frame-pacing.test.js` — scheduler against a mock X client with hand-released fence replies: coalescing/merging, ordering vs discrete events, rAF fence gating, deferred blits, timer pacing, opt-outs. Deterministic, no server needed.
- smoke suite — real-server rAF pacing test; resize-storm test updated for fence-aware timing.
- docs (`docs/window.md`, README) updated; new `examples/animation.js` (bouncing ball, live fps/latency in the title).

Existing examples get the new behavior with zero code changes.