### PR TITLE
feat(text): caret positioning and hit-testing API on TextLayout

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -192,14 +192,67 @@ app.fonts.layout([
 ```
 
 Results are inspectable before drawing: `layout.width`, `layout.height`,
-`layout.lines[] = { x, y, baseline, width, ascent, descent, runs }` where
-`runs[] = { x, width, run, span }` in visual order. `layout.draw(ctx, x, y)`
-draws, batching consecutive same-color runs into single requests.
+`layout.lines[] = { x, y, baseline, width, ascent, descent, runs, start,
+end }` where `runs[] = { x, width, run, span, start, end }` in visual order
+(`start`/`end` are the logical UTF-16 ranges the line/run covers).
+`layout.draw(ctx, x, y)` draws, batching consecutive same-color runs into
+single requests.
 
 Line breaking is UAX#14 (`linebreak` package); `\n` forces breaks; a word
 wider than `maxWidth` force-breaks at the widest cluster prefix that fits;
 trailing whitespace at line ends is stripped (and doesn't count against
 `maxWidth` during fitting, CSS-style).
+
+#### Caret positioning and hit testing
+
+For editors and text inputs, `TextLayout` maps logical text positions to
+visual caret geometry and back — bidi-, ligature- and trailing-whitespace-
+aware, so there is no need to measure `text.slice(0, caret)` prefixes
+(which drifts across kerning/shaping boundaries and breaks in mixed-
+direction text):
+
+```js
+const layout = app.fonts.layout(text, { family: 'sans-serif', size: 16 });
+
+// logical code-point index -> visual caret geometry
+const { x, y, height, line } = layout.caretPosition(caretIndex);
+ctx.fillRect(x, y, 1, height); // draw the caret
+
+// click-to-caret: layout-box coordinates -> code-point index
+const index = layout.indexAt(clickX, clickY);
+```
+
+- `caretPosition(index)` → `{ x, y, height, line }`. `index` is a logical
+  **code-point** index in `[0, codePointCount]` (out of range clamps —
+  count code points with `Array.from(text).length`, not `text.length`).
+  `x` is the caret's visual x within the layout box (alignment included),
+  `y` the top of the line box, `height` its `ascent + descent`, `line` the
+  line index.
+- `indexAt(x, y)` → logical code-point index of the caret boundary nearest
+  to layout-box coordinates: the line is picked by `y` (clamping above the
+  first / below the last line), then the nearest boundary by `x` in visual
+  order — a click past the midpoint of a glyph cluster snaps to its far
+  edge. Inverse of `caretPosition` up to the bidi boundary ambiguity below.
+
+Conventions:
+
+- **Mixed-direction lines** use the bidi levels and visual run order the
+  layout already computed for drawing. At a direction boundary a single
+  caret is reported, at the trailing edge of the character logically
+  *before* the index (at a line start: the leading edge of the following
+  character). The indices on either side of a direction boundary may
+  therefore map to the same x — the standard single-caret compromise.
+- **Ligature/cluster interiors** (one glyph carrying several code points)
+  interpolate proportionally by code-point count across the cluster's
+  advance; `indexAt` rounds to the nearest interpolated boundary.
+- **Trailing whitespace** stripped from a line end still advances the
+  caret: positions inside it extend past the visual line edge on the
+  paragraph-direction side (`caretPosition(i + 1).x > caretPosition(i).x`
+  holds for `'a   '` in LTR).
+- **Line breaks**: the index of a `\n` itself sits at the end of its line;
+  the index after it belongs to the next line. An index at a soft-wrap
+  boundary maps to the start of the wrapped line. (A final `\n` does not
+  create a trailing empty line — the layout has none.)
 
 ### 2d context
 

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -30,8 +30,13 @@ function isWsGlyph(g) {
  * - `direction` — 'ltr' | 'rtl' | 'auto' base paragraph direction
  *
  * The result is inspectable before/without drawing: `width`, `height`, and
- * `lines[] = { x, y, baseline, width, ascent, descent, runs }` with
- * `runs[] = { x, width, run, span }` in visual order.
+ * `lines[] = { x, y, baseline, width, ascent, descent, runs, start, end }`
+ * with `runs[] = { x, width, run, span, start, end }` in visual order
+ * (`start`/`end` are logical UTF-16 ranges into the full text).
+ *
+ * `caretPosition(index)` / `indexAt(x, y)` map logical code-point indices
+ * to visual caret geometry and back (bidi/ligature/trailing-whitespace
+ * aware) — see docs/text.md.
  */
 export class TextLayout {
   constructor(fonts, content, style = {}, options = {}) {
@@ -59,6 +64,8 @@ export class TextLayout {
     });
 
     const text = spans.map((s) => s.text).join('');
+    this._text = text;
+    this._cpOffsets = null; // lazy code-point index -> code-unit offset table
     const emb = embeddingLevels(text, options.direction);
     const levels = emb.levels;
     this.baseLevel = emb.paragraphs.length ? emb.paragraphs[0].level & 1 : 0;
@@ -139,16 +146,31 @@ export class TextLayout {
     let layoutWidth = 0;
 
     for (const toks of lineTokens) {
-      // entries carry .level so reorderRuns can order them (UAX#9 L2)
+      // entries carry .level so reorderRuns can order them (UAX#9 L2);
+      // .start/.end are absolute code-unit ranges into the full text, kept
+      // for caret positioning (caretPosition / indexAt)
       let entries = [];
       for (const token of toks) {
         for (const frag of token.fragments) {
           for (const run of frag.shaped.runs) {
-            entries.push({ run, span: frag.span, level: run.level });
+            entries.push({
+              run,
+              span: frag.span,
+              level: run.level,
+              start: frag.start + run.start,
+              end: frag.start + run.end
+            });
           }
         }
       }
-      stripTrailingWhitespace(entries);
+      const lineStart = toks[0].start;
+      const lineEnd = toks[toks.length - 1].end;
+      const trailing = stripTrailingWhitespace(entries);
+      const contentEnd = trailing
+        ? trailing.start
+        : entries.length
+          ? entries[entries.length - 1].end
+          : lineStart;
       entries = reorderRuns(entries);
 
       let ascent = 0;
@@ -157,7 +179,7 @@ export class TextLayout {
       const runs = [];
       let x = 0;
       for (const e of entries) {
-        runs.push({ x, width: e.run.width, run: e.run, span: e.span });
+        runs.push({ x, width: e.run.width, run: e.run, span: e.span, start: e.start, end: e.end });
         x += e.run.width;
         const m = e.run.font.metrics(e.run.size);
         if (m.ascent > ascent) ascent = m.ascent;
@@ -172,7 +194,19 @@ export class TextLayout {
         natural = m.lineHeight;
       }
       if (x > layoutWidth) layoutWidth = x;
-      this.lines.push({ x: 0, y, baseline: y + ascent, width: x, ascent, descent, runs });
+      this.lines.push({
+        x: 0,
+        y,
+        baseline: y + ascent,
+        width: x,
+        ascent,
+        descent,
+        runs,
+        start: lineStart,
+        end: lineEnd,
+        _contentEnd: contentEnd,
+        _trailing: trailing
+      });
       y += natural * lineHeightMul;
     }
 
@@ -204,7 +238,7 @@ export class TextLayout {
       if (fragText.length > 0) {
         const fragLevels = normalizedLevels(levels, pos, pos + fragText.length);
         const shaped = this.fonts._shapeCached(fragText, span, fragLevels);
-        fragments.push({ text: fragText, span, shaped });
+        fragments.push({ text: fragText, span, shaped, start: pos });
         width += shaped.width;
       }
       pos = fragEnd;
@@ -219,7 +253,7 @@ export class TextLayout {
         wsWidth = m[0].length * spaceGlyph.advanceWidth * last.span.font.scale(last.span.size);
       }
     }
-    return { fragments, width, wsWidth, required };
+    return { fragments, width, wsWidth, required, start, end };
   }
 
   // split an over-wide token at the widest cluster boundary that fits
@@ -249,7 +283,9 @@ export class TextLayout {
           hi = mid - 1;
         }
       }
-      if (best) headFrags.push({ text: best.text, span: frag.span, shaped: best.shaped });
+      if (best) {
+        headFrags.push({ text: best.text, span: frag.span, shaped: best.shaped, start: frag.start });
+      }
 
       const restFrags = [];
       const restText = frag.text.slice(best ? best.len : 0);
@@ -257,26 +293,30 @@ export class TextLayout {
         restFrags.push({
           text: restText,
           span: frag.span,
-          shaped: this.fonts._shapeCached(restText, frag.span, '0')
+          shaped: this.fonts._shapeCached(restText, frag.span, '0'),
+          start: frag.start + (best ? best.len : 0)
         });
       }
       restFrags.push(...token.fragments.slice(i + 1));
       const sum = (frags) => frags.reduce((w, f) => w + f.shaped.width, 0);
+      const splitAt = restFrags.length ? restFrags[0].start : token.end;
       const head = headFrags.length
-        ? { fragments: headFrags, width: sum(headFrags), wsWidth: 0, required: false }
+        ? { fragments: headFrags, width: sum(headFrags), wsWidth: 0, required: false, start: token.start, end: splitAt }
         : null;
       const rest = {
         fragments: restFrags,
         width: sum(restFrags),
         wsWidth: token.wsWidth,
-        required: token.required
+        required: token.required,
+        start: splitAt,
+        end: token.end
       };
       return [head, rest];
     }
     // everything fit after all (float rounding): no split needed
     return [
       { ...token, required: false },
-      { fragments: [], width: 0, wsWidth: 0, required: token.required }
+      { fragments: [], width: 0, wsWidth: 0, required: token.required, start: token.end, end: token.end }
     ];
   }
 
@@ -308,11 +348,283 @@ export class TextLayout {
     ctx._markDirty();
     return this;
   }
+
+  // ---- caret positioning / hit testing ----------------------------------
+  //
+  // Both methods speak logical **code-point** indices (what you get from
+  // `Array.from(text)` / caret arithmetic on code points), converted
+  // internally to the code-unit ranges the shaped runs carry.
+  //
+  // Conventions (v1):
+  // - Direction boundaries: a single caret, placed at the trailing edge of
+  //   the character logically before the index (the run containing the
+  //   previous character wins). At a line start the leading edge of the
+  //   run containing the index is used. Indices on both sides of a
+  //   direction boundary may therefore map to the same visual x.
+  // - Ligature/cluster interior indices interpolate proportionally (by
+  //   code-point count) across the cluster's advance.
+  // - An index just after a hard break belongs to the next line; the index
+  //   of the break character itself sits at the end of its line. An index
+  //   at a soft wrap boundary belongs to the start of the wrapped line.
+  // - Trailing whitespace stripped from a line end still advances the
+  //   caret, extending past the line edge on the paragraph-direction side.
+
+  /** lazy code-point index -> code-unit offset table (n + 1 entries) */
+  _offsets() {
+    if (!this._cpOffsets) {
+      const offs = [];
+      let cu = 0;
+      for (const ch of this._text) {
+        offs.push(cu);
+        cu += ch.length;
+      }
+      offs.push(cu);
+      this._cpOffsets = offs;
+    }
+    return this._cpOffsets;
+  }
+
+  /** code-unit offset -> code-point index (binary search) */
+  _cpOf(cu) {
+    const offs = this._offsets();
+    let lo = 0;
+    let hi = offs.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (offs[mid] <= cu) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  }
+
+  /**
+   * Visual caret geometry for a logical code-point index in
+   * `[0, codePointCount]` (out-of-range indices clamp).
+   *
+   * @returns {{ x, y, height, line }} `x` is the caret's visual x within
+   *   the layout box (alignment included), `y` the top of the line box,
+   *   `height` = ascent + descent, `line` the line index.
+   */
+  caretPosition(index) {
+    const offs = this._offsets();
+    const n = offs.length - 1;
+    const i = Math.max(0, Math.min(Math.floor(index), n));
+    const cu = offs[i];
+    let li = 0;
+    for (let l = this.lines.length - 1; l >= 0; l--) {
+      if (cu >= this.lines[l].start) {
+        li = l;
+        break;
+      }
+    }
+    const line = this.lines[li];
+    return {
+      x: this._caretXInLine(line, cu),
+      y: line.y,
+      height: line.ascent + line.descent,
+      line: li
+    };
+  }
+
+  /**
+   * Hit test: the logical code-point index of the caret boundary closest
+   * to layout-box coordinates (x, y). Picks the line by y (clamping above
+   * the first / below the last line), then the nearest boundary by x in
+   * visual order — a click past the midpoint of a cluster snaps to its far
+   * edge. Inverse of `caretPosition` up to bidi boundary ambiguity.
+   */
+  indexAt(x, y) {
+    const lines = this.lines;
+    if (lines.length === 0) return 0;
+    let li = lines.length - 1;
+    for (let l = 0; l < lines.length; l++) {
+      const bottom = l + 1 < lines.length ? lines[l + 1].y : Infinity;
+      if (y < bottom) {
+        li = l;
+        break;
+      }
+    }
+    const line = lines[li];
+    const lx = x - line.x;
+    const t = line._trailing;
+    const rightSide = !(this.baseLevel & 1);
+    if (t && (rightSide ? lx > line.width : lx < 0)) {
+      // in the stripped trailing-whitespace zone past the line edge
+      const dist = rightSide ? lx - line.width : -lx;
+      let pos = t.start;
+      let edge = 0;
+      for (const g of t.glyphs) {
+        if (dist < edge + g.ax / 2) return this._cpOf(pos);
+        edge += g.ax;
+        pos += g.len;
+      }
+      return this._cpOf(pos);
+    }
+    if (line.runs.length === 0) return this._cpOf(line.start);
+    const cx = Math.max(0, Math.min(lx, line.width));
+    let target = line.runs[line.runs.length - 1];
+    for (const r of line.runs) {
+      if (cx <= r.x + r.width) {
+        target = r;
+        break;
+      }
+    }
+    return this._cpOf(this._runIndexAt(target, cx));
+  }
+
+  /** caret x (layout-box coords) for an absolute code-unit offset on `line` */
+  _caretXInLine(line, cu) {
+    const t = line._trailing;
+    if (t && cu > t.start) {
+      // inside (or past) the stripped trailing whitespace: extend beyond
+      // the visual line edge on the paragraph-direction side
+      let adv = 0;
+      let pos = t.start;
+      for (const g of t.glyphs) {
+        if (cu >= pos + g.len) {
+          adv += g.ax;
+          pos += g.len;
+        } else {
+          if (cu > pos) adv += (g.ax * (cu - pos)) / g.len;
+          break;
+        }
+      }
+      return this.baseLevel & 1 ? line.x - adv : line.x + line.width + adv;
+    }
+    if (line.runs.length === 0) return line.x;
+    const cc = Math.min(cu, line._contentEnd);
+    // previous-character rule: the run containing the char before the index
+    let target = null;
+    if (cc > line.start) {
+      for (const r of line.runs) {
+        if (r.start < cc && cc <= r.end) {
+          target = r;
+          break;
+        }
+      }
+    }
+    if (!target) {
+      for (const r of line.runs) {
+        if (r.start <= cc && cc < r.end) {
+          target = r;
+          break;
+        }
+      }
+    }
+    if (!target) target = line.runs[this.baseLevel & 1 ? line.runs.length - 1 : 0];
+    return line.x + this._boundaryX(target, cc);
+  }
+
+  /** x of logical boundary `cu` within a positioned line run (run-local + run.x) */
+  _boundaryX(lineRun, cu) {
+    const { run, start, end } = lineRun;
+    let x = lineRun.x;
+    if (run.direction === 'rtl') {
+      // glyphs stored in visual order; leftmost glyph is logically last
+      let pos = end;
+      for (const g of run.glyphs) {
+        const len = cuLength(g.codePoints);
+        if (len === 0) {
+          x += g.ax;
+          continue;
+        }
+        if (cu >= pos) return x;
+        if (cu > pos - len) {
+          // fraction of the cluster left of the caret = code points after cu
+          const cps = g.codePoints;
+          let k = 0;
+          let c = pos;
+          for (let j = cps.length - 1; j >= 0; j--) {
+            const l = cps[j] > 0xffff ? 2 : 1;
+            if (c - l < cu) break;
+            c -= l;
+            k++;
+          }
+          return x + (g.ax * k) / cps.length;
+        }
+        pos -= len;
+        x += g.ax;
+      }
+      return x;
+    }
+    let pos = start;
+    for (const g of run.glyphs) {
+      const len = cuLength(g.codePoints);
+      if (len === 0) {
+        x += g.ax;
+        continue;
+      }
+      if (cu <= pos) return x;
+      if (cu < pos + len) {
+        const cps = g.codePoints;
+        let k = 0;
+        let c = pos;
+        for (const cp of cps) {
+          const l = cp > 0xffff ? 2 : 1;
+          if (c + l > cu) break;
+          c += l;
+          k++;
+        }
+        return x + (g.ax * k) / cps.length;
+      }
+      pos += len;
+      x += g.ax;
+    }
+    return x;
+  }
+
+  /** nearest caret boundary (code units) to line-local x within a line run */
+  _runIndexAt(lineRun, lx) {
+    const { run, start, end } = lineRun;
+    const rtl = run.direction === 'rtl';
+    let pos = rtl ? end : start;
+    let gx = lineRun.x;
+    for (const g of run.glyphs) {
+      const len = cuLength(g.codePoints);
+      if (len === 0 || g.ax <= 0) {
+        gx += g.ax;
+        if (g.ax <= 0) pos += rtl ? -len : len;
+        continue;
+      }
+      if (lx <= gx + g.ax) {
+        const cps = g.codePoints;
+        let k = Math.round(((lx - gx) / g.ax) * cps.length);
+        k = Math.max(0, Math.min(k, cps.length));
+        // move k code points into the cluster from its left edge
+        let c = pos;
+        if (rtl) {
+          for (let j = cps.length - 1; j >= cps.length - k; j--) {
+            c -= cps[j] > 0xffff ? 2 : 1;
+          }
+        } else {
+          for (let j = 0; j < k; j++) c += cps[j] > 0xffff ? 2 : 1;
+        }
+        return c;
+      }
+      pos += rtl ? -len : len;
+      gx += g.ax;
+    }
+    return pos;
+  }
+}
+
+// UTF-16 length of a glyph cluster's codePoints array
+function cuLength(codePoints) {
+  let len = 0;
+  for (const cp of codePoints) len += cp > 0xffff ? 2 : 1;
+  return len;
 }
 
 // Drop trailing whitespace glyphs from the logical end of a line.
 // Shaped runs are shared via the shaping cache — clone instead of mutating.
+// Returns what was stripped — `{ start, glyphs: [{ ax, len }] }` in logical
+// order (absolute code-unit start, per-glyph advance and code-unit length) —
+// so caret positioning can still walk through trailing spaces, or null when
+// nothing was stripped. Adjusts the surviving entries' logical `end`.
 function stripTrailingWhitespace(entries) {
+  const stripped = [];
+  let strippedStart = null;
+  const result = () => (stripped.length ? { start: strippedStart, glyphs: stripped } : null);
   for (let i = entries.length - 1; i >= 0; i--) {
     const run = entries[i].run;
     // rtl runs store glyphs in visual order: their logical end is index 0
@@ -325,21 +637,35 @@ function stripTrailingWhitespace(entries) {
       count++;
       wsWidth += g.ax;
     }
-    if (count === 0) return;
+    if (count === 0) return result();
+    // stripped glyphs in logical order (rtl glyph storage is reversed)
+    const tail = fromFront
+      ? run.glyphs.slice(0, count).reverse()
+      : run.glyphs.slice(run.glyphs.length - count);
+    let cuStripped = 0;
+    const info = tail.map((g) => {
+      const len = cuLength(g.codePoints);
+      cuStripped += len;
+      return { ax: g.ax, len };
+    });
+    stripped.unshift(...info);
+    strippedStart = entries[i].end - cuStripped;
     if (count === run.glyphs.length) {
       entries.splice(i, 1);
       continue;
     }
     entries[i] = {
       ...entries[i],
+      end: entries[i].end - cuStripped,
       run: {
         ...run,
         glyphs: fromFront ? run.glyphs.slice(count) : run.glyphs.slice(0, -count),
         width: run.width - wsWidth
       }
     };
-    return;
+    return result();
   }
+  return result();
 }
 
 // compact levels key for the shaping cache: single char when uniform

--- a/test/caret.test.js
+++ b/test/caret.test.js
@@ -1,0 +1,219 @@
+// TextLayout caret positioning / hit testing (caretPosition, indexAt) —
+// fully hermetic: uses the KaTeX .ttf files shipped with the katex
+// dependency via a StaticFontSource, no fontconfig / X server required.
+//
+// The KaTeX faces have no Hebrew coverage, so the RTL/bidi cases shape to
+// .notdef glyphs — which is fine here: embedding levels, run splitting and
+// visual reordering come from bidi-js and the layout pipeline, not from the
+// font, and the notdef glyphs still carry real advances and cluster data.
+// Ligature clusters (no KaTeX face has GSUB ligatures) are exercised by
+// substituting a synthetic multi-codepoint cluster into a real layout line.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+
+import FontManager from '../lib/text/fontmanager.js';
+import { StaticFontSource } from '../lib/text/fontsource.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(dirname(require.resolve('katex/package.json')), 'dist', 'fonts');
+
+function manager() {
+  const source = new StaticFontSource();
+  source.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), { family: 'Test Main' });
+  source.alias('sans-serif', 'Test Main');
+  return new FontManager({ source });
+}
+
+const style = { family: 'sans-serif', size: 16 };
+
+test('caretPosition: LTR positions equal accumulated run advances (draw pen positions)', () => {
+  const fm = manager();
+  const layout = fm.layout('Hello, World', style);
+  const line = layout.lines[0];
+  // expected caret x at each boundary = line.x + run.x + cumulative glyph ax,
+  // exactly how draw() advances the pen
+  const expected = [line.x + line.runs[0].x];
+  for (const r of line.runs) {
+    let x = line.x + r.x;
+    for (const g of r.run.glyphs) {
+      x += g.ax;
+      expected.push(x);
+    }
+  }
+  for (let i = 0; i < expected.length; i++) {
+    const c = layout.caretPosition(i);
+    assert.ok(Math.abs(c.x - expected[i]) < 1e-6, `caret ${i}: ${c.x} != ${expected[i]}`);
+    assert.equal(c.line, 0);
+  }
+});
+
+test('caretPosition: strictly monotonic through trailing whitespace', () => {
+  const fm = manager();
+  const layout = fm.layout('a   ', style);
+  // display width excludes the stripped spaces...
+  const bare = fm.layout('a', style);
+  assert.ok(Math.abs(layout.lines[0].width - bare.lines[0].width) < 0.01);
+  // ...but the caret keeps advancing through them
+  let prev = -Infinity;
+  for (let i = 0; i <= 4; i++) {
+    const { x } = layout.caretPosition(i);
+    assert.ok(x > prev, `caret ${i}: ${x} <= ${prev}`);
+    prev = x;
+  }
+});
+
+test('caretPosition: mixed-direction line follows visual run order', () => {
+  const fm = manager();
+  // shapes into ltr runs around a Hebrew rtl run (visually reversed glyphs)
+  const layout = fm.layout('abc שלום xyz', style);
+  const line = layout.lines[0];
+  assert.ok(line.runs.length >= 3);
+  const c = (i) => layout.caretPosition(i).x;
+  // ltr prefix increases
+  assert.ok(c(0) < c(1) && c(1) < c(2) && c(2) < c(3));
+  // interior of the rtl segment decreases as the logical index increases
+  assert.ok(c(5) > c(6) && c(6) > c(7), `rtl interior: ${c(5)}, ${c(6)}, ${c(7)}`);
+  // rtl carets sit within the rtl run's visual extent
+  const rtlRun = line.runs.find((r) => r.run.direction === 'rtl');
+  for (const i of [5, 6, 7]) {
+    assert.ok(c(i) >= line.x + rtlRun.x - 1e-6 && c(i) <= line.x + rtlRun.x + rtlRun.width + 1e-6);
+  }
+  // direction-boundary convention (documented): previous character's run
+  // wins, so index 8 (after the last rtl char) sits at the rtl run's left
+  // edge, and index 4 (after the ltr space) at the ltr run's right edge —
+  // both edges touch, so the two carets coincide
+  assert.ok(Math.abs(c(8) - (line.x + rtlRun.x)) < 1e-6);
+  assert.ok(Math.abs(c(4) - c(8)) < 1e-6);
+  // ltr suffix increases again
+  assert.ok(c(9) < c(10) && c(10) < c(11) && c(11) < c(12));
+});
+
+test('indexAt: round-trips caretPosition on LTR text incl. trailing spaces', () => {
+  const fm = manager();
+  const layout = fm.layout('The quick fox  ', style);
+  const n = 15;
+  for (let i = 0; i <= n; i++) {
+    const c = layout.caretPosition(i);
+    // clicks a hair to either side of the caret snap back to it
+    assert.equal(layout.indexAt(c.x + 0.9, c.y + 1), i, `right of caret ${i}`);
+    assert.equal(layout.indexAt(c.x - 0.9, c.y + 1), i, `left of caret ${i}`);
+  }
+});
+
+test('indexAt: round-trips inside rtl segments of a mixed line', () => {
+  const fm = manager();
+  const layout = fm.layout('abc שלום xyz', style);
+  // boundary indices 4/8 share one visual position (see convention above);
+  // all interior boundaries must round-trip exactly
+  for (const i of [0, 1, 2, 3, 5, 6, 7, 9, 10, 11, 12]) {
+    const c = layout.caretPosition(i);
+    assert.equal(layout.indexAt(c.x + 0.4, c.y + 1), i, `caret ${i}`);
+  }
+});
+
+test('indexAt: past-midpoint clicks snap to the far cluster edge', () => {
+  const fm = manager();
+  const layout = fm.layout('mm', style);
+  const [c0, c1] = [layout.caretPosition(0), layout.caretPosition(1)];
+  const adv = c1.x - c0.x;
+  assert.equal(layout.indexAt(c0.x + adv * 0.45, 1), 0);
+  assert.equal(layout.indexAt(c0.x + adv * 0.55, 1), 1);
+});
+
+test('multi-line: caret y/line from the line the index falls on', () => {
+  const fm = manager();
+  const layout = fm.layout('aaaa bbbb', style, { maxWidth: 45 });
+  assert.equal(layout.lines.length, 2);
+  // index 4 = end of first word: still line 0, at its visual end
+  const end0 = layout.caretPosition(4);
+  assert.equal(end0.line, 0);
+  assert.ok(Math.abs(end0.x - (layout.lines[0].x + layout.lines[0].width)) < 1e-6);
+  // index 5 = the soft-wrap boundary maps to the start of the next line
+  const start1 = layout.caretPosition(5);
+  assert.equal(start1.line, 1);
+  assert.equal(start1.y, layout.lines[1].y);
+  assert.ok(Math.abs(start1.x - layout.lines[1].x) < 1e-6);
+  // hit-test y clamps above the first and below the last line
+  assert.equal(layout.indexAt(0, -100), 0);
+  assert.equal(layout.indexAt(1e6, 1e6), 9);
+  // hard breaks: index of '\n' sits at end of its line, index after it on the next
+  const hard = fm.layout('a\n\nb', style);
+  assert.equal(hard.caretPosition(1).line, 0);
+  assert.equal(hard.caretPosition(2).line, 1); // blank paragraph
+  assert.equal(hard.caretPosition(3).line, 2);
+  assert.equal(hard.indexAt(50, hard.lines[1].y + 1), 2);
+});
+
+test('empty text: caret at the aligned line origin', () => {
+  const fm = manager();
+  const left = fm.layout('', style);
+  assert.deepEqual(left.caretPosition(0), { x: 0, y: 0, height: left.lines[0].ascent + left.lines[0].descent, line: 0 });
+  const center = fm.layout('', style, { maxWidth: 100, align: 'center' });
+  assert.equal(center.caretPosition(0).x, 50);
+  const right = fm.layout('', style, { maxWidth: 100, align: 'right' });
+  assert.equal(right.caretPosition(0).x, 100);
+  assert.equal(center.indexAt(50, 0), 0);
+});
+
+test('caretPosition clamps out-of-range indices', () => {
+  const fm = manager();
+  const layout = fm.layout('ab', style);
+  assert.equal(layout.caretPosition(-5).x, layout.caretPosition(0).x);
+  assert.equal(layout.caretPosition(99).x, layout.caretPosition(2).x);
+});
+
+test('code-point indexing: astral characters count as one position', () => {
+  const fm = manager();
+  const layout = fm.layout('a\u{1D465}b', style); // 3 code points, 4 code units
+  const xs = [0, 1, 2, 3].map((i) => layout.caretPosition(i).x);
+  for (let i = 1; i < xs.length; i++) assert.ok(xs[i] > xs[i - 1], `caret ${i} advances`);
+  const c = layout.caretPosition(2);
+  assert.equal(layout.indexAt(c.x + 0.4, 1), 2);
+  assert.equal(layout.indexAt(1e6, 1), 3);
+});
+
+test('ligature clusters: interior indices interpolate proportionally', () => {
+  const fm = manager();
+  // no KaTeX face carries GSUB ligatures, so emulate one: shape 'fi' and
+  // replace the line's run with a single 2-codepoint cluster glyph — the
+  // exact shape fontkit produces for a real 'fi' ligature
+  const layout = fm.layout('fi', style);
+  const line = layout.lines[0];
+  const r = line.runs[0];
+  line.runs[0] = {
+    ...r,
+    width: 10,
+    run: {
+      ...r.run,
+      width: 10,
+      glyphs: [{ id: 999, ax: 10, dx: 0, dy: 0, codePoints: [0x66, 0x69] }]
+    }
+  };
+  line.width = 10;
+  line._trailing = null;
+  assert.equal(layout.caretPosition(0).x, 0);
+  assert.equal(layout.caretPosition(1).x, 5); // halfway through the cluster
+  assert.equal(layout.caretPosition(2).x, 10);
+  // hit tests round to the nearest of the interpolated boundaries
+  assert.equal(layout.indexAt(2, 1), 0);
+  assert.equal(layout.indexAt(3, 1), 1);
+  assert.equal(layout.indexAt(6, 1), 1);
+  assert.equal(layout.indexAt(8, 1), 2);
+});
+
+test('rtl base direction: trailing spaces extend the caret leftwards', () => {
+  const fm = manager();
+  // an rtl paragraph made of ltr words: base level 1, right-aligned by
+  // 'start', words at level 2, trailing whitespace stripped at level 1
+  const layout = fm.layout('ab ', style, { direction: 'rtl', maxWidth: 100 });
+  const line = layout.lines[0];
+  assert.equal(layout.baseLevel, 1);
+  assert.ok(line.x > 0, 'start-aligned rtl line is right-aligned');
+  const c2 = layout.caretPosition(2);
+  const c3 = layout.caretPosition(3);
+  assert.ok(c3.x < c2.x, `trailing space advances leftwards: ${c3.x} !< ${c2.x}`);
+  assert.equal(layout.indexAt(c3.x - 0.4, 1), 3);
+});


### PR DESCRIPTION
Fixes #72

Adds a caret/hit-testing API to `TextLayout` so text editors (react-x11's `<textinput>` in particular) can stop measuring `text.slice(0, caret)` prefix widths — which is wrong for bidi text, drifts across kerning/shaping boundaries and breaks on stripped trailing whitespace.

## API

```js
layout.caretPosition(index) // -> { x, y, height, line }
layout.indexAt(x, y)        // -> logical code-point index
```

- `caretPosition(index)`: `index` is a logical **code-point** index in `[0, codePointCount]` (out of range clamps). `x` is the caret's visual x within the layout box (alignment included), `y` the top of the line box, `height` = `ascent + descent`, `line` the line index.
- `indexAt(x, y)`: inverse mapping for click-to-caret — picks the line by y (clamping above/below), then the nearest caret boundary by x in visual order; a click past the midpoint of a cluster snaps to its far edge. Round-trips `caretPosition` up to the bidi boundary ambiguity below.

## Documented conventions (v1)

- **Direction boundaries**: a single caret, placed by the run containing the logically *previous* character (its trailing edge in visual space); at a line start, the leading edge of the following character. Indices on both sides of an LTR/RTL boundary may map to the same x — the standard single-caret compromise.
- **Ligature clusters** (one glyph, several code points): interior indices interpolate proportionally by code-point count across the cluster advance; `indexAt` rounds to the nearest interpolated boundary.
- **Trailing whitespace**: positions inside whitespace stripped at a line end still advance, extending past the visual line edge on the paragraph-direction side (`caretPosition(i+1).x > caretPosition(i).x` for `'a   '` in LTR).
- **Line breaks**: the index of a `\n` sits at the end of its line; the index after it belongs to the next line; an index at a soft-wrap boundary maps to the start of the wrapped line.

## Implementation

The layout pass now retains logical position metadata it previously discarded — all additive, `draw()` is untouched:

- tokens/fragments carry their absolute UTF-16 start (`_makeToken`, and through `_forceBreak` splits),
- each line gets `start`/`end` and each visual line run gets its logical `start`/`end` range,
- `stripTrailingWhitespace` still clones shared shaped runs, but now returns what it stripped (`{ start, glyphs: [{ ax, len }] }` in logical order) and adjusts the surviving entry's logical end, so the caret can walk through stripped spaces using the real shaped advances (no synthetic space-advance patching needed downstream).

The public API speaks code-point indices; conversion to/from the code-unit ranges the shaped runs use is a lazily built offset table, so surrogate pairs count as one caret position.

## Tests

`test/caret.test.js`, 12 cases, fully hermetic (StaticFontSource over the KaTeX `.ttf` files shipped with the `katex` dependency — same pattern as `test/fontsource.test.js`): LTR carets equal accumulated shaped run advances (i.e. exactly the pen positions `draw()` uses, kerning included); strict monotonicity through trailing whitespace; mixed-direction visual ordering and the boundary convention; `indexAt` round-trips (LTR incl. trailing spaces, RTL segment interiors, midpoint snapping); multi-line y/line mapping incl. hard breaks and blank paragraphs; empty text per alignment; out-of-range clamping; astral (surrogate-pair) indexing; ligature-cluster interpolation; RTL-base trailing whitespace extending leftwards.

Coverage gap, noted: no RTL-capable font ships with the repo (KaTeX faces have no Hebrew/Arabic), so the RTL cases shape to `.notdef` glyphs. That still exercises the real code paths — embedding levels, run splitting and visual reordering come from bidi-js and the layout pipeline, not the font, and notdef glyphs carry real advances and cluster arrays — but per-glyph cluster data from a real RTL font is only covered indirectly. The X-server glyph-position suite already renders real Arabic via system fonts; a follow-up could add a caret case there.

No screenshots: the API is non-visual (geometry queries only); per AGENTS.md images are included only when globally useful.