### PR TITLE
fix: forward X window attributes from createWindow args to CreateWindow

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -23,6 +23,16 @@ asynchronously.
 Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 
 - `backingStore: false` — opt out of double buffering (below)
+- X window attributes, forwarded into the `CreateWindow` value list under
+  their node-x11 names: `backgroundPixmap`, `backgroundPixel`,
+  `borderPixmap`, `borderPixel`, `bitGravity`, `winGravity`,
+  `backingPlanes`, `backingPixel`, `overrideRedirect`, `saveUnder`,
+  `doNotPropagateMask`, `colormap`, `cursor`. Defaults stay in effect
+  unless overridden: NorthWest `bitGravity` (`1`) and the event mask
+  computed from the `onXxx` handlers (an explicit `eventMask` is OR-ed into
+  the computed mask). Note the X *backing-store* attribute is **not**
+  forwarded: the `backingStore` option name is taken by ntk's double
+  buffering opt-out above, which is an unrelated client-side concept.
 - `coalesceEvents: false` — deliver every noisy event individually (see
   [Frames, coalescing and slow connections](#frames-coalescing-and-slow-connections))
 - `frameSync: false` — don't pace frames with a server round-trip fence

--- a/lib/window.js
+++ b/lib/window.js
@@ -6,6 +6,31 @@ import Drawable from './drawable.js';
 import Pixmap from './pixmap.js';
 import * as xevents from './events_map.js';
 
+// X window attributes forwarded verbatim from constructor args into the
+// CreateWindow value list (node-x11 valueMask names, see x11
+// lib/corereqs.js). Deliberately not forwarded:
+//  - eventMask: computed from the onXxx handler args (an explicit
+//    args.eventMask is OR-ed into the computed mask instead)
+//  - backingStore: ntk's `backingStore: false` creation option opts out of
+//    client-side double buffering (see docs/window.md) and predates this
+//    list — it is a different concept from the X backing-store attribute,
+//    which is therefore not forwarded to avoid a silent collision
+const forwardedXAttributes = [
+  'backgroundPixmap',
+  'backgroundPixel',
+  'borderPixmap',
+  'borderPixel',
+  'bitGravity',
+  'winGravity',
+  'backingPlanes',
+  'backingPixel',
+  'overrideRedirect',
+  'saveUnder',
+  'doNotPropagateMask',
+  'colormap',
+  'cursor'
+];
+
 export default class Window extends Drawable {
   // one wrapper per X window id and connection: constructing a Window for a
   // known id returns the cached instance
@@ -68,17 +93,25 @@ export default class Window extends Drawable {
         }
       }
 
+      if (typeof args.eventMask === 'number') {
+        this.eventMask |= args.eventMask;
+      }
+
       this.width = args.width ?? 800;
       this.height = args.height ?? 800;
       this.x = args.x ?? 0;
       this.y = args.y ?? 0;
-      X.CreateWindow(this.id, parentId, this.x, this.y, this.width, this.height, 0, 0, 0, 0, {
+      const values = {
         // NorthWest bit gravity: keep the old content anchored during
         // resize instead of discarding it (less flicker between the resize
         // and our redraw)
         bitGravity: 1,
         eventMask: this.eventMask
-      });
+      };
+      for (const name of forwardedXAttributes) {
+        if (args[name] !== undefined) values[name] = args[name];
+      }
+      X.CreateWindow(this.id, parentId, this.x, this.y, this.width, this.height, 0, 0, 0, 0, values);
     } else {
       this.id = args.id;
       this.eventMask = 0;

--- a/test/window-attributes.test.js
+++ b/test/window-attributes.test.js
@@ -1,0 +1,75 @@
+// createWindow() must forward X window attributes from its args into the
+// CreateWindow value list (they used to be silently dropped). Hermetic:
+// runs against node-x11's in-process pure-JS X server, and verifies the
+// attributes server-side with a GetWindowAttributes round-trip.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import x11 from 'x11';
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+let app = null;
+
+before(async () => {
+  const server = createServer({ width: 320, height: 240 });
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+const getAttributes = (wid) =>
+  new Promise((resolve, reject) =>
+    app.X.GetWindowAttributes(wid, (err, attrs) => (err ? reject(err) : resolve(attrs)))
+  );
+
+test('overrideRedirect: true reaches the server', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30, overrideRedirect: true });
+  const attrs = await getAttributes(wnd.id);
+  assert.equal(attrs.overrideRedirect, 1, 'override-redirect set on the server window');
+  // untouched defaults survive: NorthWest bit gravity
+  assert.equal(attrs.bitGravity, 1, 'default NorthWest bit gravity kept');
+  wnd.destroy();
+});
+
+test('defaults still apply when no attributes are passed', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  const attrs = await getAttributes(wnd.id);
+  assert.equal(attrs.overrideRedirect, 0);
+  assert.equal(attrs.bitGravity, 1, 'NorthWest bit gravity default');
+  assert.ok(attrs.myEventMasks & x11.eventMask.StructureNotify, 'computed event mask in place');
+  wnd.destroy();
+});
+
+test('explicit attributes override the defaults', async () => {
+  const wnd = app.createWindow({
+    width: 40,
+    height: 30,
+    bitGravity: 5, // Center
+    winGravity: 10 // Static
+  });
+  const attrs = await getAttributes(wnd.id);
+  assert.equal(attrs.bitGravity, 5, 'bitGravity override forwarded');
+  assert.equal(attrs.winGravity, 10, 'winGravity forwarded');
+  wnd.destroy();
+});
+
+test('explicit eventMask bits are OR-ed into the computed mask', async () => {
+  const wnd = app.createWindow({
+    width: 40,
+    height: 30,
+    eventMask: x11.eventMask.PropertyChange
+  });
+  const attrs = await getAttributes(wnd.id);
+  assert.ok(attrs.myEventMasks & x11.eventMask.PropertyChange, 'requested bit present');
+  assert.ok(attrs.myEventMasks & x11.eventMask.StructureNotify, 'computed StructureNotify kept');
+  assert.equal(wnd.eventMask, attrs.myEventMasks, 'client-side bookkeeping matches the server');
+  wnd.destroy();
+});


### PR DESCRIPTION
Fixes #55

## What

`createWindow(args)` now forwards recognized X window attributes from the args into the `CreateWindow` value list: `backgroundPixmap`, `backgroundPixel`, `borderPixmap`, `borderPixel`, `bitGravity`, `winGravity`, `backingPlanes`, `backingPixel`, `overrideRedirect`, `saveUnder`, `doNotPropagateMask`, `colormap`, `cursor` (node-x11 valueMask names). Previously the value list was hardcoded to `{ bitGravity: 1, eventMask }` and these args were silently dropped.

Defaults are preserved unless overridden: NorthWest `bitGravity` and the event mask computed from `onXxx` handlers. An explicit `args.eventMask` is OR-ed into the computed mask (so internal event-mask bookkeeping stays consistent) rather than replacing it.

## backingStore name collision

ntk's existing `backingStore: false` creation option opts out of **client-side double buffering** (docs/window.md) — a different concept from the X *backing-store* window attribute that happens to share the node-x11 key name. To avoid a silent behavior collision the X attribute is **not** forwarded at all; this is called out in a code comment and in docs/window.md. If someone later needs the X attribute it can be added under a non-conflicting name (e.g. `xBackingStore`).

## Motivation

Phase-0 prerequisite for the react-x11 renderer, which passes `overrideRedirect: true` for child windows today — currently a no-op.

## Testing

New hermetic `test/window-attributes.test.js` (in-process pure-JS X server, same pattern as `test/xserver.test.js`): the in-process server does track attributes and answers `GetWindowAttributes`, so assertions are server-side round-trips — `overrideRedirect` lands, defaults survive, `bitGravity`/`winGravity` overrides land, and explicit `eventMask` bits merge with the computed mask. Full `npm test`: 249 pass.