### PR TITLE
chore: drop release-as 3.0.0 pin now that the release shipped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,9 +137,8 @@ release and publishes to npm via OIDC trusted publishing (no token secrets).
 - **Use conventional commit messages** (`feat:`, `fix:`, `feat!:` /
   `BREAKING CHANGE:`, `chore:`, `docs:`) — release-please derives the next
   version and the changelog from them. PR squash-merge titles must follow the
-  same convention.
-- `release-please-config.json` currently pins `release-as: 3.0.0` to
-  bootstrap the first modernized release — remove that key after 3.0.0 ships.
+  same convention (repo settings enforce squash-merge; GitHub merge commits
+  would double-count entries in release-please's changelog).
 
 ## Gotchas
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,6 @@
   "release-type": "node",
   "include-component-in-tag": false,
   "packages": {
-    ".": {
-      "release-as": "3.0.0"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
The pin bootstrapped the first modernized release; v3.0.0 is tagged, so release-please should derive future versions from conventional commits again. Also refreshes the AGENTS.md release notes (squash-merge is now enforced in repo settings).