### PR TITLE
fix: guard setTitle/setActions request chains against a closing client

### DIFF
--- a/lib/window.js
+++ b/lib/window.js
@@ -577,19 +577,30 @@ export default class Window extends Drawable {
     const wid = this.id;
     // legacy WM_NAME is latin-1 only (node-x11 encodes plain strings as
     // latin1) — kept for old window managers
-    X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, title);
+    safeRelease(X, () => {
+      X.ChangeProperty(0, wid, X.atoms.WM_NAME, X.atoms.STRING, 8, title);
+    });
     // modern WMs prefer the EWMH _NET_WM_NAME property, which is UTF-8;
     // interned atoms are cached by node-x11, so this round-trips only once.
     // The lookups are async: by the time they resolve the window may be
     // destroyed (ChangeProperty would BadWindow) or retitled (an older
     // write would clobber a newer one) — the serial/destroyed guards drop
-    // the stale write in both cases.
+    // the stale write in both cases. Every request in the chain is issued
+    // via safeRelease: replies drain while the connection is closing
+    // (app.close() pings before terminating), and a follow-up request from
+    // inside a reply callback would otherwise throw 'client is in closing
+    // state' from the stream read handler, where no user code can catch it.
     const serial = ++this._titleSerial;
-    X.InternAtom(false, '_NET_WM_NAME', (err, netWmName) => {
-      X.InternAtom(false, 'UTF8_STRING', (err2, utf8String) => {
-        if (err || err2 || this._destroyed || serial !== this._titleSerial) return;
+    safeRelease(X, () => {
+      X.InternAtom(false, '_NET_WM_NAME', (err, netWmName) => {
+        if (err) return;
         safeRelease(X, () => {
-          X.ChangeProperty(0, wid, netWmName, utf8String, 8, Buffer.from(title, 'utf8'));
+          X.InternAtom(false, 'UTF8_STRING', (err2, utf8String) => {
+            if (err2 || this._destroyed || serial !== this._titleSerial) return;
+            safeRelease(X, () => {
+              X.ChangeProperty(0, wid, netWmName, utf8String, 8, Buffer.from(title, 'utf8'));
+            });
+          });
         });
       });
     });
@@ -659,12 +670,22 @@ export default class Window extends Drawable {
   setActions() {
     const X = this.X;
     const wid = this.id;
-    X.InternAtom(false, 'WM_PROTOCOLS', (err, WM_PROTOCOLS) => {
-      X.InternAtom(false, 'WM_DELETE_WINDOW', (err2, WM_DELETE_WINDOW) => {
-        if (err || err2) return;
-        const data = Buffer.alloc(4);
-        data.writeUInt32LE(WM_DELETE_WINDOW, 0);
-        X.ChangeProperty(0, wid, WM_PROTOCOLS, X.atoms.ATOM, 32, data);
+    // same deferred-chain shape as setTitle: each step runs from a reply
+    // callback and must no-op instead of throwing if the connection
+    // started closing (or the window died) while the replies were in flight
+    safeRelease(X, () => {
+      X.InternAtom(false, 'WM_PROTOCOLS', (err, WM_PROTOCOLS) => {
+        if (err) return;
+        safeRelease(X, () => {
+          X.InternAtom(false, 'WM_DELETE_WINDOW', (err2, WM_DELETE_WINDOW) => {
+            if (err2 || this._destroyed) return;
+            const data = Buffer.alloc(4);
+            data.writeUInt32LE(WM_DELETE_WINDOW, 0);
+            safeRelease(X, () => {
+              X.ChangeProperty(0, wid, WM_PROTOCOLS, X.atoms.ATOM, 32, data);
+            });
+          });
+        });
       });
     });
   }

--- a/test/window-title-close-race.test.js
+++ b/test/window-title-close-race.test.js
@@ -1,0 +1,56 @@
+// Regression: setTitle() (and setActions()) issue follow-up requests from
+// InternAtom reply callbacks. app.close() sets the client's _closing flag
+// synchronously, then lets pending replies drain during its ping round-trip —
+// a follow-up request issued from one of those reply callbacks used to throw
+// 'client is in closing state' from inside the stream read handler, where no
+// user code can catch it (found by react-x11's integration tests). The
+// failure mode is an uncaught exception that takes down the process, so each
+// test's assertion is simply completing cleanly.
+//
+// Hermetic: in-process pure-JS X server, no $DISPLAY.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+async function freshApp() {
+  const server = createServer({ width: 320, height: 240 });
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+}
+
+// let any stray reply callbacks scheduled behind the close fire before the
+// test is declared done
+const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+test('closing the app right after setTitle does not crash', async () => {
+  const app = await freshApp();
+  const wnd = app.createWindow({ width: 50, height: 50, title: 'a' });
+  wnd.setTitle('updated'); // kicks off the InternAtom chain
+  await app.close(); // close before the replies drain
+  await settle();
+  assert.ok(wnd, 'survived the close with InternAtom replies in flight');
+});
+
+test('closing the app right after setActions does not crash', async () => {
+  const app = await freshApp();
+  const wnd = app.createWindow({ width: 50, height: 50 });
+  wnd.setActions(); // WM_PROTOCOLS / WM_DELETE_WINDOW InternAtom chain
+  await app.close();
+  await settle();
+  assert.ok(wnd, 'survived the close with InternAtom replies in flight');
+});
+
+test('setTitle on an already-closed app is a no-op, not a throw', async () => {
+  const app = await freshApp();
+  const wnd = app.createWindow({ width: 50, height: 50 });
+  await app.close();
+  wnd.setTitle('too late'); // must not throw synchronously either
+  await settle();
+  assert.ok(wnd);
+});


### PR DESCRIPTION
Fixes #62

## Problem

`setTitle()` and `setActions()` issue follow-up requests (a nested `InternAtom`, then `ChangeProperty`) from `InternAtom` reply callbacks. `X.close()` sets `_closing` synchronously and then lets pending replies drain during its ping round-trip — so in a short-lived app (`setTitle()` then `app.close()`) a reply arrives mid-close and the next request in the chain throws `Error: client is in closing state` (`req_proxy`, x11 `lib/xcore.js`) from inside the stream read handler: an uncaught async exception no user code can catch. Found by react-x11's integration tests against ntk 3.1.0.

Only the final `ChangeProperty` was wrapped in `safeRelease` (from #60's BadWindow fix); the `InternAtom` steps and the legacy `WM_NAME` write were not.

## Fix

- Wrap every step of the `setTitle()` deferred chain (`WM_NAME` `ChangeProperty`, both `InternAtom`s, `_NET_WM_NAME` `ChangeProperty`) in the existing `safeRelease` idiom so each no-ops cleanly when the connection is closing or gone. `safeRelease` already checks the same `_closing` flag `req_proxy` throws on, so no changes to `lib/cleanup.js` were needed.
- `setActions()` had the identical latent race (confirmed: the new test crashes on master) — same treatment, plus a `_destroyed` guard on the stale `WM_PROTOCOLS` write, mirroring `setTitle`.

## Tests

New `test/window-title-close-race.test.js` (hermetic in-process X server, no `$DISPLAY`, per-test apps since these tests close the connection):

- create window, `setTitle`, `await app.close()` immediately — completing without an uncaught exception is the assertion (the failure mode kills the process; all three tests crash on master)
- same for `setActions`
- `setTitle` on an already-closed app is a no-op rather than a synchronous throw

The `_NET_WM_NAME` happy-path round-trip (UTF8_STRING type, exact bytes, legacy `WM_NAME`) was already covered by `test/window-title.test.js` and still passes.

Full suite: 257/257 pass.