### PR TITLE
feat: re-export the yoga-layout instance as Yoga

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -36,6 +36,11 @@ parsing [postcss](https://www.npmjs.com/package/postcss). PNG/JPEG images
 render through the [image pipeline](images.md); SVG — inline or as an
 `<img>` source — through the [SVG widget](svg.md).
 
+The yoga-layout instance ntk uses is re-exported as `Yoga`
+(`import { Yoga } from 'ntk'`) so downstream layout consumers — e.g. the
+react-x11 renderer — share the same WASM module and enum values instead of
+loading a second, possibly version-mismatched copy.
+
 ## The safety / responsibility model
 
 The API is deliberately split so that a document can never act on its own:

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,4 +120,8 @@ export {
   configureTex,
   highlightCode
 };
+// the yoga-layout instance ntk lays HtmlView out with — downstream layout
+// consumers (e.g. the react-x11 renderer) must share it to avoid loading a
+// second WASM copy with potentially mismatched enums
+export { default as Yoga } from 'yoga-layout';
 export default { createClient };

--- a/test/yoga-export.test.js
+++ b/test/yoga-export.test.js
@@ -1,0 +1,24 @@
+// ntk re-exports its yoga-layout instance so downstream layout consumers
+// (e.g. the react-x11 renderer) share one WASM module and one set of enums.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import YogaDirect from 'yoga-layout';
+
+import { Yoga } from '../lib/index.js';
+
+test('Yoga is re-exported and functional', () => {
+  assert.ok(Yoga, 'Yoga export present');
+  const node = Yoga.Node.create();
+  node.setWidth(100);
+  node.calculateLayout(100, 100, Yoga.DIRECTION_LTR);
+  assert.equal(node.getComputedWidth(), 100);
+  node.free();
+});
+
+test('Yoga is the same instance htmlview uses', () => {
+  // htmlview.js does `import Yoga from 'yoga-layout'` — module resolution
+  // guarantees identity as long as both import the same specifier from the
+  // same package instance
+  assert.equal(Yoga, YogaDirect, 'single shared yoga-layout module');
+});


### PR DESCRIPTION
Fixes #57

## What

- `lib/index.js`: `export { default as Yoga } from 'yoga-layout'` (default export, matching how `lib/widgets/htmlview.js` imports it), so `import { Yoga } from 'ntk'` yields the exact instance ntk uses.
- `docs/html.md`: documents the re-export next to the yoga-layout discussion. (The published package ships only `lib/`, but docs/ lives in the repo and feeds the website.)
- `test/yoga-export.test.js`: asserts `Yoga.Node.create()` works through the re-export (layout round-trip) and that the export is identical (`===`) to the module htmlview imports.

## Motivation

Phase-0 prerequisite for the react-x11 renderer: sharing one yoga instance avoids double WASM loads and enum mismatches between nodes created by ntk and by the renderer.

## Testing

New test passes; full `npm test`: 247 pass.