### PR TITLE
feat: clipboard/selection API (app.clipboard.read/write)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ lib/window.js              Window (extends Drawable): events, geometry, WM bits
 lib/pixmap.js              offscreen drawable
 lib/drawable.js            EventEmitter base + getContext() registry
 lib/events_map.js          X event code <-> browser-ish event name tables
+lib/clipboard.js           app.clipboard: ICCCM selection/clipboard text
+                           transfer (CLIPBOARD/PRIMARY, INCR-aware reads)
 lib/renderingcontext_2d.js canvas-like context (XRender); CanvasGradient
 lib/path.js                Path2D, SVG path-data parser, affine matrices,
                            adaptive bezier flattening

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ matching file here (see AGENTS.md).
 - [Window](window.md) — window creation, properties, methods, events,
   frame pacing / event coalescing, `requestAnimationFrame`
 - [Pixmap](pixmap.md) — offscreen drawables
+- [Clipboard](clipboard.md) — `app.clipboard.write()/read()`: text transfer
+  over the CLIPBOARD/PRIMARY selections (ICCCM), INCR-aware reads
 - [2d rendering context](context-2d.md) — canvas-like drawing API over XRender
 - [Images](images.md) — PNG/JPEG loading (`loadImage`), the `Image` object,
   `drawImage`

--- a/docs/app.md
+++ b/docs/app.md
@@ -33,6 +33,9 @@ const app2 = await createClient({ display: ':1' });
 
 - `app.display` — the node-x11 display object (`screen`, `Render`, `GLX`, …)
 - `app.X` — the raw node-x11 client, for direct protocol requests
+- `app.fonts` — lazy [FontManager](fonts.md): font matching/loading, shaping
+- `app.clipboard` — lazy [Clipboard](clipboard.md): selection/clipboard
+  text transfer (`write()`/`read()`)
 
 ## Methods
 

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -1,0 +1,76 @@
+# Clipboard
+
+`app.clipboard` transfers plain text between X clients through selections —
+lazily created on first use, like `app.fonts`.
+
+X has no clipboard buffer: "copy" means owning a **selection** (the
+`CLIPBOARD` atom for explicit copy/paste, `PRIMARY` for middle-click paste)
+and answering conversion requests from whichever client pastes; "paste"
+means asking the current owner to convert its data into a property and
+reading it back. `app.clipboard` hides that ICCCM dance behind two
+promises, using a hidden 1×1 never-mapped helper window as the selection
+endpoint.
+
+```js
+import { createClient } from 'ntk';
+const app = await createClient();
+
+await app.clipboard.write('Hello, κόσμε!');
+const text = await app.clipboard.read(); // from whoever owns CLIPBOARD now
+```
+
+## `app.clipboard.write(text, [options]) → Promise`
+
+Takes ownership of a selection and serves `text` to anyone who pastes.
+
+- `options.selection` — selection atom name, default `'CLIPBOARD'`; use
+  `'PRIMARY'` for the middle-click paste buffer.
+- Resolves once the server confirms the ownership; rejects if it could not
+  be acquired.
+- Ownership (and the text) is held until another client copies — the
+  server's `SelectionClear` then drops the stored text — or the app closes.
+  The text lives in this process: unlike desktops with a clipboard manager,
+  closing the app makes the selection unavailable, which is normal X
+  behavior.
+
+Requestors are offered the targets `TARGETS`, `UTF8_STRING` and `STRING`
+(latin-1, best effort — codepoints above U+00FF are lossy). Anything else
+(`MULTIPLE`, `TIMESTAMP`, images, …) is refused with a `SelectionNotify`
+carrying property `None`, as ICCCM prescribes.
+
+## `app.clipboard.read([options]) → Promise<string>`
+
+Reads the current text of a selection from whoever owns it.
+
+- `options.selection` — as above, default `'CLIPBOARD'`.
+- `options.timeout` — ms to wait for the owner at each protocol step,
+  default 2000.
+- Conversion is requested as `UTF8_STRING` first; if the owner refuses
+  (old Xt/Motif apps), it is retried once as latin-1 `STRING`.
+- Incremental (`INCR`) transfers are followed transparently, so pasting
+  data larger than the server's single-transfer limit works.
+- Rejects with a descriptive error when the selection has no owner, when
+  the owner supports neither text target, or when the owner stops
+  responding within `timeout`.
+
+Concurrent `read()` calls on one app are serialized internally (they share
+one transfer property on the helper window).
+
+## Limitations
+
+- Text only — no image or rich-content targets (yet).
+- `INCR` is not implemented on the **write** side: when another client
+  pastes, the whole payload goes to the server in a single `ChangeProperty`
+  request. Texts approaching the server's maximum request length (~256 KB
+  without BIG-REQUESTS, which node-x11 does not negotiate) may fail to
+  paste into other applications.
+- `SetSelectionOwner` is issued with `CurrentTime` — ntk has no "last user
+  input" timestamp to arbitrate ownership races with.
+
+## Testing without a display
+
+The whole protocol runs against node-x11's in-process JS X server (which
+routes `SetSelectionOwner` / `ConvertSelection` / `SendEvent` since x11
+3.1.0) — see [xserver.md](xserver.md) and `test/clipboard.test.js`, where
+two ntk clients and raw node-x11 clients (a `STRING`-only legacy owner, an
+`INCR` owner) pass text to each other hermetically.

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,3 +1,4 @@
+import Clipboard from './clipboard.js';
 import Pixmap from './pixmap.js';
 import FontManager from './text/fontmanager.js';
 import Window from './window.js';
@@ -18,6 +19,7 @@ export default class App {
     this.X = display.client;
     this.options = options;
     this._fonts = null;
+    this._clipboard = null;
     // node-x11 emits X errors it cannot route to a request callback as
     // 'error' on the client — from inside its packet parser. With no
     // listener that emit throws and the parser never re-arms, silently
@@ -34,6 +36,12 @@ export default class App {
   get fonts() {
     if (!this._fonts) this._fonts = new FontManager({ source: this.options.fontSource });
     return this._fonts;
+  }
+
+  /** selection/clipboard transfer: write()/read() text (docs/clipboard.md) */
+  get clipboard() {
+    if (!this._clipboard) this._clipboard = new Clipboard(this);
+    return this._clipboard;
   }
 
   createWindow(args) {

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -1,0 +1,317 @@
+import x11 from 'x11';
+
+import { safeRelease } from './cleanup.js';
+
+// Clipboard (app.clipboard): ICCCM selection transfer for plain text.
+//
+// X has no clipboard buffer — "copy" means owning a selection atom
+// (CLIPBOARD for explicit copy/paste, PRIMARY for middle-click paste) and
+// answering conversion requests from whoever pastes; "paste" means asking
+// the current owner to convert into a property on one of our windows. This
+// module hides that dance behind write()/read() promises, using a hidden
+// 1x1 never-mapped helper window as the selection endpoint.
+//
+// Supported targets when ntk owns a selection: TARGETS, UTF8_STRING and
+// STRING (latin-1, best effort). Everything else — MULTIPLE, TIMESTAMP,
+// images — is refused with SelectionNotify property None per ICCCM.
+//
+// Reads prefer UTF8_STRING and retry once with STRING when the owner
+// refuses (old Xt/Motif apps). Incremental (INCR) transfers are supported
+// on the read side, so pasting more than the server's transfer limit works.
+//
+// LIMITATION: INCR is NOT implemented on the write side — write() hands the
+// whole payload to the server in a single ChangeProperty when a requestor
+// converts. Texts approaching the server's maximum request length (~256KB
+// on servers without BIG-REQUESTS, node-x11 does not negotiate it) may fail
+// to paste into other applications.
+
+const DEFAULT_TIMEOUT = 2000;
+
+// SendEvent takes the raw 32-byte wire form of the event to deliver and
+// node-x11 has no packer for outgoing events, so build SelectionNotify
+// (code 31) by hand: CARD8 code, pad, CARD16 sequence (filled server-side),
+// TIMESTAMP, requestor WINDOW, then selection/target/property ATOMs.
+function encodeSelectionNotify(time, requestor, selection, target, property) {
+  const b = Buffer.alloc(32);
+  b[0] = 31;
+  b.writeUInt32LE(time >>> 0, 4);
+  b.writeUInt32LE(requestor >>> 0, 8);
+  b.writeUInt32LE(selection >>> 0, 12);
+  b.writeUInt32LE(target >>> 0, 16);
+  b.writeUInt32LE(property >>> 0, 20);
+  return b;
+}
+
+export default class Clipboard {
+  constructor(app) {
+    this.app = app;
+    this.X = app.X;
+    this._window = null; // hidden helper window, created on first use
+    this._owned = new Map(); // selection atom -> text we serve
+    this._atoms = null; // { TARGETS, UTF8_STRING, INCR }
+    this._transferProp = null; // property reads are converted into
+    this._ready = null;
+    this._readQueue = Promise.resolve();
+    this._onXEvent = this._onXEvent.bind(this);
+  }
+
+  /**
+   * Take ownership of a selection and serve `text` to anyone who pastes.
+   * Resolves once the server confirms the ownership; ownership (and the
+   * text) is held until another client copies or the app closes.
+   *
+   * @param {string} text
+   * @param {object} [options] { selection: 'CLIPBOARD' (default) or
+   *   'PRIMARY' (middle-click paste) — any selection atom name works }
+   * @returns {Promise<void>}
+   */
+  async write(text, { selection = 'CLIPBOARD' } = {}) {
+    await this._ensure();
+    const sel = await this._atom(selection);
+    this._owned.set(sel, String(text));
+    // time 0 = CurrentTime: best effort — ntk has no "last user input"
+    // timestamp to arbitrate ownership races with (ICCCM prefers one)
+    this.X.SetSelectionOwner(this._window.id, sel, 0);
+    // SetSelectionOwner is void: confirm via GetSelectionOwner that the
+    // server actually made us the owner
+    const owner = await new Promise((resolve, reject) =>
+      this.X.GetSelectionOwner(sel, (err, wid) => (err ? reject(err) : resolve(wid)))
+    );
+    if (owner !== this._window.id) {
+      this._owned.delete(sel);
+      throw new Error(`clipboard: failed to acquire ${selection} selection ownership`);
+    }
+  }
+
+  /**
+   * Read the current text of a selection from whoever owns it.
+   * Rejects when the selection has no owner, when the owner supports
+   * neither UTF8_STRING nor STRING, or when the owner stops responding
+   * (`timeout` ms, default 2000).
+   *
+   * @param {object} [options] { selection: 'CLIPBOARD' | 'PRIMARY' | ...,
+   *   timeout: ms to wait for the owner at each protocol step }
+   * @returns {Promise<string>}
+   */
+  read({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT } = {}) {
+    // serialize: concurrent reads would share the one transfer property on
+    // the helper window, so let each conversion finish before the next
+    const run = () => this._read(selection, timeout);
+    const result = this._readQueue.then(run, run);
+    this._readQueue = result.catch(() => {});
+    return result;
+  }
+
+  async _read(selection, timeout) {
+    await this._ensure();
+    const X = this.X;
+    const sel = await this._atom(selection);
+    const prop = this._transferProp;
+
+    let notify = await this._convert(sel, this._atoms.UTF8_STRING, prop, selection, timeout);
+    if (notify.property === 0) {
+      // property None: no owner, or the owner refused UTF8_STRING (old
+      // Xt/Motif apps) — ask again for latin-1 STRING before giving up
+      notify = await this._convert(sel, X.atoms.STRING, prop, selection, timeout);
+    }
+    if (notify.property === 0) {
+      const owner = await new Promise((resolve, reject) =>
+        X.GetSelectionOwner(sel, (err, wid) => (err ? reject(err) : resolve(wid)))
+      );
+      throw new Error(
+        owner
+          ? `clipboard: ${selection} selection owner refused both UTF8_STRING and STRING targets`
+          : `clipboard: nothing to paste — ${selection} selection has no owner`
+      );
+    }
+    const { type, data } = await this._fetchProperty(prop, selection, timeout);
+    return data.toString(type === X.atoms.STRING ? 'latin1' : 'utf8');
+  }
+
+  // lazily create the helper window, resolve atoms, hook selection events
+  _ensure() {
+    if (this._ready) return this._ready;
+    this._ready = (async () => {
+      // 1x1 and never mapped: selection ownership and transfer properties
+      // need a window id, not visible pixels. PropertyChange is in the
+      // creation mask so INCR chunk notifications arrive without a later
+      // ChangeWindowAttributes round-trip.
+      this._window = this.app.createWindow({
+        width: 1,
+        height: 1,
+        eventMask: x11.eventMask.PropertyChange
+      });
+      const [TARGETS, UTF8_STRING, INCR, transferProp] = await Promise.all([
+        this._atom('TARGETS'),
+        this._atom('UTF8_STRING'),
+        this._atom('INCR'),
+        this._atom('NTK_SELECTION')
+      ]);
+      this._atoms = { TARGETS, UTF8_STRING, INCR };
+      this._transferProp = transferProp;
+      // SelectionRequest/SelectionClear carry the owner in ev.owner, not
+      // ev.wid, so node-x11's event_consumers routing (keyed on ev.wid)
+      // never delivers them to the Window wrapper — listen on the raw
+      // client instead
+      this.X.on('event', this._onXEvent);
+    })();
+    return this._ready;
+  }
+
+  _atom(name) {
+    // predefined atoms (PRIMARY = 1, STRING = 31, ...) resolve without a
+    // round-trip; node-x11 caches interned ones after the first reply
+    return new Promise((resolve, reject) =>
+      this.X.InternAtom(false, name, (err, atom) => (err ? reject(err) : resolve(atom)))
+    );
+  }
+
+  _onXEvent(ev) {
+    if (!this._window || (ev.type !== 29 && ev.type !== 30)) return;
+    if (ev.owner !== this._window.id) return;
+    if (ev.type === 29) {
+      // SelectionClear: another client copied — we no longer answer for it
+      this._owned.delete(ev.selection);
+    } else {
+      this._onSelectionRequest(ev);
+    }
+  }
+
+  // we own the selection and somebody is pasting: write the converted data
+  // to the requestor's property and confirm (or refuse) via SelectionNotify
+  _onSelectionRequest(ev) {
+    const X = this.X;
+    const a = this._atoms;
+    const text = this._owned.get(ev.selection);
+    // obsolete requestors may pass property None — ICCCM says use the
+    // target atom as the property name then
+    let property = ev.property || ev.target;
+    // the whole answer runs from the packet parser's emit: if the
+    // connection is closing, drop it instead of throwing (see cleanup.js)
+    safeRelease(X, () => {
+      if (text === undefined) {
+        property = 0; // raced with a SelectionClear we haven't seen yet
+      } else if (ev.target === a.TARGETS) {
+        const data = Buffer.alloc(12);
+        data.writeUInt32LE(a.TARGETS, 0);
+        data.writeUInt32LE(a.UTF8_STRING, 4);
+        data.writeUInt32LE(X.atoms.STRING, 8);
+        X.ChangeProperty(0, ev.requestor, property, X.atoms.ATOM, 32, data);
+      } else if (ev.target === a.UTF8_STRING) {
+        X.ChangeProperty(0, ev.requestor, property, a.UTF8_STRING, 8, Buffer.from(text, 'utf8'));
+      } else if (ev.target === X.atoms.STRING) {
+        // latin-1 best effort: codepoints above U+00FF are lossy here;
+        // modern requestors ask for UTF8_STRING
+        X.ChangeProperty(0, ev.requestor, property, X.atoms.STRING, 8, Buffer.from(text, 'latin1'));
+      } else {
+        // unsupported target (MULTIPLE, TIMESTAMP, images, ...): refuse
+        // with property None per ICCCM
+        property = 0;
+      }
+      X.SendEvent(
+        ev.requestor,
+        0,
+        0,
+        encodeSelectionNotify(ev.time, ev.requestor, ev.selection, ev.target, property)
+      );
+    });
+  }
+
+  // ConvertSelection and wait for the owner's SelectionNotify answer
+  _convert(sel, target, prop, selectionName, timeout) {
+    return new Promise((resolve, reject) => {
+      const X = this.X;
+      const wid = this._window.id;
+      const onEvent = (ev) => {
+        if (ev.type !== 31 || ev.requestor !== wid || ev.selection !== sel) return;
+        cleanup();
+        resolve(ev);
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `clipboard: timed out after ${timeout}ms waiting for the ${selectionName} selection owner to convert`
+          )
+        );
+      }, timeout);
+      const cleanup = () => {
+        clearTimeout(timer);
+        X.removeListener('event', onEvent);
+      };
+      X.on('event', onEvent);
+      X.ConvertSelection(wid, sel, target, prop, 0);
+    });
+  }
+
+  _getProperty(prop) {
+    // delete=true: for plain transfers frees the property; for INCR chunks
+    // it doubles as the "send the next chunk" handshake
+    return new Promise((resolve, reject) =>
+      this.X.GetProperty(1, this._window.id, prop, 0, 0, 0x1fffffff, (err, res) =>
+        err ? reject(err) : resolve(res)
+      )
+    );
+  }
+
+  // read the converted property, following the INCR protocol when the
+  // owner chose an incremental transfer
+  async _fetchProperty(prop, selectionName, timeout) {
+    // collect NewValue notifications from here on: with INCR the owner's
+    // next chunk lands as soon as we delete the previous property, possibly
+    // before an await below resumes — a listener installed later would
+    // miss it. The helper window gets 'property' events through the normal
+    // pipeline (PropertyNotify carries ev.wid).
+    const queue = [];
+    let waiter = null;
+    const onProperty = (ev) => {
+      if (ev.atom !== prop || ev.state !== 0) return; // 0 = NewValue
+      if (waiter) {
+        const w = waiter;
+        waiter = null;
+        w(ev);
+      } else {
+        queue.push(ev);
+      }
+    };
+    this._window.on('property', onProperty);
+
+    const nextChunkNotify = () =>
+      new Promise((resolve, reject) => {
+        if (queue.length) return resolve(queue.shift());
+        const timer = setTimeout(() => {
+          waiter = null;
+          reject(
+            new Error(
+              `clipboard: INCR transfer of ${selectionName} selection stalled (no chunk within ${timeout}ms)`
+            )
+          );
+        }, timeout);
+        waiter = (ev) => {
+          clearTimeout(timer);
+          resolve(ev);
+        };
+      });
+
+    try {
+      const first = await this._getProperty(prop);
+      if (first.type !== this._atoms.INCR) return first;
+      // INCR (ICCCM 2.7.2): the property held a lower-bound byte count and
+      // our delete-on-read told the owner to start. Each chunk arrives as
+      // a NewValue PropertyNotify; reading it with delete=true requests
+      // the next one; a zero-length chunk ends the transfer.
+      const chunks = [];
+      let type = 0;
+      for (;;) {
+        await nextChunkNotify();
+        const part = await this._getProperty(prop);
+        if (part.data.length === 0) break;
+        type = part.type;
+        chunks.push(part.data);
+      }
+      return { type, data: Buffer.concat(chunks) };
+    } finally {
+      this._window.removeListener('property', onProperty);
+    }
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 import x11 from 'x11';
 
 import App from './app.js';
+import Clipboard from './clipboard.js';
 import Window from './window.js';
 import Pixmap from './pixmap.js';
 import Picture from './picture.js';
@@ -98,6 +99,7 @@ export function createClient(options, callback) {
 
 export {
   App,
+  Clipboard,
   Window,
   Pixmap,
   Picture,

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -1,0 +1,215 @@
+// Clipboard/selection transfer, fully hermetic: several clients connect to
+// node-x11's in-process X server (which routes SetSelectionOwner /
+// ConvertSelection / SendEvent since x11 3.1.0) and pass text between each
+// other exactly like separate processes would on a real display. Raw
+// node-x11 clients play the "foreign application" roles: a STRING-only
+// legacy owner, an INCR owner, a TARGETS requestor.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import x11 from 'x11';
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+let server = null;
+let writer = null; // ntk app that copies
+let reader = null; // ntk app that pastes
+let raw = null; // plain node-x11 display for foreign-app roles
+
+const connect = () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd });
+};
+
+before(async () => {
+  server = createServer({ width: 320, height: 240 });
+  writer = await connect();
+  reader = await connect();
+  raw = (await connect()).display;
+});
+
+after(async () => {
+  if (writer) await writer.close();
+  if (reader) await reader.close();
+  if (raw) await new Promise((resolve) => raw.client.close(resolve));
+});
+
+const atom = (X, name) =>
+  new Promise((resolve, reject) =>
+    X.InternAtom(false, name, (err, a) => (err ? reject(err) : resolve(a)))
+  );
+
+const getProperty = (X, wid, prop, del = 1) =>
+  new Promise((resolve, reject) =>
+    X.GetProperty(del, wid, prop, 0, 0, 0x1fffffff, (err, res) => (err ? reject(err) : resolve(res)))
+  );
+
+// the raw 32-byte SelectionNotify for SendEvent (same shape lib/clipboard.js builds)
+const selectionNotify = (time, requestor, selection, target, property) => {
+  const b = Buffer.alloc(32);
+  b[0] = 31;
+  b.writeUInt32LE(time >>> 0, 4);
+  b.writeUInt32LE(requestor >>> 0, 8);
+  b.writeUInt32LE(selection >>> 0, 12);
+  b.writeUInt32LE(target >>> 0, 16);
+  b.writeUInt32LE(property >>> 0, 20);
+  return b;
+};
+
+const rawWindow = (display) => {
+  const X = display.client;
+  const wid = X.AllocID();
+  X.CreateWindow(wid, display.screen[0].root, 0, 0, 1, 1, 0, 0, 0, 0, {});
+  return wid;
+};
+
+test('round-trip between two clients, including non-ASCII UTF-8', async () => {
+  const text = 'Hello, κόσμε! 🎉 — ntk';
+  await writer.clipboard.write(text);
+  assert.equal(await reader.clipboard.read(), text);
+});
+
+test('round-trip on the same connection (self paste)', async () => {
+  await writer.clipboard.write('self');
+  assert.equal(await writer.clipboard.read(), 'self');
+});
+
+test('empty string round-trips as empty, not an error', async () => {
+  await writer.clipboard.write('');
+  assert.equal(await reader.clipboard.read(), '');
+});
+
+test('PRIMARY is independent of CLIPBOARD', async () => {
+  await writer.clipboard.write('for ctrl-v');
+  await writer.clipboard.write('for middle click', { selection: 'PRIMARY' });
+  assert.equal(await reader.clipboard.read({ selection: 'PRIMARY' }), 'for middle click');
+  assert.equal(await reader.clipboard.read(), 'for ctrl-v');
+});
+
+test('read with no owner rejects with a descriptive error', async () => {
+  await assert.rejects(
+    reader.clipboard.read({ selection: 'NTK_TEST_UNOWNED' }),
+    /no owner/
+  );
+});
+
+test('ownership handover: last writer wins, loser forgets its text', async () => {
+  await writer.clipboard.write('older');
+  await reader.clipboard.write('newer');
+  assert.equal(await writer.clipboard.read(), 'newer');
+  // the server told the previous owner via SelectionClear; give the
+  // notification a beat to land on the writer's connection
+  const clipboardAtom = await atom(writer.X, 'CLIPBOARD');
+  for (let i = 0; i < 50 && writer.clipboard._owned.has(clipboardAtom); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(writer.clipboard._owned.has(clipboardAtom), false);
+});
+
+test('TARGETS lists [TARGETS, UTF8_STRING, STRING]; unknown targets are refused', async () => {
+  await writer.clipboard.write('anything');
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [CLIPBOARD, TARGETS, UTF8_STRING, PROP, PNG] = await Promise.all(
+    ['CLIPBOARD', 'TARGETS', 'UTF8_STRING', 'NTK_TEST_PROP', 'image/png'].map((n) => atom(X, n))
+  );
+
+  const convert = (target) =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('no SelectionNotify')), 2000);
+      const onEvent = (ev) => {
+        if (ev.type !== 31 || ev.requestor !== wid) return;
+        clearTimeout(timer);
+        X.removeListener('event', onEvent);
+        resolve(ev);
+      };
+      X.on('event', onEvent);
+      X.ConvertSelection(wid, CLIPBOARD, target, PROP, 0);
+    });
+
+  const targetsReply = await convert(TARGETS);
+  assert.equal(targetsReply.property, PROP, 'TARGETS conversion succeeds');
+  const prop = await getProperty(X, wid, PROP);
+  assert.equal(prop.type, X.atoms.ATOM);
+  const offered = [0, 4, 8].map((o) => prop.data.readUInt32LE(o));
+  assert.deepEqual(offered, [TARGETS, UTF8_STRING, X.atoms.STRING]);
+
+  const refused = await convert(PNG);
+  assert.equal(refused.property, 0, 'unsupported target refused with property None');
+});
+
+test('falls back to STRING when the owner refuses UTF8_STRING', async () => {
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [SELECTION, UTF8_STRING] = await Promise.all(
+    ['NTK_TEST_LEGACY', 'UTF8_STRING'].map((n) => atom(X, n))
+  );
+
+  // legacy owner: STRING only, latin-1 payload
+  const onRequest = (ev) => {
+    if (ev.type !== 30 || ev.owner !== wid) return;
+    let property = ev.property;
+    if (ev.target === X.atoms.STRING) {
+      X.ChangeProperty(0, ev.requestor, property, X.atoms.STRING, 8, Buffer.from('caf\xe9', 'latin1'));
+    } else {
+      property = 0;
+    }
+    X.SendEvent(ev.requestor, 0, 0, selectionNotify(ev.time, ev.requestor, ev.selection, ev.target, property));
+  };
+  X.on('event', onRequest);
+  X.SetSelectionOwner(wid, SELECTION, 0);
+  try {
+    assert.notEqual(UTF8_STRING, 0, 'UTF8_STRING atom interned');
+    assert.equal(await reader.clipboard.read({ selection: 'NTK_TEST_LEGACY' }), 'café');
+  } finally {
+    X.removeListener('event', onRequest);
+  }
+});
+
+test('INCR transfer reassembles chunks split mid-codepoint', async () => {
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [SELECTION, UTF8_STRING, INCR] = await Promise.all(
+    ['NTK_TEST_INCR', 'UTF8_STRING', 'INCR'].map((n) => atom(X, n))
+  );
+
+  const text = `${'x'.repeat(1000)}κόσμος🎉${'y'.repeat(1000)}`;
+  const payload = Buffer.from(text, 'utf8');
+  // deliberately split inside multibyte sequences: decode must only happen
+  // after reassembly
+  const chunks = [payload.subarray(0, 1001), payload.subarray(1001, 1010), payload.subarray(1010)];
+
+  const onEvent = (ev) => {
+    if (ev.type === 30 && ev.owner === wid) {
+      if (ev.target !== UTF8_STRING) {
+        X.SendEvent(ev.requestor, 0, 0, selectionNotify(ev.time, ev.requestor, ev.selection, ev.target, 0));
+        return;
+      }
+      // announce INCR: property holds a lower-bound byte count; watch the
+      // requestor's property deletions to pace the chunks
+      X.ChangeWindowAttributes(ev.requestor, { eventMask: x11.eventMask.PropertyChange }, () => {});
+      const size = Buffer.alloc(4);
+      size.writeUInt32LE(payload.length, 0);
+      X.ChangeProperty(0, ev.requestor, ev.property, INCR, 32, size);
+      X.SendEvent(ev.requestor, 0, 0, selectionNotify(ev.time, ev.requestor, ev.selection, ev.target, ev.property));
+      onEvent.pending = [...chunks, Buffer.alloc(0)];
+      onEvent.transfer = { requestor: ev.requestor, property: ev.property };
+    } else if (ev.type === 28 && onEvent.transfer && ev.wid === onEvent.transfer.requestor && ev.state === 1) {
+      // requestor consumed (deleted) the previous value: send the next
+      // chunk; the zero-length one ends the transfer
+      if (ev.atom !== onEvent.transfer.property || !onEvent.pending.length) return;
+      X.ChangeProperty(0, onEvent.transfer.requestor, onEvent.transfer.property, UTF8_STRING, 8, onEvent.pending.shift());
+    }
+  };
+  X.on('event', onEvent);
+  X.SetSelectionOwner(wid, SELECTION, 0);
+  try {
+    assert.equal(await reader.clipboard.read({ selection: 'NTK_TEST_INCR' }), text);
+  } finally {
+    X.removeListener('event', onEvent);
+  }
+});


### PR DESCRIPTION
Fixes #66

react-x11's upcoming `<textinput>` widget needs copy/paste; this adds the missing selection plumbing to ntk so downstream users don't have to hand-roll the ICCCM dance.

## What

New `lib/clipboard.js` behind a lazy `app.clipboard` getter (same pattern as `app.fonts`), exported from `lib/index.js`. A hidden 1x1 never-mapped helper window is created on first use as the selection endpoint.

- **`app.clipboard.write(text, { selection = 'CLIPBOARD' })`** — SetSelectionOwner (verified via GetSelectionOwner), then answers `SelectionRequest`s: `TARGETS` → `[TARGETS, UTF8_STRING, STRING]`, `UTF8_STRING` → UTF-8 bytes, `STRING` → latin-1 best effort; any other target is refused with a `SelectionNotify` carrying property None per ICCCM. `SelectionClear` (another client copied) drops the stored text. `'PRIMARY'` works via the option.
- **`app.clipboard.read({ selection = 'CLIPBOARD', timeout = 2000 })`** — ConvertSelection into a property on the helper window, awaits `SelectionNotify`, GetProperty with delete. Asks for `UTF8_STRING` first and retries once with `STRING` when refused (old Xt/Motif apps); rejects with descriptive errors for no-owner, both-targets-refused, and owner timeout. **INCR transfers are followed on the read side** (chunk loop paced by property deletion, reassembled before decoding). Concurrent reads are serialized (they share one transfer property).

Protocol notes baked into the code comments:

- Selection events carry `owner`/`requestor` instead of a `wid`, so node-x11's `event_consumers` routing never delivers them to a `Window` wrapper — the module listens on the raw client. `PropertyNotify` does carry `wid`, so INCR chunk notifications ride the normal window event pipeline.
- The `SelectionNotify` reply to a `SelectionRequest` is a `SendEvent` of a hand-built 32-byte event buffer (node-x11 has no outgoing-event packer).
- Requestors passing property None get the target atom as the property name, per ICCCM's obsolete-client rule.

## Known limitation

INCR is **not** implemented on the write side: when another client pastes, the whole payload goes out in a single `ChangeProperty`. Texts approaching the server's max request length (~256KB without BIG-REQUESTS, which node-x11 does not negotiate) may fail to paste into other apps. Documented prominently in the module header and docs/clipboard.md.

## Tests

`test/clipboard.test.js` is fully hermetic against node-x11's in-process X server (which routes SetSelectionOwner/ConvertSelection/SendEvent since x11 3.1.0 — no node-x11 changes needed): two ntk apps plus raw node-x11 clients playing foreign-application roles.

- ntk↔ntk round-trip incl. non-ASCII/astral UTF-8, self-paste, empty string
- PRIMARY independent of CLIPBOARD
- no-owner read rejects descriptively
- ownership handover: last writer wins, previous owner forgets its text on SelectionClear
- raw requestor: TARGETS list contents, unknown target (`image/png`) refused with property None
- raw STRING-only legacy owner: UTF8_STRING refusal triggers the latin-1 fallback
- raw INCR owner: chunks deliberately split mid-codepoint reassemble correctly

`npm test`: 266 pass, 0 fail.

## Docs

New docs/clipboard.md (indexed in docs/README.md, picked up by the website's autogenerated sidebar), `app.clipboard`/`app.fonts` listed in docs/app.md, AGENTS.md layout table updated.