### PR TITLE
SVG in HtmlView (inline + img sources) and mermaid diagrams in MarkdownView

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ lib/image.js               Image: PNG/JPEG decode (pngjs/jpeg-js), server upload
 lib/widgets/css.js         CSS for HtmlView: parse (postcss), cascade, computed styles
 lib/widgets/htmlview.js    HtmlView widget: htmlparser2 DOM + yoga-layout boxes
 lib/widgets/markdown.js    markdown parsing (adapter over marked)
+lib/widgets/mermaid.js     mermaid fences: mermaid-package parser (headless,
+                           lazy) + native dagre/sequence layout and drawing
 lib/widgets/markdownview.js  MarkdownView widget (highlighted + math fences)
 lib/widgets/highlight.js   fence syntax highlighting (adapter over highlight.js)
 lib/widgets/svgview.js     SvgView widget: static SVG via Path2D + 2d context

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ text costs about a byte per glyph on the wire. Font names resolve through
 fontconfig (`fc-match`). Very large and continuously animated sizes render
 as server-side trapezoids instead of cached bitmaps. A `TextLayout` engine
 wraps styled text to a target width, a `MarkdownView` widget renders
-markdown (with syntax-highlighted code fences) on top of it, and a
-KaTeX-backed `TexView` renders TeX math — see [docs/text.md](docs/text.md)
-and [docs/tex.md](docs/tex.md).
+markdown (with syntax-highlighted code fences, mermaid flowchart/sequence
+diagrams, and KaTeX math via `TexView`) on top of it — see
+[docs/text.md](docs/text.md), [docs/mermaid.md](docs/mermaid.md) and
+[docs/tex.md](docs/tex.md).
 
 PNG/JPEG images decode client-side (`loadImage`) and composite server-side
 via `ctx.drawImage` ([docs/images.md](docs/images.md)). An `HtmlView`

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@ matching file here (see AGENTS.md).
   wire-efficiency design, the vector (trapezoid) path for large/animated sizes
 - [TeX / math](tex.md) — KaTeX-based formula rendering: `layoutTex`, `TexView`,
   markdown math fences
+- [Mermaid diagrams](mermaid.md) — ```` ```mermaid ```` fences in MarkdownView:
+  flowcharts (dagre) and sequence diagrams, parsed by mermaid's own grammar,
+  drawn natively
 - [HTML widget](html.md) — `HtmlView`: static HTML + CSS subset, yoga-layout
   flexbox/block layout, links, images, the resource-loading safety model
 - [SVG widget](svg.md) — `SvgView`: static SVG rendering through the 2d

--- a/docs/html.md
+++ b/docs/html.md
@@ -33,7 +33,8 @@ native modules); inline runs are shaped and wrapped by the ntk text pipeline
 uses [htmlparser2](https://www.npmjs.com/package/htmlparser2), selector
 matching [css-select](https://www.npmjs.com/package/css-select), stylesheet
 parsing [postcss](https://www.npmjs.com/package/postcss). PNG/JPEG images
-render through the [image pipeline](images.md).
+render through the [image pipeline](images.md); SVG — inline or as an
+`<img>` source — through the [SVG widget](svg.md).
 
 ## The safety / responsibility model
 
@@ -97,10 +98,17 @@ plus a `fonts` manager, then drive `layout()`/`draw()` yourself.
   lower/upper-alpha` markers
 - tables: `table thead tbody tfoot tr td th` — approximated as flex rows
   with equal-width cells (no content-based column sizing)
-- images: `img` with `src` (PNG/JPEG), `width`/`height` attributes, `alt`
-  placeholder text while loading / on failure
+- images: `img` with `src` (PNG/JPEG/SVG), `width`/`height` attributes,
+  `alt` placeholder text while loading / on failure. SVG sources are
+  detected by content sniffing (any of: file bytes, a `loadResource`
+  buffer, `data:image/svg+xml` URIs — base64 or percent-encoded) and
+  rendered as vectors via [SvgView](svg.md)
+- inline `<svg>`: a replaced element, laid out like an image — intrinsic
+  size from `width`/`height`/`viewBox` (ratio-preserving shrink to the
+  container), rendered by [SvgView](svg.md) with its supported subset;
+  adopted synchronously, so sizing is right on the first layout pass
 - dropped: `head style script title meta link template noscript iframe
-  object embed audio video canvas svg input select textarea button`
+  object embed audio video canvas input select textarea button`
 
 ## Supported CSS
 
@@ -147,4 +155,6 @@ Image loading is asynchronous. Boxes with `width`/`height` (attributes or
 CSS) reserve space immediately; unsized images occupy 0×0 until decoded,
 then the widget invalidates layout and re-renders automatically (window
 mode). Decoded images upload to the X server once and are freed on
-`setHtml`/`destroy`.
+`setHtml`/`destroy`. Inline `<svg>` needs no loading at all; `<img>` SVG
+sources go through the same asynchronous resolution as rasters but hold no
+server-side resources (they redraw as vectors).

--- a/docs/mermaid.md
+++ b/docs/mermaid.md
@@ -1,0 +1,66 @@
+# Mermaid diagrams
+
+MarkdownView renders ```` ```mermaid ```` fences as diagrams. Parsing uses
+the [mermaid](https://www.npmjs.com/package/mermaid) package's own grammar
+— imported lazily and run headless (mermaid's *renderer* is the only part
+that needs a browser, so ntk draws natively instead): flowcharts are laid
+out by [@dagrejs/dagre](https://www.npmjs.com/package/@dagrejs/dagre) and
+sequence diagrams by a classic column/row pass, with text measured by the
+ntk font pipeline and everything composited server-side through the
+[2d context](context-2d.md).
+
+````markdown
+```mermaid
+flowchart LR
+  A[Request] --> B{Cached?}
+  B -->|yes| C([Serve from cache])
+  B -->|no| D[(Database)]
+```
+````
+
+See `examples/mermaid.js` for a full tour.
+
+## Supported diagrams
+
+- **flowchart / graph** — all directions (`TB`/`TD`/`BT`/`LR`/`RL`); node
+  shapes: rect, round, stadium, subroutine, cylinder, circle, diamond,
+  hexagon (other shapes draw as rects); solid/dotted/thick edges with
+  labels, chains (`A --> B --> C`) and `&` fans
+- **sequenceDiagram** — `participant`/`actor` with `as` aliases; arrows
+  `->`, `-->`, `->>`, `-->>`, `-x`, `--x`, `-)`, `--)`; `Note left
+  of`/`right of`/`over A,B`; `loop`/`opt`/`alt`/`else`/`par`/`and`/
+  `critical`/`break` frames; `autonumber`; self-messages
+
+Any other diagram type (gantt, pie, class, state, …) parses but has no
+native renderer: the fence falls back to a plain code block — the same
+contract as invalid ```` ```math ```` fences.
+
+## Behavior
+
+- **Async**: the mermaid grammar loads on the first fence (hundreds of ms);
+  fences render as code blocks until parsing resolves, then the view
+  invalidates and re-renders automatically (window mode). Standalone users:
+  lay out again after a tick, as with HtmlView images.
+- **Fit**: diagrams wider than the content width are laid out again at a
+  proportionally smaller font (floor 8px), then centered.
+- **Theme**: node/actor fills follow mermaid's default palette; label
+  knock-out backgrounds use the markdown theme's `background`, text uses
+  the theme `color`.
+
+## Direct API
+
+```js
+import { parseMermaid, layoutMermaid } from 'ntk/lib/widgets/mermaid.js';
+
+const model = await parseMermaid('flowchart LR\n A --> B'); // throws if unsupported
+const box = layoutMermaid(model, { fonts: app.fonts, size: 13, maxWidth: 600 });
+box.draw(ctx, x, y); // box.width / box.height / box.type / box.warnings
+```
+
+## Headless mermaid, for the curious
+
+The mermaid package only touches the DOM in two places that matter here:
+DOMPurify label sanitization (shimmed to the identity — labels are drawn
+as text, never injected into any DOM) and the SVG renderer (unused; ntk
+draws diagrams itself). Everything else — the grammar, the diagram
+databases — runs fine in Node.

--- a/docs/svg.md
+++ b/docs/svg.md
@@ -27,6 +27,11 @@ view.draw(ctx, x, y, width, height);
 See `examples/svg-viewer.js` for a small viewer
 (`node svg-viewer.js file.svg`).
 
+[HtmlView](html.md) uses this widget for SVG inside HTML documents: inline
+`<svg>` elements and `<img>` sources that sniff as SVG (files, buffers,
+`data:image/svg+xml` URIs) are laid out like images and drawn through
+`SvgView`.
+
 ## API
 
 - `new SvgView(window[, opts])` — `window` may be `null` for standalone use.
@@ -36,6 +41,9 @@ See `examples/svg-viewer.js` for a small viewer
     preserving aspect ratio) or `'fill'` (stretch)
 - `view.setSvg(svgText)` — parse and adopt a document (a string containing
   an `<svg>` element). Re-renders in window mode
+- `view.setSvgDom(element)` — adopt an already-parsed htmlparser2 `<svg>`
+  element. Used by [HtmlView](html.md) for inline SVG; tolerates HTML-mode
+  parses (lowercased tag/attribute names like `viewbox`, `lineargradient`)
 - `view.draw(ctx, x, y[, w, h])` — draw into any 2d context; `w`/`h` default
   to the natural size. The `viewBox` (when present) is scaled to the target
   box

--- a/examples/html.js
+++ b/examples/html.js
@@ -48,11 +48,29 @@ const pages = {
         </div>
       </div>
 
-      <img src="${gradientPng(120, 60)}" alt="generated gradient">
+      <div style="display: flex; gap: 16px; align-items: center; margin: 8px 0">
+        <img src="${gradientPng(120, 60)}" alt="generated gradient">
+        <!-- inline svg renders through SvgView, sized like an image -->
+        <svg width="60" height="60" viewBox="0 0 24 24">
+          <defs>
+            <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0" stop-color="#ffba08"/>
+              <stop offset="1" stop-color="#d00000"/>
+            </linearGradient>
+          </defs>
+          <circle cx="12" cy="12" r="10" fill="none" stroke="url(#ring)" stroke-width="3"/>
+          <path d="M8 12 l3 3 l5 -6" fill="none" stroke="#2d6a4f" stroke-width="2.5"/>
+        </svg>
+        <!-- and so do <img> elements with an svg data: URI source -->
+        <img width="60" height="60" alt="svg heart" src="data:image/svg+xml,${encodeURIComponent(
+          '<svg viewBox="0 0 32 32"><path d="M16 28 C4 19 2 12 6 8 C10 4 15 7 16 11 C17 7 22 4 26 8 C30 12 28 19 16 28 Z" fill="#e5383b"/></svg>'
+        )}">
+      </div>
 
       <h2>Pages</h2>
       <ul>
         <li><a href="page:styles">Styling showcase</a> — cascade, selectors, colors</li>
+        <li><a href="page:svg">SVG</a> — inline markup and img sources</li>
         <li><a href="page:pre">Preformatted text</a> — white-space handling</li>
         <li><a href="https://github.com/sidorares/ntk">ntk on GitHub</a> (opens in your browser)</li>
       </ul>
@@ -90,6 +108,42 @@ const pages = {
         <li>alpha markers</li>
         <li>are supported too</li>
       </ol>
+    </body>`,
+
+  svg: `
+    <body>
+      <p><a href="page:home">← back</a></p>
+      <h1>SVG in HtmlView</h1>
+      <p>Inline <code>&lt;svg&gt;</code> elements are replaced elements —
+        laid out like images (intrinsic size from
+        <code>width</code>/<code>height</code>/<code>viewBox</code>,
+        ratio-preserving shrink) and rendered by <code>SvgView</code>
+        through the same server-side 2d pipeline.</p>
+
+      <div style="display: flex; gap: 12px; align-items: flex-end">
+        <svg width="90" height="90" viewBox="0 0 24 24">
+          <rect x="2" y="2" width="20" height="20" rx="4" fill="#eef3fb" stroke="#ccd9ee"/>
+          <path d="M6 16 L10 9 L13 13 L16 7 L18 16 Z" fill="#0077b6"/>
+        </svg>
+        <svg width="70" height="70" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" fill="#ffe9a8" stroke="#c8a028"/>
+          <circle cx="9" cy="10" r="1.4" fill="#333"/>
+          <circle cx="15" cy="10" r="1.4" fill="#333"/>
+          <path d="M8 14 Q12 18 16 14" fill="none" stroke="#333" stroke-width="1.5"/>
+        </svg>
+        <svg width="50" height="90" viewBox="0 0 10 18">
+          <rect x="4" y="6" width="2" height="12" fill="#7f4f24"/>
+          <path d="M5 0 L9 8 H1 Z" fill="#2d6a4f"/>
+        </svg>
+      </div>
+
+      <p>An <code>&lt;img&gt;</code> whose source is SVG (file path,
+        <code>data:image/svg+xml</code>, or a <code>loadResource</code>
+        buffer) is sniffed and routed the same way — vector, so it stays
+        sharp at any size:</p>
+      <img width="260" alt="scene" src="data:image/svg+xml,${encodeURIComponent(
+        '<svg viewBox="0 0 60 30"><rect width="60" height="30" fill="#8ecae6"/><circle cx="50" cy="7" r="4" fill="#ffdd00"/><path d="M0 22 Q15 15 30 21 T60 20 V30 H0 Z" fill="#74c69d"/><path d="M12 24 L17 14 L22 24 Z" fill="#2d6a4f"/></svg>'
+      )}">
     </body>`,
 
   pre: `

--- a/examples/mermaid.js
+++ b/examples/mermaid.js
@@ -1,0 +1,73 @@
+// Mermaid diagrams inside markdown: ```mermaid fences are parsed by the
+// mermaid package's own grammar (headless) and rendered natively — dagre
+// layout for flowcharts, classic column/row layout for sequence diagrams,
+// all drawn server-side through the 2d context. Unsupported diagram types
+// (here: the gantt at the bottom) fall back to a plain code block.
+import { createClient, MarkdownView } from '../lib/index.js';
+
+const doc = `# Mermaid
+
+## Flowchart — shapes, edge styles, labels
+
+\`\`\`mermaid
+flowchart LR
+  A[Request] --> B{Cached?}
+  B -->|yes| C([Serve from cache])
+  B -->|no| D[(Database)]
+  D --> E[[Render]]
+  E -.-> F((Done))
+  C ==> F
+\`\`\`
+
+## Flowchart — top-down
+
+\`\`\`mermaid
+flowchart TD
+  start([Start]) --> input[Read config]
+  input --> valid{Valid?}
+  valid -->|yes| run{{Run job}}
+  valid -->|no| err[Report error]
+  err --> input
+  run --> done((OK))
+\`\`\`
+
+## Sequence diagram
+
+\`\`\`mermaid
+sequenceDiagram
+  autonumber
+  participant C as Client
+  participant S as Server
+  participant D as DB
+  C->>S: GET /report
+  S->>D: query
+  D-->>S: rows
+  alt cache hit
+    S-->>C: 200 (cached)
+  else miss
+    S-->>C: 200 (fresh)
+  end
+  loop every 30s
+    C->>S: poll status
+    S-xC: timeout
+  end
+  Note over C,S: connection closed
+  S->>S: cleanup
+\`\`\`
+
+## Unsupported types fall back to code
+
+\`\`\`mermaid
+gantt
+  title A Gantt chart
+  section One
+  Task :a1, 2024-01-01, 30d
+\`\`\`
+`;
+
+const app = await createClient();
+const wnd = app.createWindow({ width: 700, height: 900, title: 'ntk mermaid' });
+const view = new MarkdownView(wnd, {});
+view.setMarkdown(doc);
+wnd.map();
+console.log('diagrams render once the mermaid grammar finishes loading; wheel scrolls');

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -490,9 +490,23 @@ class RenderingContext2d {
 
     const tris = [];
     for (const poly of polys) {
+      // drop consecutive (near-)duplicate points — zero-length segments make
+      // extrude-polyline emit NaN joins that turn into spikes at the origin
       const pts = [];
-      for (let i = 0; i < poly.pts.length; i += 2) pts.push([poly.pts[i], poly.pts[i + 1]]);
-      if (poly.closed) pts.push([poly.pts[0], poly.pts[1]]);
+      let lx = Infinity;
+      let ly = Infinity;
+      for (let i = 0; i < poly.pts.length; i += 2) {
+        const x = poly.pts[i];
+        const y = poly.pts[i + 1];
+        if (!(Math.abs(x - lx) > 1e-6 || Math.abs(y - ly) > 1e-6)) continue;
+        pts.push([x, y]);
+        lx = x;
+        ly = y;
+      }
+      if (pts.length >= 2 && poly.closed) {
+        const [fx, fy] = pts[0];
+        if (Math.abs(fx - lx) > 1e-6 || Math.abs(fy - ly) > 1e-6) pts.push([fx, fy]);
+      }
       if (pts.length < 2) continue;
       const mesh = stroke.build(pts);
       for (const tri of mesh.cells) {

--- a/lib/widgets/htmlview.js
+++ b/lib/widgets/htmlview.js
@@ -10,6 +10,7 @@ import Yoga from 'yoga-layout';
 import { decodeImage, Image } from '../image.js';
 import { TextLayout } from '../text/layout.js';
 import { computeStyles, cssColor } from './css.js';
+import SvgView from './svgview.js';
 
 const DEFAULT_THEME = {
   family: 'sans-serif',
@@ -47,7 +48,7 @@ const WRAP = {
 };
 const EDGES = [Yoga.EDGE_TOP, Yoga.EDGE_RIGHT, Yoga.EDGE_BOTTOM, Yoga.EDGE_LEFT];
 
-const VOID_SKIP = new Set(['script', 'style', 'head', 'title', 'meta', 'link', 'template', 'noscript', 'iframe', 'object', 'embed', 'audio', 'video', 'canvas', 'svg', 'input', 'select', 'textarea', 'button']);
+const VOID_SKIP = new Set(['script', 'style', 'head', 'title', 'meta', 'link', 'template', 'noscript', 'iframe', 'object', 'embed', 'audio', 'video', 'canvas', 'input', 'select', 'textarea', 'button']);
 
 /**
  * A widget that renders a static subset of HTML + CSS into a window (or any
@@ -240,7 +241,9 @@ export default class HtmlView {
         run.push({ text: '\n', style: st, href: elHref, pre: true });
         return;
       }
-      if (el.name === 'img') {
+      if (el.name === 'img' || el.name === 'svg') {
+        // replaced elements: inline <svg> renders through SvgView, like an
+        // image with an intrinsic size (its children never join text flow)
         flushRun();
         out.push({ kind: 'image', element: el, style: st, href: elHref });
         return;
@@ -386,39 +389,68 @@ export default class HtmlView {
   _collectImages(box) {
     if (box.kind === 'image') {
       const el = box.element;
-      const src = el.attribs?.src;
-      if (src && !this._images.has(el)) {
-        const entry = { image: null, failed: false };
-        this._images.set(el, entry);
-        this._fetchImage(src, el).then(
-          (img) => {
-            entry.image = img;
-            if (!img) entry.failed = true;
-            this._layoutWidth = -1;
-            if (this.window && this.window._mapped) this.render();
-          },
-          () => {
+      if (el.name === 'svg') {
+        // inline svg: adopt the already-parsed element synchronously, so
+        // its intrinsic size is known on the first layout pass
+        if (!this._images.has(el)) {
+          const entry = { image: null, svg: null, failed: false };
+          this._images.set(el, entry);
+          try {
+            entry.svg = new SvgView(null).setSvgDom(el);
+          } catch {
             entry.failed = true;
-            this._layoutWidth = -1;
-            if (this.window && this.window._mapped) this.render();
           }
-        );
+        }
+      } else {
+        const src = el.attribs?.src;
+        if (src && !this._images.has(el)) {
+          const entry = { image: null, svg: null, failed: false };
+          this._images.set(el, entry);
+          this._fetchImage(src, el).then(
+            (res) => {
+              if (res instanceof SvgView) entry.svg = res;
+              else entry.image = res;
+              if (!res) entry.failed = true;
+              this._layoutWidth = -1;
+              if (this.window && this.window._mapped) this.render();
+            },
+            () => {
+              entry.failed = true;
+              this._layoutWidth = -1;
+              if (this.window && this.window._mapped) this.render();
+            }
+          );
+        }
       }
     }
     for (const child of box.children) this._collectImages(child);
   }
 
+  // decoded bytes -> Image (PNG/JPEG) or SvgView (sniffed SVG markup)
+  _decodeResource(buf) {
+    const head = buf.subarray(0, 1024).toString('utf8');
+    if (head.trimStart().startsWith('<') && /<svg[\s>]/i.test(head)) {
+      return new SvgView(null).setSvg(buf.toString('utf8'));
+    }
+    return decodeImage(buf);
+  }
+
   /** resolve + decode an image source according to the resource policy */
   async _fetchImage(src, element) {
     if (src.startsWith('data:')) {
+      const svg = /^data:image\/svg\+xml(?:;charset=[\w-]+)?(;base64)?,(.*)$/s.exec(src);
+      if (svg) {
+        const text = svg[1] ? Buffer.from(svg[2], 'base64').toString('utf8') : decodeURIComponent(svg[2]);
+        return new SvgView(null).setSvg(text);
+      }
       const m = /^data:image\/[\w+.-]+;base64,(.*)$/s.exec(src);
       if (!m) return null;
       return decodeImage(Buffer.from(m[1], 'base64'));
     }
     if (typeof this._loadResource === 'function') {
       const res = await this._loadResource(src, { element });
-      if (res instanceof Image) return res;
-      if (res) return decodeImage(res);
+      if (res instanceof Image || res instanceof SvgView) return res;
+      if (res) return this._decodeResource(res);
       return null;
     }
     if (this._loadResource === null || this._loadResource === false) return null;
@@ -433,7 +465,7 @@ export default class HtmlView {
     }
     const url = new URL(src, base);
     if (url.protocol !== 'file:') return null;
-    return decodeImage(await readFile(url));
+    return this._decodeResource(await readFile(url));
   }
 
   // -------------------------------------------------------------------------
@@ -472,8 +504,8 @@ export default class HtmlView {
       const img = entry?.image;
       const cssW = st.width;
       const cssH = st.height;
-      const natW = img?.width ?? (entry?.failed ? 80 : 0);
-      const natH = img?.height ?? (entry?.failed ? 40 : 0);
+      const natW = img?.width ?? entry?.svg?.naturalWidth ?? (entry?.failed ? 80 : 0);
+      const natH = img?.height ?? entry?.svg?.naturalHeight ?? (entry?.failed ? 40 : 0);
       if (cssW === 'auto' && cssH === 'auto') {
         // natural size, shrunk (ratio-preserving) to the available width; a
         // measure function is used because yoga's min/max clamping does not
@@ -716,10 +748,14 @@ export default class HtmlView {
   _drawImage(ctx, box, x, y) {
     const entry = this._images.get(box.element);
     const img = entry?.image;
+    const w = box.contentW ?? box.w;
+    const h = box.contentH ?? box.h;
     if (img) {
-      const w = box.contentW ?? box.w;
-      const h = box.contentH ?? box.h;
       if (w > 0 && h > 0) ctx.drawImage(img, Math.round(box.contentX ?? x), Math.round(box.contentY ?? y), Math.round(w), Math.round(h));
+      return;
+    }
+    if (entry?.svg) {
+      if (w > 0 && h > 0) entry.svg.draw(ctx, Math.round(box.contentX ?? x), Math.round(box.contentY ?? y), Math.round(w), Math.round(h));
       return;
     }
     // placeholder: light box with alt text

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -1,6 +1,7 @@
 import { TextLayout } from '../text/layout.js';
 import { tokenize } from './highlight.js';
 import { parseMarkdown } from './markdown.js';
+import { layoutMermaid, parseMermaid } from './mermaid.js';
 import { layoutTex } from './tex.js';
 
 const MATH_LANGS = new Set(['math', 'tex', 'latex', 'katex']);
@@ -97,9 +98,33 @@ export default class MarkdownView {
 
   setMarkdown(src) {
     this._blocks = parseMarkdown(src);
+    this._mermaid = new Map();
     this._layoutWidth = -1;
     if (this.window && this.window._mapped) this.render();
     return this;
+  }
+
+  // ```mermaid fences parse asynchronously (the mermaid grammar loads
+  // lazily); the fence shows as a code block until the model arrives, then
+  // layout is invalidated — same pattern as image loading in HtmlView
+  _mermaidEntry(text) {
+    if (!this._mermaid) this._mermaid = new Map();
+    let entry = this._mermaid.get(text);
+    if (!entry) {
+      entry = { model: null, failed: false };
+      this._mermaid.set(text, entry);
+      parseMermaid(text).then(
+        (model) => {
+          entry.model = model;
+          this._layoutWidth = -1;
+          if (this.window && this.window._mapped) this.render();
+        },
+        () => {
+          entry.failed = true; // unsupported/invalid: stays a code block
+        }
+      );
+    }
+    return entry;
   }
 
   /** lay content out for a container width; returns total content height */
@@ -170,6 +195,31 @@ export default class MarkdownView {
         }
 
         case 'code': {
+          // ```mermaid fences render as diagrams (flowchart / sequence);
+          // unsupported types or parse errors fall back to the code block
+          if ((block.lang || '').toLowerCase() === 'mermaid') {
+            let box = null;
+            const entry = this._mermaidEntry(block.text);
+            if (entry.model) {
+              try {
+                box = layoutMermaid(entry.model, {
+                  fonts,
+                  size: Math.round(t.size * 0.82),
+                  family: t.family,
+                  maxWidth: width,
+                  theme: { labelBg: t.background, text: t.color }
+                });
+              } catch {
+                // fall through to the plain code block
+              }
+            }
+            if (box) {
+              const bx = x + Math.max(0, (width - box.width) / 2);
+              this._items.push({ kind: 'tex', x: bx, y, box });
+              y += box.height;
+              break;
+            }
+          }
           // ```math / ```latex fences render as display-mode formulas
           if (MATH_LANGS.has((block.lang || '').toLowerCase())) {
             let box = null;

--- a/lib/widgets/mermaid.js
+++ b/lib/widgets/mermaid.js
@@ -1,0 +1,720 @@
+// Mermaid diagram rendering for the markdown widget (```mermaid fences).
+//
+// Parsing uses the mermaid package's own grammar (lazily imported, run
+// headless — see loadMermaid()); mermaid's *renderer* is the only part
+// that needs a browser, so the two most-used diagram types are drawn
+// natively instead: **flowcharts** laid out by @dagrejs/dagre and
+// **sequence diagrams** with a classic column/row layout. Text is measured
+// with the ntk font pipeline and everything draws through the 2d context —
+// no SVG round-trip, no browser. Diagram types without a native renderer
+// here throw from parseMermaid(), and MarkdownView falls back to a plain
+// code block (same contract as invalid math).
+//
+//   const model = await parseMermaid('flowchart LR\n A[Start] --> B{OK?}');
+//   const box = layoutMermaid(model, { fonts });
+//   box.draw(ctx, x, y);   // box.width / box.height
+import dagre from '@dagrejs/dagre';
+
+const DEFAULT_THEME = {
+  nodeFill: '#ececff',
+  nodeBorder: '#9370db',
+  line: '#555555',
+  text: '#333333',
+  labelBg: '#ffffff', // behind edge labels; set to the page background
+  actorFill: '#ececff',
+  actorBorder: '#9370db',
+  noteFill: '#fff5ad',
+  noteBorder: '#b8b855',
+  frameBorder: '#999999',
+  frameLabel: '#666666'
+};
+
+// ---------------------------------------------------------------------------
+// parsing: the mermaid package's own grammar, run headless
+//
+// mermaid's renderer needs a browser (getBBox and friends), but its parsers
+// and diagram DBs work in Node once DOMPurify — which mermaid only uses to
+// sanitize label HTML for browser injection — is shimmed to the identity.
+// Labels here never reach a DOM: they are drawn as plain text.
+
+let mermaidLoad = null;
+
+function loadMermaid() {
+  if (!mermaidLoad) {
+    mermaidLoad = (async () => {
+      const DOMPurify = (await import('dompurify')).default;
+      if (typeof DOMPurify.sanitize !== 'function') {
+        DOMPurify.sanitize = (s) => String(s);
+        DOMPurify.addHook = () => {};
+      }
+      const mermaid = (await import('mermaid')).default;
+      mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
+      return mermaid;
+    })();
+  }
+  return mermaidLoad;
+}
+
+function cleanLabel(text) {
+  return String(text ?? '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .trim();
+}
+
+const SHAPE_MAP = {
+  square: 'rect',
+  rect: 'rect',
+  round: 'round',
+  rounded: 'round',
+  stadium: 'stadium',
+  subroutine: 'subroutine',
+  cylinder: 'cylinder',
+  cyl: 'cylinder',
+  circle: 'circle',
+  doublecircle: 'circle',
+  dbl_circ: 'circle',
+  diamond: 'diamond',
+  question: 'diamond',
+  decision: 'diamond',
+  hexagon: 'hexagon',
+  hex: 'hexagon'
+};
+
+function normalizeFlowchart(db) {
+  const nodes = [];
+  for (const [id, v] of db.getVertices()) {
+    const kind = v.type ?? v.shape;
+    nodes.push({ id, shape: SHAPE_MAP[kind] ?? 'rect', label: cleanLabel(v.text ?? id) || id });
+  }
+  const edges = db.getEdges().map((e) => ({
+    from: e.start,
+    to: e.end,
+    label: cleanLabel(e.text) || null,
+    style: e.stroke === 'dotted' ? 'dotted' : e.stroke === 'thick' ? 'thick' : 'solid',
+    arrow: e.type !== 'arrow_open'
+  }));
+  if (nodes.length === 0) throw new Error('flowchart: no nodes');
+  const dir = db.getDirection?.() ?? 'TB';
+  const rankdir = { TD: 'TB' }[dir] ?? (['TB', 'BT', 'LR', 'RL'].includes(dir) ? dir : 'TB');
+  return { type: 'flowchart', rankdir, nodes, edges, warnings: [] };
+}
+
+// sequenceDb LINETYPE values (stable across mermaid 8-11)
+const LT = {
+  SOLID: 0, DOTTED: 1, NOTE: 2, SOLID_CROSS: 3, DOTTED_CROSS: 4,
+  SOLID_OPEN: 5, DOTTED_OPEN: 6,
+  LOOP_START: 10, LOOP_END: 11, ALT_START: 12, ALT_ELSE: 13, ALT_END: 14,
+  OPT_START: 15, OPT_END: 16, ACTIVE_START: 17, ACTIVE_END: 18,
+  PAR_START: 19, PAR_AND: 20, PAR_END: 21, RECT_START: 22, RECT_END: 23,
+  SOLID_POINT: 24, DOTTED_POINT: 25, AUTONUMBER: 26,
+  CRITICAL_START: 27, CRITICAL_OPTION: 28, CRITICAL_END: 29,
+  BREAK_START: 30, BREAK_END: 31, PAR_OVER_START: 32
+};
+
+const SEQ_LINE = {
+  [LT.SOLID]: { dotted: false, head: 'arrow' },
+  [LT.DOTTED]: { dotted: true, head: 'arrow' },
+  [LT.SOLID_CROSS]: { dotted: false, head: 'cross' },
+  [LT.DOTTED_CROSS]: { dotted: true, head: 'cross' },
+  [LT.SOLID_OPEN]: { dotted: false, head: 'none' },
+  [LT.DOTTED_OPEN]: { dotted: true, head: 'none' },
+  [LT.SOLID_POINT]: { dotted: false, head: 'open' },
+  [LT.DOTTED_POINT]: { dotted: true, head: 'open' }
+};
+
+const FRAME_START = {
+  [LT.LOOP_START]: 'loop', [LT.ALT_START]: 'alt', [LT.OPT_START]: 'opt',
+  [LT.PAR_START]: 'par', [LT.PAR_OVER_START]: 'par',
+  [LT.CRITICAL_START]: 'critical', [LT.BREAK_START]: 'break'
+};
+const FRAME_END = new Set([LT.LOOP_END, LT.ALT_END, LT.OPT_END, LT.PAR_END, LT.CRITICAL_END, LT.BREAK_END]);
+const FRAME_DIVIDER = new Set([LT.ALT_ELSE, LT.PAR_AND, LT.CRITICAL_OPTION]);
+
+function normalizeSequence(db) {
+  const participants = [];
+  for (const [id, a] of db.getActors()) {
+    participants.push({ id, label: cleanLabel(a.description) || id, actor: a.type === 'actor' });
+  }
+  if (participants.length === 0) throw new Error('sequence: no participants');
+
+  const items = [];
+  const warnings = [];
+  let numbering = db.showSequenceNumbers?.() ? 1 : 0;
+  const actorId = (v) => (typeof v === 'object' && v !== null ? v.actor : v);
+
+  for (const m of db.getMessages()) {
+    const t = m.type;
+    if (t === LT.AUTONUMBER) {
+      numbering = m.message?.visible === false ? 0 : 1;
+      continue;
+    }
+    if (t === LT.NOTE) {
+      const pos = m.placement === 0 ? 'left of' : m.placement === 1 ? 'right of' : 'over';
+      const ids = [actorId(m.from)];
+      const to = actorId(m.to);
+      if (to && to !== ids[0]) ids.push(to);
+      items.push({ kind: 'note', pos, ids, text: cleanLabel(m.message) });
+      continue;
+    }
+    if (t in FRAME_START) {
+      items.push({ kind: 'frame', frame: FRAME_START[t], text: cleanLabel(m.message ?? '') });
+      continue;
+    }
+    if (FRAME_END.has(t)) {
+      items.push({ kind: 'frameEnd' });
+      continue;
+    }
+    if (FRAME_DIVIDER.has(t)) {
+      items.push({ kind: 'divider', text: cleanLabel(m.message ?? '') });
+      continue;
+    }
+    const line = SEQ_LINE[t];
+    if (line) {
+      let text = cleanLabel(m.message);
+      if (numbering) text = `${numbering++}. ${text}`;
+      items.push({ kind: 'message', from: actorId(m.from), to: actorId(m.to), text, ...line });
+      continue;
+    }
+    if (t !== LT.ACTIVE_START && t !== LT.ACTIVE_END && t !== LT.RECT_START && t !== LT.RECT_END) {
+      warnings.push(`sequence: ignored message type ${t}`);
+    }
+  }
+  return { type: 'sequence', participants, items, warnings };
+}
+
+/**
+ * Parse mermaid source with the mermaid package's own parser (loaded
+ * lazily, headless) and normalize the diagram DB into the model consumed
+ * by layoutMermaid(). Throws for diagram types without a native renderer
+ * here (anything but flowchart / sequence).
+ */
+export async function parseMermaid(text) {
+  const mermaid = await loadMermaid();
+  const diagram = await mermaid.mermaidAPI.getDiagramFromText(String(text));
+  const type = diagram.type;
+  if (/^flowchart/.test(type) || type === 'graph') return normalizeFlowchart(diagram.db);
+  if (/^sequence/.test(type)) return normalizeSequence(diagram.db);
+  throw new Error(`mermaid: no native renderer for diagram type "${type}"`);
+}
+
+// ---------------------------------------------------------------------------
+// text measurement helpers
+
+function makeMeasurer(fonts, family, size) {
+  const style = { family, size, weight: 'normal', style: 'normal' };
+  style.font = fonts.match(family, style);
+  const metrics = style.font.metrics(size);
+  const lineH = Math.ceil((metrics.ascent + metrics.descent) * 1.25);
+  return {
+    style,
+    lineH,
+    ascent: metrics.ascent,
+    width: (s) => (s ? fonts.shape(s, style).width : 0),
+    linesOf: (s) => String(s ?? '').split('\n'),
+    block(s) {
+      const lines = this.linesOf(s);
+      let w = 0;
+      for (const l of lines) w = Math.max(w, this.width(l));
+      return { lines, w, h: lines.length * lineH };
+    }
+  };
+}
+
+function drawTextBlock(ctx, meas, family, size, color, lines, cx, topY) {
+  ctx.fillStyle = color;
+  ctx.font = `${size}px ${family}`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'alphabetic';
+  let y = topY + meas.ascent;
+  for (const line of lines) {
+    const w = meas.width(line);
+    ctx.fillText(line, cx - w / 2, y);
+    y += meas.lineH;
+  }
+}
+
+// manual dashes (the 2d context has no setLineDash)
+function dashedLine(ctx, x0, y0, x1, y1, dash = 4, gap = 4) {
+  const dx = x1 - x0;
+  const dy = y1 - y0;
+  const len = Math.hypot(dx, dy);
+  if (!len) return;
+  const ux = dx / len;
+  const uy = dy / len;
+  let t = 0;
+  ctx.beginPath();
+  while (t < len) {
+    const e = Math.min(t + dash, len);
+    ctx.moveTo(x0 + ux * t, y0 + uy * t);
+    ctx.lineTo(x0 + ux * e, y0 + uy * e);
+    t = e + gap;
+  }
+  ctx.stroke();
+}
+
+function dashedPolyline(ctx, pts, dash = 4, gap = 4) {
+  for (let i = 0; i + 1 < pts.length; i++) dashedLine(ctx, pts[i].x, pts[i].y, pts[i + 1].x, pts[i + 1].y, dash, gap);
+}
+
+function arrowHead(ctx, x, y, fromX, fromY, size, color) {
+  const a = Math.atan2(y - fromY, x - fromX);
+  const s = size;
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(x - s * Math.cos(a - 0.45), y - s * Math.sin(a - 0.45));
+  ctx.lineTo(x - s * Math.cos(a + 0.45), y - s * Math.sin(a + 0.45));
+  ctx.closePath();
+  ctx.fill();
+}
+
+// ---------------------------------------------------------------------------
+// flowchart layout + drawing
+
+function nodeSize(node, meas) {
+  const { w, h } = meas.block(node.label);
+  const padX = 14;
+  const padY = 9;
+  switch (node.shape) {
+    case 'diamond':
+      return { w: w * 1.5 + 28, h: h * 2 + 18 };
+    case 'circle': {
+      const d = Math.max(w, h) + 24;
+      return { w: d, h: d };
+    }
+    case 'hexagon':
+      return { w: w + padX * 2 + h + 12, h: h + padY * 2 };
+    case 'cylinder':
+      return { w: w + padX * 2, h: h + padY * 2 + 14 };
+    case 'subroutine':
+      return { w: w + padX * 2 + 12, h: h + padY * 2 };
+    case 'stadium':
+      return { w: w + padX * 2 + h, h: h + padY * 2 };
+    default:
+      return { w: w + padX * 2, h: h + padY * 2 };
+  }
+}
+
+function nodePath(ctx, node, x, y, w, h) {
+  // (x, y) is the node center
+  ctx.beginPath();
+  switch (node.shape) {
+    case 'round':
+      ctx.roundRect(x - w / 2, y - h / 2, w, h, 6);
+      break;
+    case 'stadium':
+      ctx.roundRect(x - w / 2, y - h / 2, w, h, h / 2);
+      break;
+    case 'circle':
+      ctx.arc(x, y, w / 2, 0, Math.PI * 2);
+      break;
+    case 'diamond':
+      ctx.moveTo(x, y - h / 2);
+      ctx.lineTo(x + w / 2, y);
+      ctx.lineTo(x, y + h / 2);
+      ctx.lineTo(x - w / 2, y);
+      ctx.closePath();
+      break;
+    case 'hexagon': {
+      const c = h / 2;
+      ctx.moveTo(x - w / 2 + c, y - h / 2);
+      ctx.lineTo(x + w / 2 - c, y - h / 2);
+      ctx.lineTo(x + w / 2, y);
+      ctx.lineTo(x + w / 2 - c, y + h / 2);
+      ctx.lineTo(x - w / 2 + c, y + h / 2);
+      ctx.lineTo(x - w / 2, y);
+      ctx.closePath();
+      break;
+    }
+    default:
+      ctx.rect(x - w / 2, y - h / 2, w, h);
+  }
+}
+
+function layoutFlowchart(model, meas, family, size, theme) {
+  const g = new dagre.graphlib.Graph({ multigraph: true });
+  // separations follow the font size so shrink-to-fit scales ~linearly
+  g.setGraph({
+    rankdir: model.rankdir,
+    nodesep: Math.round(size * 2.8),
+    ranksep: Math.round(size * 3),
+    marginx: 6,
+    marginy: 6
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const node of model.nodes) {
+    const { w, h } = nodeSize(node, meas);
+    g.setNode(node.id, { width: w, height: h, node });
+  }
+  model.edges.forEach((edge, i) => {
+    const attrs = { edge };
+    if (edge.label) {
+      const { w, h } = meas.block(edge.label);
+      attrs.width = w + 8;
+      attrs.height = h + 4;
+      attrs.labelpos = 'c';
+    }
+    g.setEdge(edge.from, edge.to, attrs, `e${i}`);
+  });
+
+  dagre.layout(g);
+  const gw = Math.ceil(g.graph().width ?? 0);
+  const gh = Math.ceil(g.graph().height ?? 0);
+
+  return {
+    type: 'flowchart',
+    width: gw,
+    height: gh,
+    warnings: model.warnings,
+    draw(ctx, ox = 0, oy = 0) {
+      // edges under nodes
+      for (const e of g.edges()) {
+        const info = g.edge(e);
+        const edge = info.edge;
+        const pts = info.points.map((p) => ({ x: p.x + ox, y: p.y + oy }));
+        ctx.strokeStyle = theme.line;
+        ctx.lineWidth = edge.style === 'thick' ? 2.6 : 1.4;
+        if (edge.style === 'dotted') {
+          dashedPolyline(ctx, pts, 3, 3.5);
+        } else {
+          ctx.beginPath();
+          ctx.moveTo(pts[0].x, pts[0].y);
+          if (pts.length === 2) {
+            ctx.lineTo(pts[1].x, pts[1].y);
+          } else {
+            for (let i = 1; i < pts.length - 1; i++) {
+              const mx = (pts[i].x + pts[i + 1].x) / 2;
+              const my = (pts[i].y + pts[i + 1].y) / 2;
+              if (i === pts.length - 2) ctx.quadraticCurveTo(pts[i].x, pts[i].y, pts[i + 1].x, pts[i + 1].y);
+              else ctx.quadraticCurveTo(pts[i].x, pts[i].y, mx, my);
+            }
+          }
+          ctx.stroke();
+        }
+        if (edge.arrow) {
+          const tip = pts[pts.length - 1];
+          const before = pts[pts.length - 2] ?? pts[0];
+          arrowHead(ctx, tip.x, tip.y, before.x, before.y, 7 + (edge.style === 'thick' ? 2 : 0), theme.line);
+        }
+        if (edge.label) {
+          const { lines, w, h } = meas.block(edge.label);
+          const lx = info.x + ox;
+          const ly = info.y + oy;
+          ctx.fillStyle = theme.labelBg;
+          ctx.fillRect(Math.round(lx - w / 2 - 3), Math.round(ly - h / 2 - 1), Math.ceil(w + 6), Math.ceil(h + 2));
+          drawTextBlock(ctx, meas, family, size, theme.text, lines, lx, ly - h / 2);
+        }
+      }
+      // nodes
+      for (const id of g.nodes()) {
+        const info = g.node(id);
+        const node = info.node;
+        const x = info.x + ox;
+        const y = info.y + oy;
+        ctx.fillStyle = theme.nodeFill;
+        ctx.strokeStyle = theme.nodeBorder;
+        ctx.lineWidth = 1.3;
+        if (node.shape === 'cylinder') {
+          const capH = 10;
+          const w = info.width;
+          const h = info.height;
+          const top = y - h / 2;
+          ctx.beginPath();
+          ctx.rect(x - w / 2, top + capH / 2, w, h - capH);
+          ctx.fill();
+          ctx.beginPath();
+          ctx.moveTo(x - w / 2, top + capH / 2);
+          ctx.lineTo(x - w / 2, top + h - capH / 2);
+          ctx.moveTo(x + w / 2, top + capH / 2);
+          ctx.lineTo(x + w / 2, top + h - capH / 2);
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.ellipse(x, top + h - capH / 2, w / 2, capH / 2, 0, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.ellipse(x, top + capH / 2, w / 2, capH / 2, 0, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.stroke();
+        } else {
+          nodePath(ctx, node, x, y, info.width, info.height);
+          ctx.fill();
+          nodePath(ctx, node, x, y, info.width, info.height);
+          ctx.stroke();
+          if (node.shape === 'subroutine') {
+            ctx.beginPath();
+            ctx.moveTo(x - info.width / 2 + 5, y - info.height / 2);
+            ctx.lineTo(x - info.width / 2 + 5, y + info.height / 2);
+            ctx.moveTo(x + info.width / 2 - 5, y - info.height / 2);
+            ctx.lineTo(x + info.width / 2 - 5, y + info.height / 2);
+            ctx.stroke();
+          }
+        }
+        const { lines, h } = meas.block(node.label);
+        drawTextBlock(ctx, meas, family, size, theme.text, lines, x, y - h / 2);
+      }
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// sequence layout + drawing
+
+function layoutSequence(model, meas, family, size, theme) {
+  const P = model.participants;
+  const idx = new Map(P.map((p, i) => [p.id, i]));
+  const actorPadX = 12;
+  const actorH = meas.lineH + 16;
+  const boxW = P.map((p) => Math.max(60, meas.width(p.label) + actorPadX * 2));
+
+  // gaps between adjacent lifelines, widened until every message/note fits
+  const gaps = new Array(Math.max(0, P.length - 1)).fill(110);
+  const need = (a, b, w) => {
+    if (a === b) return;
+    const [lo, hi] = a < b ? [a, b] : [b, a];
+    let sum = 0;
+    for (let i = lo; i < hi; i++) sum += gaps[i];
+    if (sum < w) {
+      const add = (w - sum) / (hi - lo);
+      for (let i = lo; i < hi; i++) gaps[i] += add;
+    }
+  };
+  for (const item of model.items) {
+    if (item.kind === 'message' && item.from !== item.to) {
+      need(idx.get(item.from), idx.get(item.to), meas.width(item.text) + 36);
+    } else if (item.kind === 'note' && item.pos === 'over' && item.ids.length > 1) {
+      need(idx.get(item.ids[0]), idx.get(item.ids[item.ids.length - 1]), meas.block(item.text).w + 30);
+    }
+  }
+  // lifeline x positions
+  const cx = [];
+  let x = Math.max(20, boxW[0] / 2 + 8);
+  for (let i = 0; i < P.length; i++) {
+    if (i > 0) x += Math.max(gaps[i - 1], boxW[i - 1] / 2 + boxW[i] / 2 + 20);
+    cx.push(x);
+  }
+
+  // vertical layout pass: assign a y to every item
+  const rows = [];
+  const frames = [];
+  const openFrames = [];
+  let y = actorH + 14;
+  const frameInset = () => openFrames.length * 8;
+  for (const item of model.items) {
+    if (item.kind === 'frame') {
+      openFrames.push({ item, top: y, dividers: [] });
+      y += meas.lineH + 12;
+      continue;
+    }
+    if (item.kind === 'divider') {
+      const f = openFrames[openFrames.length - 1];
+      y += 8;
+      if (f) f.dividers.push({ y, text: item.text });
+      y += meas.lineH + 6;
+      continue;
+    }
+    if (item.kind === 'frameEnd') {
+      const f = openFrames.pop();
+      if (f) {
+        y += 8;
+        frames.push({ ...f, bottom: y });
+        y += 10;
+      }
+      continue;
+    }
+    if (item.kind === 'note') {
+      const { w, h } = { w: meas.block(item.text).w, h: meas.block(item.text).h };
+      rows.push({ item, y, noteW: w + 20, noteH: h + 10 });
+      y += h + 24;
+      continue;
+    }
+    // message
+    const self = item.from === item.to;
+    rows.push({ item, y });
+    y += meas.lineH + (self ? 26 : 16);
+  }
+  while (openFrames.length) {
+    const f = openFrames.pop();
+    frames.push({ ...f, bottom: y });
+    y += 10;
+  }
+  const bodyBottom = y + 6;
+  const height = Math.ceil(bodyBottom + actorH);
+  const width = Math.ceil(cx[cx.length - 1] + Math.max(24, boxW[P.length - 1] / 2 + 10));
+
+  const drawActor = (ctx, i, ox, top) => {
+    const w = boxW[i];
+    const h = actorH;
+    const x0 = ox + cx[i] - w / 2;
+    ctx.fillStyle = theme.actorFill;
+    ctx.strokeStyle = theme.actorBorder;
+    ctx.lineWidth = 1.3;
+    ctx.beginPath();
+    ctx.roundRect(x0, top, w, h, 4);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.roundRect(x0, top, w, h, 4);
+    ctx.stroke();
+    drawTextBlock(ctx, meas, family, size, theme.text, [P[i].label], ox + cx[i], top + (h - meas.lineH) / 2);
+  };
+
+  return {
+    type: 'sequence',
+    width,
+    height,
+    warnings: model.warnings,
+    draw(ctx, ox = 0, oy = 0) {
+      // lifelines
+      ctx.strokeStyle = theme.frameBorder;
+      ctx.lineWidth = 1;
+      for (let i = 0; i < P.length; i++) {
+        dashedLine(ctx, cx[i] + ox, oy + actorH, cx[i] + ox, oy + bodyBottom, 4, 4);
+      }
+      // frames (behind messages, above lifelines)
+      for (const f of frames) {
+        const x0 = ox + 8;
+        const x1 = ox + width - 8;
+        ctx.strokeStyle = theme.frameBorder;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.rect(x0, oy + f.top, x1 - x0, f.bottom - f.top);
+        ctx.stroke();
+        const tag = f.item.frame;
+        const tagW = meas.width(tag) + 14;
+        ctx.fillStyle = theme.actorFill;
+        ctx.fillRect(x0, oy + f.top, tagW, meas.lineH + 6);
+        ctx.strokeRect(x0, oy + f.top, tagW, meas.lineH + 6);
+        drawTextBlock(ctx, meas, family, size, theme.text, [tag], x0 + tagW / 2, oy + f.top + 3);
+        if (f.item.text) {
+          drawTextBlock(ctx, meas, family, size, theme.frameLabel, [`[${f.item.text}]`], x0 + tagW + meas.width(`[${f.item.text}]`) / 2 + 10, oy + f.top + 3);
+        }
+        for (const d of f.dividers) {
+          dashedLine(ctx, x0, oy + d.y, x1, oy + d.y, 5, 4);
+          if (d.text) {
+            drawTextBlock(ctx, meas, family, size, theme.frameLabel, [`[${d.text}]`], x0 + 30 + meas.width(`[${d.text}]`) / 2, oy + d.y + 3);
+          }
+        }
+      }
+      // messages and notes
+      for (const row of rows) {
+        const item = row.item;
+        if (item.kind === 'note') {
+          const ids = item.ids.map((id) => idx.get(id));
+          let nx;
+          if (item.pos === 'over') {
+            const lo = Math.min(...ids);
+            const hi = Math.max(...ids);
+            nx = (cx[lo] + cx[hi]) / 2;
+          } else if (item.pos === 'right of') {
+            nx = cx[ids[0]] + row.noteW / 2 + 12;
+          } else {
+            nx = cx[ids[0]] - row.noteW / 2 - 12;
+          }
+          const { lines } = meas.block(item.text);
+          ctx.fillStyle = theme.noteFill;
+          ctx.strokeStyle = theme.noteBorder;
+          ctx.lineWidth = 1;
+          ctx.fillRect(ox + nx - row.noteW / 2, oy + row.y, row.noteW, row.noteH);
+          ctx.strokeRect(ox + nx - row.noteW / 2, oy + row.y, row.noteW, row.noteH);
+          drawTextBlock(ctx, meas, family, size, theme.text, lines, ox + nx, oy + row.y + 5);
+          continue;
+        }
+        // message
+        const a = idx.get(item.from);
+        const b = idx.get(item.to);
+        const lineY = oy + row.y + meas.lineH + 4;
+        ctx.strokeStyle = theme.line;
+        ctx.lineWidth = 1.3;
+        if (a === b) {
+          // self message: out, down, back
+          const x0 = ox + cx[a];
+          const loopW = 28;
+          const pts = [
+            { x: x0, y: lineY },
+            { x: x0 + loopW, y: lineY },
+            { x: x0 + loopW, y: lineY + 14 },
+            { x: x0, y: lineY + 14 }
+          ];
+          if (item.dotted) dashedPolyline(ctx, pts, 4, 3);
+          else {
+            ctx.beginPath();
+            ctx.moveTo(pts[0].x, pts[0].y);
+            for (const p of pts.slice(1)) ctx.lineTo(p.x, p.y);
+            ctx.stroke();
+          }
+          arrowHead(ctx, x0 + 2, lineY + 14, x0 + loopW, lineY + 14, 7, theme.line);
+          drawTextBlock(ctx, meas, family, size, theme.text, meas.linesOf(item.text), x0 + loopW + 8 + meas.width(item.text) / 2, oy + row.y + 6);
+          continue;
+        }
+        const x0 = ox + cx[a];
+        const x1 = ox + cx[b];
+        if (item.dotted) dashedLine(ctx, x0, lineY, x1, lineY, 5, 4);
+        else {
+          ctx.beginPath();
+          ctx.moveTo(x0, lineY);
+          ctx.lineTo(x1, lineY);
+          ctx.stroke();
+        }
+        const dir = x1 > x0 ? 1 : -1;
+        if (item.head === 'cross') {
+          const cxx = x1 - dir * 6;
+          ctx.beginPath();
+          ctx.moveTo(cxx - 5, lineY - 5);
+          ctx.lineTo(cxx + 5, lineY + 5);
+          ctx.moveTo(cxx - 5, lineY + 5);
+          ctx.lineTo(cxx + 5, lineY - 5);
+          ctx.stroke();
+        } else if (item.head !== 'none') {
+          arrowHead(ctx, x1, lineY, x0, lineY, 8, theme.line);
+        }
+        if (item.text) {
+          drawTextBlock(ctx, meas, family, size, theme.text, [item.text], (x0 + x1) / 2, oy + row.y);
+        }
+      }
+      // actors, top and bottom
+      for (let i = 0; i < P.length; i++) {
+        drawActor(ctx, i, ox, oy);
+        drawActor(ctx, i, ox, oy + bodyBottom);
+      }
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Lay out a mermaid diagram without drawing it. Returns a box:
+ * `{ width, height, type, warnings, draw(ctx, x, y) }`.
+ *
+ * Supported: `flowchart`/`graph` (TB/TD/BT/LR/RL, all common node shapes,
+ * solid/dotted/thick edges with labels, chains and `&` fans) and
+ * `sequenceDiagram` (participants/actors, all arrow kinds, notes,
+ * loop/opt/alt/par frames with else/and dividers, autonumber).
+ * Anything else throws — callers fall back to a code block.
+ *
+ * @param {object} model parsed diagram from `await parseMermaid(text)`
+ * @param {object} options { fonts, size = 13, family = 'sans-serif', theme,
+ *   maxWidth } — when maxWidth is given and the diagram comes out wider,
+ *   it is laid out again at a proportionally smaller font size (floor 8px)
+ */
+export function layoutMermaid(model, { fonts, size = 13, family = 'sans-serif', theme = {}, maxWidth } = {}) {
+  if (!fonts) throw new Error('layoutMermaid: fonts (FontManager) is required');
+  if (!model || (model.type !== 'flowchart' && model.type !== 'sequence')) {
+    throw new Error('layoutMermaid: expected a model from parseMermaid()');
+  }
+  const th = { ...DEFAULT_THEME, ...theme };
+  const attempt = (px) => {
+    const meas = makeMeasurer(fonts, family, px);
+    return model.type === 'flowchart'
+      ? layoutFlowchart(model, meas, family, px, th)
+      : layoutSequence(model, meas, family, px, th);
+  };
+  let box = attempt(size);
+  let px = size;
+  for (let i = 0; maxWidth && box.width > maxWidth && px > 8 && i < 4; i++) {
+    px = Math.max(8, Math.floor((px * maxWidth) / box.width));
+    box = attempt(px);
+  }
+  return box;
+}

--- a/lib/widgets/svgview.js
+++ b/lib/widgets/svgview.js
@@ -58,12 +58,28 @@ const STYLE_ATTRS = {
 
 const NUMERIC = new Set(['strokeWidth', 'miterLimit', 'fillOpacity', 'strokeOpacity', 'fontSize']);
 
+// documents may come from an XML parse (setSvg: exact case) or from an HTML
+// parse (HtmlView inline <svg>: tag/attribute names lowercased) — compare
+// names lowercased and look attributes up by their lowercase form too
+const tag = (node) => (node.name || '').toLowerCase();
+
+function attr(node, name) {
+  const a = node.attribs;
+  if (!a) return undefined;
+  return a[name] ?? a[name.toLowerCase()];
+}
+
 function attrNum(node, name, fallback = 0) {
-  const v = node.attribs?.[name];
+  const v = attr(node, name);
   if (v === undefined || v === '') return fallback;
   const n = parseFloat(v);
   return Number.isFinite(n) ? n : fallback;
 }
+
+const NON_RENDERED = new Set([
+  'defs', 'title', 'desc', 'metadata', 'symbol', 'style',
+  'lineargradient', 'radialgradient', 'clippath', 'mask', 'filter', 'pattern', 'marker'
+]);
 
 /** parse an SVG transform list into ctx.transform() calls */
 export function parseSvgTransform(str) {
@@ -116,7 +132,7 @@ export function parseSvgTransform(str) {
 function shapePath(node) {
   const a = node.attribs || {};
   const path = new Path2D();
-  switch (node.name) {
+  switch (tag(node)) {
     case 'path':
       return a.d ? new Path2D(a.d) : null;
     case 'rect': {
@@ -215,14 +231,27 @@ export default class SvgView {
     const doc = parseDocument(String(svg), { xmlMode: true });
     const findSvg = (nodes) => {
       for (const n of nodes || []) {
-        if (n.type === 'tag' && n.name === 'svg') return n;
+        if (n.type === 'tag' && tag(n) === 'svg') return n;
         const inner = findSvg(n.children);
         if (inner) return inner;
       }
       return null;
     };
-    this._root = findSvg(doc.children);
-    if (!this._root) throw new Error('SvgView: no <svg> element found');
+    const root = findSvg(doc.children);
+    if (!root) throw new Error('SvgView: no <svg> element found');
+    return this.setSvgDom(root);
+  }
+
+  /**
+   * Adopt an already-parsed `<svg>` element (htmlparser2 DOM node) — used
+   * by HtmlView for inline SVG. HTML-mode parses (lowercased tag/attribute
+   * names) are handled.
+   */
+  setSvgDom(element) {
+    if (!element || element.type !== 'tag' || tag(element) !== 'svg') {
+      throw new Error('SvgView: expected an <svg> element');
+    }
+    this._root = element;
 
     this._ids = new Map();
     const collect = (node) => {
@@ -235,7 +264,7 @@ export default class SvgView {
     collect(this._root);
 
     const a = this._root.attribs || {};
-    const vb = (a.viewBox || a.viewbox || '')
+    const vb = (attr(this._root, 'viewBox') || '')
       .split(/[\s,]+/)
       .filter((s) => s !== '')
       .map(parseFloat);
@@ -325,13 +354,13 @@ export default class SvgView {
     const url = /^url\(['"]?#([^'")]+)['"]?\)/.exec(value);
     if (!url) return value;
     const node = this._ids.get(url[1]);
-    if (!node || (node.name !== 'linearGradient' && node.name !== 'radialGradient')) return null;
+    if (!node || (tag(node) !== 'lineargradient' && tag(node) !== 'radialgradient')) return null;
     return this._gradient(ctx, node, path);
   }
 
   _gradient(ctx, node, path) {
     const a = node.attribs || {};
-    const units = a.gradientUnits || 'objectBoundingBox';
+    const units = attr(node, 'gradientUnits') || 'objectBoundingBox';
     const bbox = units === 'objectBoundingBox' ? pathBBox(path) : null;
     const coord = (raw, fallback, axis) => {
       let v = raw === undefined ? fallback : parseFloat(raw);
@@ -347,7 +376,7 @@ export default class SvgView {
     const dev = (px, py) => matApply(mat, px, py);
 
     let gradient;
-    if (node.name === 'linearGradient') {
+    if (tag(node) === 'lineargradient') {
       const [x1, y1] = dev(coord(a.x1, 0, 'x'), coord(a.y1, 0, 'y'));
       const [x2, y2] = dev(coord(a.x2, 1, 'x'), coord(a.y2, 0, 'y'));
       gradient = ctx.createLinearGradient(x1, y1, x2, y2);
@@ -363,7 +392,7 @@ export default class SvgView {
     }
 
     for (const stop of node.children || []) {
-      if (stop.type !== 'tag' || stop.name !== 'stop') continue;
+      if (stop.type !== 'tag' || tag(stop) !== 'stop') continue;
       const sa = stop.attribs || {};
       const decls = {};
       for (const decl of (sa.style || '').split(';')) {
@@ -393,10 +422,8 @@ export default class SvgView {
 
   _renderNode(node, ctx, parentStyle, alpha, depth) {
     if (depth > 32) return;
-    const name = node.name;
-    if (name === 'defs' || name === 'title' || name === 'desc' || name === 'metadata' || name === 'symbol' || name === 'style' || name === 'linearGradient' || name === 'radialGradient' || name === 'clipPath' || name === 'mask' || name === 'filter') {
-      return;
-    }
+    const name = tag(node);
+    if (NON_RENDERED.has(name)) return;
 
     const style = this._style(node, parentStyle);
     const opacity = parseFloat(node.attribs?.opacity ?? '1');
@@ -424,7 +451,7 @@ export default class SvgView {
           const uy = attrNum(node, 'y');
           ctx.save();
           if (ux || uy) ctx.translate(ux, uy);
-          if (target.name === 'symbol') this._renderChildren(target, ctx, style, nodeAlpha, depth + 1);
+          if (tag(target) === 'symbol') this._renderChildren(target, ctx, style, nodeAlpha, depth + 1);
           else this._renderNode(target, ctx, style, nodeAlpha, depth + 1);
           ctx.restore();
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "bidi-js": "^1.0.3",
         "canvas-fontstyle": "^1.0.1",
         "css-select": "^7.0.0",
@@ -22,6 +23,7 @@
         "keysym": "0.0.6",
         "linebreak": "^1.1.0",
         "marked": "^18.0.7",
+        "mermaid": "^11.16.0",
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
@@ -32,6 +34,72 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -39,6 +107,282 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
       }
     },
     "node_modules/as-number": {
@@ -130,6 +474,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/css-select": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
@@ -161,6 +514,529 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dfa": {
@@ -218,6 +1094,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
@@ -247,6 +1132,17 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/extrude-polyline": {
       "version": "1.0.6",
@@ -288,6 +1184,12 @@
       "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==",
       "license": "zlib"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -317,6 +1219,37 @@
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/jpeg-js": {
@@ -350,6 +1283,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
     "node_modules/linebreak": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
@@ -369,6 +1313,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -383,6 +1333,63 @@
       "version": "18.0.7",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
       "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -434,6 +1441,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -449,6 +1462,12 @@
         "color-convert": "~0.5.0"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -462,6 +1481,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.19.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/polyline-miter-util": {
@@ -522,6 +1557,36 @@
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -531,11 +1596,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -561,6 +1650,19 @@
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/x11": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "node": ">=20.19.0"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "bidi-js": "^1.0.3",
     "canvas-fontstyle": "^1.0.1",
     "css-select": "^7.0.0",
@@ -46,6 +47,7 @@
     "keysym": "0.0.6",
     "linebreak": "^1.1.0",
     "marked": "^18.0.7",
+    "mermaid": "^11.16.0",
     "parse-color": "^1.0.0",
     "pngjs": "^7.0.0",
     "postcss": "^8.5.23",

--- a/test/htmlview.test.js
+++ b/test/htmlview.test.js
@@ -169,3 +169,176 @@ test('setHtml twice replaces the document cleanly', needsFonts, () => {
   assert.equal(byName(view, 'h2').length, 1);
   view.destroy();
 });
+
+// ---------------------------------------------------------------------------
+// svg support: inline <svg> and <img> with an svg source
+
+// minimal recording 2d context (transform-aware) for draw() assertions
+function svgMockCtx() {
+  const calls = [];
+  const mul = (m, n) => [
+    m[0] * n[0] + m[2] * n[1], m[1] * n[0] + m[3] * n[1],
+    m[0] * n[2] + m[2] * n[3], m[1] * n[2] + m[3] * n[3],
+    m[0] * n[4] + m[2] * n[5] + m[4], m[1] * n[4] + m[3] * n[5] + m[5]
+  ];
+  return {
+    calls,
+    _m: [1, 0, 0, 1, 0, 0],
+    _stack: [],
+    fillStyle: null,
+    strokeStyle: null,
+    globalAlpha: 1,
+    lineWidth: 1,
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    miterLimit: 10,
+    font: '',
+    textAlign: 'start',
+    save() { this._stack.push({ m: this._m.slice() }); },
+    restore() { const s = this._stack.pop(); if (s) this._m = s.m; },
+    translate(x, y) { this._m = mul(this._m, [1, 0, 0, 1, x, y]); },
+    scale(x, y = x) { this._m = mul(this._m, [x, 0, 0, y, 0, 0]); },
+    transform(...a) { this._m = mul(this._m, a); },
+    getTransform() { const [a, b, c, d, e, f] = this._m; return { a, b, c, d, e, f }; },
+    fillRect(...a) { calls.push(['fillRect', ...a]); },
+    fill(path, rule) { calls.push(['fill', path, rule, this.fillStyle, this._m.slice()]); },
+    stroke(path) { calls.push(['stroke', path, this.strokeStyle]); },
+    fillText(...a) { calls.push(['fillText', ...a]); },
+    createLinearGradient(x1, y1, x2, y2) {
+      return { type: 'linear', x1, y1, x2, y2, stops: [], addColorStop(o, c) { this.stops.push([o, c]); return this; } };
+    },
+    createRadialGradient() { return { stops: [], addColorStop(o, c) { this.stops.push([o, c]); return this; } }; }
+  };
+}
+
+test('inline svg: sized from width/height attributes, first layout pass', needsFonts, () => {
+  const view = layoutOf('<svg width="64" height="32" viewBox="0 0 8 4"><rect width="8" height="4"/></svg>');
+  const svg = byName(view, 'svg')[0];
+  assert.equal(svg.w, 64);
+  assert.equal(svg.h, 32);
+  const entry = view._images.get(svg.element);
+  assert.ok(entry.svg, 'SvgView adopted synchronously');
+});
+
+test('inline svg: viewBox ratio drives sizing when width is styled', needsFonts, () => {
+  const view = layoutOf('<svg viewBox="0 0 10 5" style="width: 200px"></svg>');
+  const svg = byName(view, 'svg')[0];
+  assert.equal(svg.w, 200);
+  assert.equal(svg.h, 100, 'height follows the 2:1 viewBox ratio');
+});
+
+test('inline svg: shrinks ratio-preserving to the container width', needsFonts, () => {
+  const view = layoutOf(
+    '<div style="width: 100px; margin: 0"><svg width="200" height="100"><rect width="1" height="1"/></svg></div>'
+  );
+  const svg = byName(view, 'svg')[0];
+  assert.equal(Math.round(svg.w), 100);
+  assert.equal(Math.round(svg.h), 50);
+});
+
+test('inline svg: draws shapes through the context, scaled to the box', needsFonts, () => {
+  const view = layoutOf(
+    '<div style="margin: 0; padding: 0"><svg width="40" height="40" viewBox="0 0 4 4"><rect width="4" height="4" fill="#ff0000"/></svg></div>'
+  );
+  const ctx = svgMockCtx();
+  view.draw(ctx, 0, 0);
+  const fills = ctx.calls.filter((c) => c[0] === 'fill');
+  assert.equal(fills.length, 1);
+  assert.equal(fills[0][3], '#ff0000');
+  const m = fills[0][4];
+  assert.equal(m[0], 10, 'viewBox unit scaled 10x into the 40px box');
+});
+
+test('inline svg: html-lowercased camelCase (viewBox, linearGradient) still works', needsFonts, () => {
+  const view = layoutOf(
+    `<svg width="40" height="40" viewBox="0 0 4 4">
+       <defs><linearGradient id="g" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="4" y2="0">
+         <stop offset="0" stop-color="#000"/><stop offset="1" stop-color="#fff"/>
+       </linearGradient></defs>
+       <rect width="4" height="4" fill="url(#g)"/>
+     </svg>`
+  );
+  const ctx = svgMockCtx();
+  view.draw(ctx, 0, 0);
+  const fill = ctx.calls.find((c) => c[0] === 'fill');
+  assert.ok(fill, 'gradient-filled rect drew');
+  assert.equal(fill[3].type, 'linear');
+  assert.equal(fill[3].stops.length, 2);
+  assert.equal(fill[3].x2, 40, 'userSpaceOnUse coords mapped through the 10x scale');
+});
+
+test('inline svg: display none hides it; children never join text flow', needsFonts, () => {
+  const view = layoutOf(
+    '<p style="margin:0">before<svg style="display: none" width="50" height="50"><title>tooltip text</title></svg>after</p>'
+  );
+  assert.equal(byName(view, 'svg').length, 0, 'display:none svg produces no box');
+  const texts = find(view._root, (b) => b.kind === 'text');
+  const spans = texts.flatMap((t) => t.spans ?? []).map((s) => s.text).join('');
+  assert.ok(!spans.includes('tooltip'), 'svg children do not leak into text');
+});
+
+test('img: svg source via loadResource buffer is sniffed and adopted', needsFonts, async () => {
+  const view = new HtmlView(null, {
+    fonts,
+    loadResource: async () => Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="30" height="60"><circle r="5"/></svg>')
+  });
+  view.setHtml('<img src="pic.svg">');
+  await new Promise((r) => setTimeout(r, 20));
+  view.layout(400);
+  const img = byName(view, 'img')[0];
+  const entry = view._images.get(img.element);
+  assert.ok(entry.svg, 'sniffed as svg');
+  assert.equal(entry.image, null);
+  assert.equal(img.w, 30);
+  assert.equal(img.h, 60);
+});
+
+test('img: data:image/svg+xml URI (utf8 and base64) loads', needsFonts, async () => {
+  const svgText = '<svg width="24" height="24"><rect width="24" height="24" fill="#00ff00"/></svg>';
+  const utf8 = 'data:image/svg+xml,' + encodeURIComponent(svgText);
+  const b64 = 'data:image/svg+xml;base64,' + Buffer.from(svgText).toString('base64');
+  for (const uri of [utf8, b64]) {
+    const view = new HtmlView(null, { fonts });
+    view.setHtml(`<img src="${uri}">`);
+    await new Promise((r) => setTimeout(r, 20));
+    view.layout(400);
+    const img = byName(view, 'img')[0];
+    assert.equal(img.w, 24, uri.slice(0, 30));
+    assert.ok(view._images.get(img.element).svg);
+  }
+});
+
+test('img: svg file loads through baseUrl and draws', needsFonts, async () => {
+  const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const dir = await mkdtemp(join(tmpdir(), 'ntk-svg-'));
+  await writeFile(join(dir, 'icon.svg'), '<svg viewBox="0 0 2 2" width="20" height="20"><rect width="2" height="2" fill="#0000ff"/></svg>');
+  try {
+    const view = new HtmlView(null, { fonts, baseUrl: dir });
+    view.setHtml('<div style="margin:0;padding:0"><img src="icon.svg"></div>');
+    await new Promise((r) => setTimeout(r, 30));
+    view.layout(400);
+    const img = byName(view, 'img')[0];
+    assert.equal(img.w, 20);
+    const ctx = svgMockCtx();
+    view.draw(ctx, 0, 0);
+    const fill = ctx.calls.find((c) => c[0] === 'fill');
+    assert.equal(fill[3], '#0000ff');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('img: raster decoding is untouched by svg sniffing', needsFonts, async () => {
+  const { PNG } = await import('pngjs');
+  const png = new PNG({ width: 12, height: 8 });
+  const view = new HtmlView(null, { fonts, loadResource: async () => PNG.sync.write(png) });
+  view.setHtml('<img src="x.png">');
+  await new Promise((r) => setTimeout(r, 20));
+  view.layout(400);
+  const entry = view._images.values().next().value;
+  assert.ok(entry.image, 'decoded as raster');
+  assert.equal(entry.svg, null);
+  assert.equal(entry.image.width, 12);
+});

--- a/test/mermaid.test.js
+++ b/test/mermaid.test.js
@@ -1,0 +1,163 @@
+// Mermaid diagram tests: parsing via the mermaid package (headless) and
+// native layout. Layout/draw tests need fontconfig for text measurement.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { test } from 'node:test';
+
+import FontManager from '../lib/text/fontmanager.js';
+import { layoutMermaid, parseMermaid } from '../lib/widgets/mermaid.js';
+import MarkdownView from '../lib/widgets/markdownview.js';
+
+let hasFontconfig = true;
+try {
+  execFileSync('fc-match', ['--version'], { stdio: 'ignore' });
+} catch {
+  hasFontconfig = false;
+}
+const needsFonts = { skip: !hasFontconfig && 'fc-match not installed' };
+const fonts = hasFontconfig ? new FontManager() : null;
+
+// ---------------------------------------------------------------------------
+// parsing (mermaid's own grammar, normalized)
+
+test('flowchart: shapes, edge styles and labels normalize from the mermaid db', async () => {
+  const m = await parseMermaid(`flowchart LR
+    A[Start] --> B{Ready?}
+    B -->|yes| C([Go])
+    B -->|no| D[(Store)]
+    C -.-> E((End))
+    D == retry ==> B
+    F[[Sub]] --- G{{Hex}}
+  `);
+  assert.equal(m.type, 'flowchart');
+  assert.equal(m.rankdir, 'LR');
+  const shape = (id) => m.nodes.find((n) => n.id === id)?.shape;
+  assert.equal(shape('A'), 'rect');
+  assert.equal(shape('B'), 'diamond');
+  assert.equal(shape('C'), 'stadium');
+  assert.equal(shape('D'), 'cylinder');
+  assert.equal(shape('E'), 'circle');
+  assert.equal(shape('F'), 'subroutine');
+  assert.equal(shape('G'), 'hexagon');
+
+  const edge = (from, to) => m.edges.find((e) => e.from === from && e.to === to);
+  assert.equal(edge('B', 'C').label, 'yes');
+  assert.equal(edge('C', 'E').style, 'dotted');
+  assert.equal(edge('D', 'B').style, 'thick');
+  assert.equal(edge('D', 'B').label, 'retry');
+  assert.equal(edge('F', 'G').arrow, false);
+});
+
+test('flowchart: graph TD header and chains', async () => {
+  const m = await parseMermaid('graph TD\n  A --> B --> C\n  A & B --> D');
+  assert.equal(m.rankdir, 'TB');
+  const pairs = m.edges.map((e) => `${e.from}${e.to}`).sort();
+  assert.deepEqual(pairs, ['AB', 'AD', 'BC', 'BD']);
+});
+
+test('sequence: actors, arrows, notes, frames and autonumber normalize', async () => {
+  const m = await parseMermaid(`sequenceDiagram
+    autonumber
+    participant A as Alice
+    actor B as Bob
+    A->>B: Hello
+    B-->>A: Hi
+    A-xB: gone
+    A->B: open
+    loop retry
+      A-)B: async
+    end
+    alt good
+      A->>B: yes
+    else bad
+      B->>A: no
+    end
+    Note over A,B: done
+    Note right of B: aside
+    A->>A: think
+  `);
+  assert.equal(m.type, 'sequence');
+  assert.deepEqual(
+    m.participants.map((p) => [p.id, p.label, p.actor]),
+    [['A', 'Alice', false], ['B', 'Bob', true]]
+  );
+  const msgs = m.items.filter((i) => i.kind === 'message');
+  assert.equal(msgs[0].text, '1. Hello');
+  assert.equal(msgs[0].head, 'arrow');
+  assert.equal(msgs[1].dotted, true);
+  assert.equal(msgs[2].head, 'cross');
+  assert.equal(msgs[3].head, 'none');
+  assert.equal(msgs[4].head, 'open');
+  const frames = m.items.filter((i) => i.kind === 'frame').map((f) => f.frame);
+  assert.deepEqual(frames, ['loop', 'alt']);
+  assert.equal(m.items.filter((i) => i.kind === 'divider')[0].text, 'bad');
+  assert.equal(m.items.filter((i) => i.kind === 'frameEnd').length, 2);
+  const notes = m.items.filter((i) => i.kind === 'note');
+  assert.deepEqual(notes[0].ids, ['A', 'B']);
+  assert.equal(notes[0].pos, 'over');
+  assert.equal(notes[1].pos, 'right of');
+  const self = msgs[msgs.length - 1];
+  assert.equal(self.from, self.to);
+});
+
+test('unsupported diagram types reject', async () => {
+  await assert.rejects(() => parseMermaid('pie\n "a": 1\n "b": 2'), /no native renderer/);
+  await assert.rejects(() => parseMermaid('not a diagram at all'));
+});
+
+// ---------------------------------------------------------------------------
+// layout
+
+test('flowchart layout: positive size, maxWidth shrinks to fit', needsFonts, async () => {
+  const model = await parseMermaid(
+    'flowchart LR\n A[one] --> B[two] --> C[three] --> D[four] --> E[five] --> F[six]'
+  );
+  const box = layoutMermaid(model, { fonts, size: 14 });
+  assert.ok(box.width > 300 && box.height > 20);
+  assert.equal(box.type, 'flowchart');
+
+  const fitted = layoutMermaid(model, { fonts, size: 14, maxWidth: 420 });
+  assert.ok(fitted.width < box.width, 'shrunk from the unconstrained layout');
+  assert.ok(fitted.width <= 430, `fitted ${fitted.width} into ~420`);
+  // impossible targets bottom out at the 8px font floor instead of looping
+  const floor = layoutMermaid(model, { fonts, size: 14, maxWidth: 50 });
+  assert.ok(floor.width > 50, 'floor respected');
+});
+
+test('sequence layout: gaps widen for long labels', needsFonts, async () => {
+  const short = layoutMermaid(await parseMermaid('sequenceDiagram\n A->>B: hi'), { fonts });
+  const long = layoutMermaid(
+    await parseMermaid('sequenceDiagram\n A->>B: a rather long message label that needs space'),
+    { fonts }
+  );
+  assert.ok(long.width > short.width);
+});
+
+test('layoutMermaid validates its input', needsFonts, () => {
+  assert.throws(() => layoutMermaid('flowchart LR\n A --> B', { fonts }), /parseMermaid/);
+  assert.throws(() => layoutMermaid({ type: 'flowchart', nodes: [], edges: [] }, {}), /fonts/);
+});
+
+// ---------------------------------------------------------------------------
+// markdown integration
+
+test('markdown: mermaid fence becomes a diagram box after async parse', needsFonts, async () => {
+  const view = new MarkdownView(null, { fonts });
+  view.setMarkdown('```mermaid\nflowchart LR\n A[Hello] --> B[World]\n```');
+  view.layout(500); // kicks off the async parse; fence is a code block for now
+  await new Promise((r) => setTimeout(r, 2000));
+  view.layout(500);
+  const diagram = view._items.find((i) => i.kind === 'tex' && i.box.type === 'flowchart');
+  assert.ok(diagram, 'diagram item present after parse resolves');
+  assert.ok(diagram.box.width > 100);
+});
+
+test('markdown: unsupported mermaid stays a code block', needsFonts, async () => {
+  const view = new MarkdownView(null, { fonts });
+  view.setMarkdown('```mermaid\ngantt\n title x\n```');
+  view.layout(500);
+  await new Promise((r) => setTimeout(r, 2000));
+  view.layout(500);
+  assert.ok(!view._items.some((i) => i.kind === 'tex'), 'no diagram box');
+  assert.ok(view._items.some((i) => i.kind === 'rect'), 'code block background present');
+});

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict';
 import { after, before, test } from 'node:test';
 
-import { createClient, HtmlView, Path2D, SvgView } from '../lib/index.js';
+import { createClient, HtmlView, MarkdownView, Path2D, SvgView } from '../lib/index.js';
 
 const withTimeout = (promise, ms, what) =>
   Promise.race([
@@ -257,6 +257,36 @@ test('HtmlView: inline <svg> and svg <img> render as vectors', async (t) => {
   assert.deepEqual(px(image, 64, 10, 10), [255, 0, 0], 'inline svg rect');
   assert.deepEqual(px(image, 64, 8, 36), [0, 0, 255], 'svg img below it');
   assert.deepEqual(px(image, 64, 50, 50), [255, 255, 255], 'background untouched');
+  pixmap.destroy();
+});
+
+test('MarkdownView: mermaid fence renders diagram pixels', async (t) => {
+  if (skip) return t.skip(skip);
+  const pixmap = app.createPixmap({ width: 300, height: 200, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, 300, 200);
+
+  const view = new MarkdownView(null, { fonts: app.fonts });
+  view.setMarkdown('```mermaid\nflowchart LR\n A[Hello] --> B[World]\n```');
+  view.layout(280);
+  await withTimeout(
+    (async () => {
+      while (![...view._mermaid.values()][0]?.model) await new Promise((r) => setTimeout(r, 50));
+    })(),
+    10000,
+    'mermaid parse'
+  );
+  view.layout(280);
+  view.draw(ctx, 10, 10);
+
+  const image = await readPixels(ctx, 300, 200);
+  // scan for the node fill color #ececff (BGRA readback)
+  let filled = 0;
+  for (let i = 0; i < image.data.length; i += 4) {
+    if (image.data[i + 2] === 0xec && image.data[i + 1] === 0xec && image.data[i] === 0xff) filled++;
+  }
+  assert.ok(filled > 200, `node fill pixels present (${filled})`);
   pixmap.destroy();
 });
 

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict';
 import { after, before, test } from 'node:test';
 
-import { createClient, Path2D, SvgView } from '../lib/index.js';
+import { createClient, HtmlView, Path2D, SvgView } from '../lib/index.js';
 
 const withTimeout = (promise, ms, what) =>
   Promise.race([
@@ -193,6 +193,28 @@ test('stroke: lineWidth and clipped strokes honor the mask path', async (t) => {
   pixmap.destroy();
 });
 
+test('stroke: closed subpaths do not spike to the origin', async (t) => {
+  // regression: a closed path whose flattened points end exactly on the
+  // start point fed a zero-length segment to extrude-polyline, producing
+  // NaN joins rendered as triangles at (0,0)
+  if (skip) return t.skip(skip);
+  const { pixmap, ctx } = freshCtx();
+
+  ctx.strokeStyle = 'black';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(40, 40, 15, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.stroke();
+
+  const image = await readPixels(ctx, 64, 64);
+  assert.deepEqual(px(image, 64, 40, 25), [0, 0, 0], 'circle outline drew');
+  for (const [x, y] of [[2, 2], [10, 10], [20, 20]]) {
+    assert.deepEqual(px(image, 64, x, y), [255, 255, 255], `no spike at ${x},${y}`);
+  }
+  pixmap.destroy();
+});
+
 test('strokeRect and quadraticCurveTo render', async (t) => {
   if (skip) return t.skip(skip);
   const { pixmap, ctx } = freshCtx();
@@ -210,6 +232,31 @@ test('strokeRect and quadraticCurveTo render', async (t) => {
   const image = await readPixels(ctx, 64, 64);
   assert.deepEqual(px(image, 64, 32, 8), [0, 0, 255], 'strokeRect top edge');
   assert.deepEqual(px(image, 64, 32, 30), [0, 0, 0], 'quad curve interior');
+  pixmap.destroy();
+});
+
+test('HtmlView: inline <svg> and svg <img> render as vectors', async (t) => {
+  if (skip) return t.skip(skip);
+  const { pixmap, ctx } = freshCtx();
+
+  const uri =
+    'data:image/svg+xml,' +
+    encodeURIComponent('<svg viewBox="0 0 4 4"><rect width="4" height="4" fill="#0000ff"/></svg>');
+  const view = new HtmlView(null);
+  view.setHtml(
+    `<div style="margin:0;padding:0">
+       <svg width="32" height="32" viewBox="0 0 4 4"><rect width="4" height="4" fill="#ff0000"/></svg>
+       <img width="16" height="16" src="${uri}">
+     </div>`
+  );
+  await new Promise((r) => setTimeout(r, 20)); // let the data: URI resolve
+  view.layout(64);
+  view.draw(ctx, 0, 0);
+
+  const image = await readPixels(ctx, 64, 64);
+  assert.deepEqual(px(image, 64, 10, 10), [255, 0, 0], 'inline svg rect');
+  assert.deepEqual(px(image, 64, 8, 36), [0, 0, 255], 'svg img below it');
+  assert.deepEqual(px(image, 64, 50, 50), [255, 255, 255], 'background untouched');
   pixmap.destroy();
 });
 


### PR DESCRIPTION
Two features building on the #51 SVG/canvas work:

## SVG support in HtmlView (`cb18d0c`)

- **Inline `<svg>`** is now a replaced element: laid out like an image (intrinsic size from `width`/`height`/`viewBox`, ratio-preserving shrink, CSS sizing respected), rendered by `SvgView`. The already-parsed DOM element is adopted synchronously via the new `SvgView.setSvgDom()`, so sizing is right on the first layout pass and svg children never leak into text flow.
- **`<img>` with an SVG source** — three routes, all rendered as vectors: `data:image/svg+xml` URIs (base64 and percent-encoded), `baseUrl` file loads, and `loadResource` buffers (content-sniffed, so the extension doesn't matter; the hook may also return an `SvgView`). Raster decoding untouched.
- `SvgView` is now case-tolerant for tag/attribute names (`viewbox`, `lineargradient`, `gradientunits`, …) since HtmlView parses in HTML mode, which lowercases them.
- **Bug fix found by pixel verification**: closed-path strokes fed a zero-length segment to extrude-polyline when a flattened subpath ended exactly on its start point — the NaN joins rendered as spikes at the origin. Consecutive duplicate points are now dropped (regression pixel test included).

## Mermaid diagrams in MarkdownView (`4e06b5a`)

````markdown
```mermaid
flowchart LR
  A[Request] --> B{Cached?}
  B -->|yes| C([Serve from cache])
```
````

- **Parsing: the mermaid package's own grammar**, lazily imported and run headless. mermaid only needs a DOM for DOMPurify label sanitization (shimmed to identity — labels are drawn as text, never injected anywhere) and for its SVG renderer (unused). The lazy import means the dependency costs nothing until the first ```mermaid fence.
- **Rendering: native** — flowcharts laid out with `@dagrejs/dagre`, sequence diagrams with a column/row pass; text measured by the ntk font pipeline, drawn server-side through the 2d context. Covered: all common node shapes, solid/dotted/thick edges with labels, arrow/cross/open heads, participants/actors, notes, loop/alt/opt/par/critical/break frames, autonumber, self-messages.
- Fences parse asynchronously (code block until ready, then automatic relayout — the HtmlView image-loading pattern). Unsupported diagram types (gantt, pie, …) fall back to a plain code block, same contract as invalid math fences. Wide diagrams shrink-to-fit down to an 8px font floor.
- New deps: `mermaid` (parser only, lazy) and `@dagrejs/dagre` (pure JS).

## Tests / docs / examples

- 228/228 tests pass against a real X server: 10 HtmlView SVG unit tests, 9 mermaid tests (DB normalization, layout/fit, markdown integration incl. fallback), plus pixel smoke tests for HtmlView-svg, the stroke-spike regression, and mermaid node fills.
- Examples: `examples/html.js` gained inline-svg + svg-img samples and an SVG page; new `examples/mermaid.js` four-diagram tour.
- Docs: `docs/html.md`, `docs/svg.md` updated; new `docs/mermaid.md`; README/AGENTS refreshed.