### PR TITLE
feat: mouse cursor support via the X11 cursor font

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -151,12 +151,54 @@ All return `this` unless noted.
   `cancelAnimationFrame(id)` (see above)
 - `createWindow(params)` — child window (`parent` preset to this window)
 - `createPixmap(params)` — pixmap defaulting to this window's size, depth 32
+- `setCursor(nameOrShapeId)` — mouse cursor shown over the window (see
+  [Cursor](#cursor) below); `setCursor(null)` restores the parent's cursor
 - `queryPointer(cb)`, `grabPointer()`, `setMouseHintOnly(isOn)`
 - `queryTree(cb)` — `cb(err, { parent, root, children })`, all as `Window`s
 - `reparentTo(newParent, x, y)`
 - `setActions()` — opt in to the WM_DELETE_WINDOW protocol (window manager
   sends a `message` event instead of killing the connection on close)
 - `destroy()` — destroy the window server-side (also `Symbol.dispose`)
+
+## Cursor
+
+`wnd.setCursor(name)` sets the mouse cursor shown while the pointer is over
+the window:
+
+```js
+input.setCursor('text'); // I-beam over a text input
+button.setCursor('pointer'); // hand over a button or link
+wnd.setCursor(null); // back to inheriting the parent's cursor
+```
+
+Cursors come from the standard X11 `cursor` font. Names are CSS-like and
+resolve to cursorfont.h glyph indices; a raw glyph index (any `XC_*`
+constant) is accepted too. Unknown names throw synchronously, listing the
+valid names. Created cursors are server-side resources, cached per
+connection on `app.cursors` and freed on `app.close()`.
+
+| name | cursor font glyph |
+|---|---|
+| `default`, `arrow` | `XC_left_ptr` (68) |
+| `text` | `XC_xterm` (152) |
+| `pointer`, `hand` | `XC_hand2` (60) |
+| `wait` | `XC_watch` (150) |
+| `move` | `XC_fleur` (52) |
+| `crosshair` | `XC_crosshair` (34) |
+| `ew-resize`, `col-resize` | `XC_sb_h_double_arrow` (108) |
+| `ns-resize`, `row-resize` | `XC_sb_v_double_arrow` (116) |
+| `nwse-resize` | `XC_bottom_right_corner` (14) |
+| `nesw-resize` | `XC_bottom_left_corner` (12) |
+| `grab` | `XC_hand1` (58) |
+| `help` | `XC_question_arrow` (92) |
+| `not-allowed` | `XC_X_cursor` (0) |
+
+`createWindow({ cursor })` still accepts a raw X cursor id at creation time;
+`app.cursors.get(name)` supplies one if you need it there:
+
+```js
+const wnd = app.createWindow({ width: 300, height: 200, cursor: app.cursors.get('crosshair') });
+```
 
 ## Events
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,3 +1,4 @@
+import { CursorCache } from './cursor.js';
 import Pixmap from './pixmap.js';
 import FontManager from './text/fontmanager.js';
 import Window from './window.js';
@@ -18,6 +19,7 @@ export default class App {
     this.X = display.client;
     this.options = options;
     this._fonts = null;
+    this._cursors = null;
     // node-x11 emits X errors it cannot route to a request callback as
     // 'error' on the client — from inside its packet parser. With no
     // listener that emit throws and the parser never re-arms, silently
@@ -36,6 +38,12 @@ export default class App {
     return this._fonts;
   }
 
+  /** per-connection cache of X11 cursor-font cursors (see lib/cursor.js) */
+  get cursors() {
+    if (!this._cursors) this._cursors = new CursorCache(this);
+    return this._cursors;
+  }
+
   createWindow(args) {
     return new Window(this, args);
   }
@@ -50,6 +58,10 @@ export default class App {
 
   // flush pending requests and close the connection
   close() {
+    if (this._cursors) {
+      this._cursors.dispose();
+      this._cursors = null;
+    }
     return new Promise((resolve) => this.X.close(resolve));
   }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1,0 +1,101 @@
+import { safeRelease } from './cleanup.js';
+
+// Friendly (CSS-cursor-ish) name -> glyph index in the standard X11 'cursor'
+// font (X11/cursorfont.h). Each cursor occupies two glyphs: the shape at the
+// even index and its mask at index + 1, which is why every value here is even.
+export const cursorShapes = {
+  default: 68, // XC_left_ptr
+  arrow: 68, // XC_left_ptr
+  text: 152, // XC_xterm
+  pointer: 60, // XC_hand2
+  hand: 60, // XC_hand2
+  wait: 150, // XC_watch
+  move: 52, // XC_fleur
+  crosshair: 34, // XC_crosshair
+  'ew-resize': 108, // XC_sb_h_double_arrow
+  'ns-resize': 116, // XC_sb_v_double_arrow
+  'nwse-resize': 14, // XC_bottom_right_corner
+  'nesw-resize': 12, // XC_bottom_left_corner
+  'col-resize': 108, // XC_sb_h_double_arrow
+  'row-resize': 116, // XC_sb_v_double_arrow
+  grab: 58, // XC_hand1
+  help: 92, // XC_question_arrow
+  'not-allowed': 0 // XC_X_cursor
+};
+
+/**
+ * Resolve a friendly cursor name (see `cursorShapes`) or a raw cursor-font
+ * glyph index to the glyph index. Throws on unknown names so typos surface
+ * immediately instead of silently keeping the old cursor.
+ */
+export function resolveCursorShape(nameOrShape) {
+  if (typeof nameOrShape === 'number') {
+    if (!Number.isInteger(nameOrShape) || nameOrShape < 0) {
+      throw new Error(`invalid cursor shape id: ${nameOrShape}`);
+    }
+    return nameOrShape;
+  }
+  const shape = cursorShapes[nameOrShape];
+  if (shape === undefined) {
+    throw new Error(
+      `unknown cursor name '${nameOrShape}' — valid names: ${Object.keys(cursorShapes).join(', ')}`
+    );
+  }
+  return shape;
+}
+
+/**
+ * Per-App cache of cursors created from the standard X11 'cursor' font.
+ * Cursors are server-side resources, so one is created per shape and reused
+ * for every window of the connection; `app.close()` disposes the cache.
+ * Accessed via `app.cursors` (lazily created) — user code normally never
+ * touches this directly, `wnd.setCursor(name)` goes through it.
+ */
+export class CursorCache {
+  constructor(app) {
+    this.X = app.X;
+    this._font = 0; // the 'cursor' font, opened on first use
+    this._byShape = new Map(); // glyph index -> cursor xid
+  }
+
+  /** cursor xid for a friendly name or raw glyph index, creating it on first use */
+  get(nameOrShape) {
+    const shape = resolveCursorShape(nameOrShape);
+    const cached = this._byShape.get(shape);
+    if (cached) return cached;
+
+    const X = this.X;
+    if (!this._font) {
+      this._font = X.AllocID();
+      X.OpenFont(this._font, 'cursor');
+    }
+    const cid = X.AllocID();
+    // per X convention the mask glyph follows the shape glyph in the cursor
+    // font; black foreground on white background (RGB is 16 bit per channel)
+    const black = { R: 0, G: 0, B: 0 };
+    const white = { R: 0xffff, G: 0xffff, B: 0xffff };
+    X.CreateGlyphCursor(cid, this._font, this._font, shape, shape + 1, black, white);
+    this._byShape.set(shape, cid);
+    return cid;
+  }
+
+  /** free the server-side cursors (and the font); safe to call repeatedly */
+  dispose() {
+    const X = this.X;
+    for (const cid of this._byShape.values()) {
+      safeRelease(X, () => {
+        X.FreeCursor(cid);
+        X.ReleaseID(cid);
+      });
+    }
+    this._byShape.clear();
+    if (this._font) {
+      const fid = this._font;
+      this._font = 0;
+      safeRelease(X, () => {
+        X.CloseFont(fid);
+        X.ReleaseID(fid);
+      });
+    }
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 import x11 from 'x11';
 
 import App from './app.js';
+import { CursorCache, cursorShapes, resolveCursorShape } from './cursor.js';
 import Window from './window.js';
 import Pixmap from './pixmap.js';
 import Picture from './picture.js';
@@ -99,6 +100,9 @@ export function createClient(options, callback) {
 export {
   App,
   Window,
+  CursorCache,
+  cursorShapes,
+  resolveCursorShape,
   Pixmap,
   Picture,
   Image,

--- a/lib/window.js
+++ b/lib/window.js
@@ -607,6 +607,22 @@ export default class Window extends Drawable {
     return this;
   }
 
+  /**
+   * Set the mouse cursor shown over this window. Accepts a friendly name
+   * ('text', 'pointer', 'wait', ... — see cursorShapes in lib/cursor.js and
+   * docs/window.md) or a raw X11 cursor-font glyph index. Cursors are
+   * created once per connection and cached on the app. `setCursor(null)`
+   * restores the parent window's cursor (X cursor = None). Throws
+   * synchronously on unknown names.
+   */
+  setCursor(nameOrShape) {
+    const cursor = nameOrShape == null ? 0 : this.app.cursors.get(nameOrShape);
+    safeRelease(this.X, () => {
+      this.X.ChangeWindowAttributes(this.id, { cursor }, () => {});
+    });
+    return this;
+  }
+
   setMouseHintOnly(isOn) {
     if (isOn && !(this.eventMask & x11.eventMask.PointerMotionHint)) {
       this.eventMask |= x11.eventMask.PointerMotionHint;

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -1,0 +1,115 @@
+// wnd.setCursor(name) creates a cursor from the standard X11 'cursor' font
+// (OpenFont + CreateGlyphCursor) and applies it via ChangeWindowAttributes.
+// Hermetic: runs against node-x11's in-process pure-JS X server and verifies
+// the results server-side through the server's resource table (the core
+// GetWindowAttributes reply has no cursor field, so the wire protocol offers
+// no readback; the server object is available here anyway).
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, cursorShapes, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+let server = null;
+let app = null;
+
+const connect = async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+};
+
+// X processes requests in order: once this cheap request has its reply,
+// everything issued before it has been executed by the server
+const roundtrip = (a) => new Promise((resolve, reject) => a.X.GetInputFocus((err) => (err ? reject(err) : resolve())));
+
+before(async () => {
+  server = createServer({ width: 320, height: 240 });
+  app = await connect();
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+test('setCursor(name) creates a cursor-font cursor and sets it on the window', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.setCursor('text');
+  const cid = app.cursors.get('text'); // cached: the same id setCursor used
+  await roundtrip(app);
+
+  const serverWin = server.resources.get(wnd.id);
+  assert.equal(serverWin.cursor, cid, 'window attribute points at the created cursor');
+
+  const cursor = server.resources.get(cid);
+  assert.equal(cursor.type, 'cursor');
+  assert.equal(cursor.sourceChar, cursorShapes.text, 'source glyph is the shape index');
+  assert.equal(cursor.maskChar, cursorShapes.text + 1, 'mask glyph is shape + 1');
+  assert.deepEqual(cursor.fore, [0, 0, 0], 'black foreground');
+  assert.deepEqual(cursor.back, [0xffff, 0xffff, 0xffff], 'white background');
+
+  const font = server.resources.get(cursor.sourceFont);
+  assert.equal(font.name, 'cursor', "glyphs come from the standard 'cursor' font");
+  assert.equal(cursor.maskFont, cursor.sourceFont, 'mask uses the same font');
+  wnd.destroy();
+});
+
+test('cursors are cached per connection, aliases share the shape', async () => {
+  assert.equal(app.cursors.get('text'), app.cursors.get('text'), 'same id for the same name');
+  assert.equal(app.cursors.get('pointer'), app.cursors.get('hand'), 'aliases resolve to one cursor');
+  assert.notEqual(app.cursors.get('default'), app.cursors.get('text'), 'distinct shapes get distinct cursors');
+  await roundtrip(app);
+});
+
+test('raw cursor-font glyph indices are accepted', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.setCursor(34); // XC_crosshair
+  await roundtrip(app);
+  const cursor = server.resources.get(server.resources.get(wnd.id).cursor);
+  assert.equal(cursor.sourceChar, 34);
+  assert.equal(cursor.maskChar, 35);
+  assert.equal(app.cursors.get('crosshair'), app.cursors.get(34), 'numeric and named lookups share the cache');
+  wnd.destroy();
+});
+
+test('setCursor(null) restores the parent cursor (None)', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.setCursor('wait');
+  await roundtrip(app);
+  assert.notEqual(server.resources.get(wnd.id).cursor, 0);
+  wnd.setCursor(null);
+  await roundtrip(app);
+  assert.equal(server.resources.get(wnd.id).cursor, 0, 'cursor attribute back to None');
+  wnd.destroy();
+});
+
+test('unknown cursor names throw synchronously and list the valid names', () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  assert.throws(() => wnd.setCursor('sideways'), (err) => {
+    assert.match(err.message, /unknown cursor name 'sideways'/);
+    for (const name of Object.keys(cursorShapes)) {
+      assert.ok(err.message.includes(name), `error lists '${name}'`);
+    }
+    return true;
+  });
+  wnd.destroy();
+});
+
+test('app.close() frees the cached cursors and the cursor font', async () => {
+  const app2 = await connect();
+  const cid = app2.cursors.get('move');
+  await roundtrip(app2);
+  const fontId = server.resources.get(cid).sourceFont;
+  assert.ok(server.resources.get(fontId), 'font resource exists while cached');
+
+  // dispose is what close() runs; exercise it with the connection still up
+  // so the FreeCursor/CloseFont requests are observable server-side
+  app2.cursors.dispose();
+  await roundtrip(app2);
+  assert.equal(server.resources.get(cid), undefined, 'cursor freed');
+  assert.equal(server.resources.get(fontId), undefined, 'font closed');
+  await app2.close();
+});


### PR DESCRIPTION
Fixes #65

Adds pointer feedback for downstream widget code (react-x11: I-beam over inputs, hand over buttons/links, resize arrows, watch during long operations).

## What

- **`lib/cursor.js`** — creates cursors from the standard X11 `cursor` font: `OpenFont('cursor')` + `CreateGlyphCursor` with source glyph = shape index and mask glyph = shape + 1 (the X convention), black foreground / white background. `CursorCache` caches one cursor per shape per connection (they are server-side resources) and `dispose()` frees them (`FreeCursor` + `CloseFont` via the existing `safeRelease` pattern).
- **`App`** — lazy `app.cursors` getter (mirrors `app.fonts`); `app.close()` disposes the cache before closing.
- **`Window.setCursor(nameOrShapeId)`** — resolves through `app.cursors`, then `ChangeWindowAttributes { cursor }`. `setCursor(null)` restores the parent's cursor (cursor = None). Unknown names throw synchronously listing the valid names. The existing `createWindow({ cursor })` attribute forwarding (#56) is untouched and composes: `app.cursors.get(name)` supplies a raw id for it.
- **Exports** — `cursorShapes`, `resolveCursorShape`, `CursorCache` from `lib/index.js`.
- **Docs** — new Cursor section in `docs/window.md` with the name table.

## Name map (cursorfont.h glyph indices)

| name | glyph |
|---|---|
| `default`, `arrow` | XC_left_ptr (68) |
| `text` | XC_xterm (152) |
| `pointer`, `hand` | XC_hand2 (60) |
| `wait` | XC_watch (150) |
| `move` | XC_fleur (52) |
| `crosshair` | XC_crosshair (34) |
| `ew-resize`, `col-resize` | XC_sb_h_double_arrow (108) |
| `ns-resize`, `row-resize` | XC_sb_v_double_arrow (116) |
| `nwse-resize` | XC_bottom_right_corner (14) |
| `nesw-resize` | XC_bottom_left_corner (12) |
| `grab` | XC_hand1 (58) |
| `help` | XC_question_arrow (92) |
| `not-allowed` | XC_X_cursor (0) |

## Testing

`test/cursor.test.js` runs hermetically against node-x11's in-process X server, which already implements OpenFont, CreateGlyphCursor, FreeCursor, CloseFont and the `cursor` window attribute — no node-x11 changes were needed. The core GetWindowAttributes reply has no cursor field (protocol limitation), so assertions read the server's resource table directly: created cursor glyphs/colors/font, the window's cursor attribute, cache identity (aliases share one cursor), None restore, the unknown-name error, and that dispose actually frees the cursor and font server-side.

Full suite: 263 pass, 0 fail.