### PR TITLE
feat: onInvalidate hook for async content in standalone MarkdownView/HtmlView

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -66,6 +66,7 @@ new HtmlView(window, {
   theme,            // { family, size, color, background } base look
   stylesheet,       // string | string[] — extra author CSS (after <style>s)
   onLink,           // (href, event, element) => void
+  onInvalidate,     // () => void — async content (an image) arrived
   baseUrl,          // path / file URL for relative image src resolution
   loadResource,     // custom resource loader, or null to disable
   fonts             // FontManager — only for windowless (standalone) use
@@ -75,7 +76,9 @@ new HtmlView(window, {
 In window mode the widget wires itself: renders on `expose`, re-wraps on
 `resize`, scrolls with the wheel (X11 buttons 4/5), fires `onLink` on left
 click. Standalone mode mirrors `MarkdownView`: pass `null` for the window
-plus a `fonts` manager, then drive `layout()`/`draw()` yourself.
+plus a `fonts` manager, then drive `layout()`/`draw()` yourself; pass
+`onInvalidate` to re-layout/redraw when async content (an image) arrives —
+window mode repaints on its own.
 
 ## Methods
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -306,7 +306,9 @@ files, browsers, history) are the embedder's job —
 browser built this way.
 
 Headless/embedded use: `new MarkdownView(null, { fonts })`, then
-`view.layout(width)` → content height, `view.draw(ctx, x, y)`.
+`view.layout(width)` → content height, `view.draw(ctx, x, y)`. Pass
+`onInvalidate` to re-layout/redraw when async content (a mermaid model)
+arrives — without it a `\`\`\`mermaid` fence stays a plain code block.
 
 `TextLayout` note for widget authors: spans keep unknown fields through
 layout normalization, and line runs expose their span (`run.span`), so

--- a/examples/markdown.js
+++ b/examples/markdown.js
@@ -41,6 +41,17 @@ Fences tagged \`math\`/\`latex\` render with KaTeX:
 \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}
 \`\`\`
 
+## Mermaid
+
+Fences tagged \`mermaid\` draw as diagrams (flowchart / sequence):
+
+\`\`\`mermaid
+flowchart LR
+  A[shape] --> B[wrap]
+  B --> C[draw]
+  C --> D((glyphs on wire))
+\`\`\`
+
 ## Tables
 
 | Stage | What happens | Cost |
@@ -68,7 +79,14 @@ Fences tagged \`math\`/\`latex\` render with KaTeX:
 const app = await createClient();
 const wnd = app.createWindow({ width: 640, height: 720, title: 'ntk markdown' });
 const ctx = wnd.getContext('2d');
-const view = new MarkdownView(null, { fonts: app.fonts });
+const view = new MarkdownView(null, {
+  fonts: app.fonts,
+  // mermaid fences parse asynchronously; re-layout when the model arrives
+  onInvalidate: () => {
+    layoutWidth = -1;
+    render();
+  }
+});
 
 let currentPath = null; // null = home page, else absolute path of the .md
 const history = [];

--- a/lib/widgets/htmlview.js
+++ b/lib/widgets/htmlview.js
@@ -65,6 +65,9 @@ const VOID_SKIP = new Set(['script', 'style', 'head', 'title', 'meta', 'link', '
  * Standalone (windowless) use mirrors MarkdownView:
  *   const view = new HtmlView(null, { fonts });
  *   view.setHtml(html); view.layout(width); view.draw(ctx, x, y);
+ * Content that arrives asynchronously (images) invalidates the layout —
+ * pass `onInvalidate` to re-layout/redraw when that happens (window mode
+ * repaints automatically).
  */
 export default class HtmlView {
   constructor(window, opts = {}) {
@@ -74,6 +77,10 @@ export default class HtmlView {
 
     /** called with (href, event, element) when a link is activated */
     this.onLink = opts.onLink ?? null;
+    /** called when async content (an image) invalidates the layout;
+     *  standalone hosts re-layout/redraw here — window mode also repaints
+     *  on its own */
+    this.onInvalidate = opts.onInvalidate ?? null;
     /** extra author stylesheet(s) applied after document <style>s */
     this._userSheets = [].concat(opts.stylesheet ?? []);
     /**
@@ -407,19 +414,24 @@ export default class HtmlView {
               if (res instanceof SvgView) entry.svg = res;
               else entry.image = res;
               if (!res) entry.failed = true;
-              this._layoutWidth = -1;
-              if (this.window && this.window._mapped) this.render();
+              this._invalidate();
             },
             () => {
               entry.failed = true;
-              this._layoutWidth = -1;
-              if (this.window && this.window._mapped) this.render();
+              this._invalidate();
             }
           );
         }
       }
     }
     for (const child of box.children) this._collectImages(child);
+  }
+
+  /** async content arrived: drop the cached layout, repaint and/or notify */
+  _invalidate() {
+    this._layoutWidth = -1;
+    if (this.window && this.window._mapped) this.render();
+    if (this.onInvalidate) this.onInvalidate();
   }
 
   // decoded bytes -> Image (PNG/JPEG) or SvgView (sniffed SVG markup)

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -51,7 +51,10 @@ const DEFAULT_THEME = {
  *   wnd.map();
  *
  * Standalone use (no window attach): `view.layout(width)` then
- * `view.draw(ctx, x, y)`; `view.contentHeight` after layout.
+ * `view.draw(ctx, x, y)`; `view.contentHeight` after layout. Content that
+ * arrives asynchronously (mermaid models) invalidates the layout — pass
+ * `onInvalidate` to re-layout/redraw when that happens (window mode
+ * repaints automatically).
  */
 export default class MarkdownView {
   constructor(window, opts = {}) {
@@ -70,6 +73,10 @@ export default class MarkdownView {
     /** called with (href, event) when a rendered link is clicked (window
      *  mode wires mousedown automatically; standalone callers use linkAt) */
     this.onLink = opts.onLink ?? null;
+    /** called when async content (a mermaid model) invalidates the layout;
+     *  standalone hosts re-layout/redraw here — window mode also repaints
+     *  on its own */
+    this.onInvalidate = opts.onInvalidate ?? null;
 
     if (this.window) {
       this._ctx = this.window.getContext('2d');
@@ -116,8 +123,7 @@ export default class MarkdownView {
       parseMermaid(text).then(
         (model) => {
           entry.model = model;
-          this._layoutWidth = -1;
-          if (this.window && this.window._mapped) this.render();
+          this._invalidate();
         },
         () => {
           entry.failed = true; // unsupported/invalid: stays a code block
@@ -125,6 +131,13 @@ export default class MarkdownView {
       );
     }
     return entry;
+  }
+
+  /** async content arrived: drop the cached layout, repaint and/or notify */
+  _invalidate() {
+    this._layoutWidth = -1;
+    if (this.window && this.window._mapped) this.render();
+    if (this.onInvalidate) this.onInvalidate();
   }
 
   /** lay content out for a container width; returns total content height */

--- a/test/htmlview.test.js
+++ b/test/htmlview.test.js
@@ -342,3 +342,21 @@ test('img: raster decoding is untouched by svg sniffing', needsFonts, async () =
   assert.equal(entry.svg, null);
   assert.equal(entry.image.width, 12);
 });
+
+test('standalone view fires onInvalidate when an image arrives', needsFonts, async () => {
+  const { PNG } = await import('pngjs');
+  const png = new PNG({ width: 16, height: 4 });
+  let invalidated;
+  const done = new Promise((r) => (invalidated = r));
+  const view = new HtmlView(null, {
+    fonts,
+    loadResource: async () => PNG.sync.write(png),
+    onInvalidate: invalidated
+  });
+  view.setHtml('<img src="x.png">');
+  view.layout(400); // image still loading: no intrinsic size yet
+  await done;
+  view.layout(400);
+  const img = byName(view, 'img')[0];
+  assert.equal(img.w, 16, 'natural width after onInvalidate re-layout');
+});

--- a/test/mermaid.test.js
+++ b/test/mermaid.test.js
@@ -152,6 +152,20 @@ test('markdown: mermaid fence becomes a diagram box after async parse', needsFon
   assert.ok(diagram.box.width > 100);
 });
 
+test('markdown: standalone view fires onInvalidate when the model arrives', needsFonts, async () => {
+  let invalidated;
+  const done = new Promise((r) => (invalidated = r));
+  const view = new MarkdownView(null, { fonts, onInvalidate: invalidated });
+  view.setMarkdown('```mermaid\nflowchart LR\n A[Hello] --> B[World]\n```');
+  view.layout(500); // fence is a code block; parse resolves in the background
+  await done;
+  view.layout(500);
+  assert.ok(
+    view._items.some((i) => i.kind === 'tex' && i.box.type === 'flowchart'),
+    'diagram item present after onInvalidate'
+  );
+});
+
 test('markdown: unsupported mermaid stays a code block', needsFonts, async () => {
   const view = new MarkdownView(null, { fonts });
   view.setMarkdown('```mermaid\ngantt\n title x\n```');


### PR DESCRIPTION
## What

Standalone (windowless) `MarkdownView` / `HtmlView` had no way to tell their host that async content arrived: a ````mermaid```` fence stayed a plain code block and an `<img>` kept its placeholder size forever — the internal invalidation only repainted in window mode.

Both widgets now accept an `onInvalidate` callback, called whenever async content (a parsed mermaid model, a fetched or failed image) drops the cached layout. Embedders re-run `layout()`/`draw()` from it. Window-mode behavior is unchanged (it still repaints on its own).

## Why

This is the missing piece for embedding these widgets in a retained-mode host — react-x11's upcoming `<markdown>`/`<html>` elements wire `onInvalidate` straight into their invalidate-and-repaint path (see react-x11 NEXT_STEPS roadmap item 1).

## Changes

- `MarkdownView`: `opts.onInvalidate`; the mermaid async-parse path now funnels through a shared `_invalidate()` (drop cached layout → window-mode repaint → notify).
- `HtmlView`: same hook and `_invalidate()` for the async image path (success and failure).
- Tests: standalone `onInvalidate` firing for a mermaid model (`test/mermaid.test.js`) and for an async image (`test/htmlview.test.js`).
- Docs: `docs/text.md`, `docs/html.md`; `examples/markdown.js` gains a mermaid section driven through the hook.

## Tests

`npm test`: 280 pass, 0 fail.