### PR TITLE
fix(2d): glyph drawing now honours the clip mask

### DIFF
--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -736,6 +736,34 @@ class RenderingContext2d {
     this._markDirty();
   }
 
+  /**
+   * Composite shaped glyph runs onto this context, honouring the clip.
+   *
+   * CompositeGlyphs writes straight to the destination picture, so it has
+   * no way to consult our clip mask — text drawn through it used to spill
+   * out of clipped boxes while every fill and stroke stayed inside. With a
+   * clip active, render the glyph coverage into the scratch a8 mask
+   * instead, intersect that with the clip, and paint the real source
+   * through the result — the same shape as _fillPolys.
+   */
+  drawGlyphs(op, src, positioned) {
+    const app = this.window.app;
+    const R = this.Render;
+    if (!this.clipMask) {
+      drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
+      this._markDirty();
+      return;
+    }
+    this._ensureFillMask();
+    this._glyphSource ??= this.createSolidPicture(1, 1, 1, 1);
+    R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
+    // solid white through the glyphs leaves their coverage in the a8 mask
+    drawGlyphRuns(app, R.PictOp.Over, this._glyphSource.id, this.fillMask.id, positioned);
+    R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    R.Composite(op, src.id, this.fillMask.id, this.picture.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    this._markDirty();
+  }
+
   // combined clip ∩ globalAlpha mask for direct composites (rect/image
   // fast paths); returns a picture id or 0. Reuses the fill scratch mask.
   _compositeMask() {
@@ -928,8 +956,7 @@ class RenderingContext2d {
       positioned.push({ run, x: cursor, y: oy });
       cursor += run.width;
     }
-    drawGlyphRuns(app, this.Render.PictOp.Over, this._backgroundPicture.id, this.picture.id, positioned);
-    this._markDirty();
+    this.drawGlyphs(this.Render.PictOp.Over, this._backgroundPicture, positioned);
   }
 
   /**

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -334,7 +334,13 @@ export class TextLayout {
       const flush = () => {
         if (batch.length === 0) return;
         const src = batchColor ? ctx._stylePicture(batchColor) : ctx._backgroundPicture;
-        drawGlyphRuns(app, Render.PictOp.Over, src.id, ctx.picture.id, batch);
+        // via the context so the clip mask is applied (drawGlyphRuns
+        // composites straight onto the picture and cannot see it)
+        if (typeof ctx.drawGlyphs === 'function') {
+          ctx.drawGlyphs(Render.PictOp.Over, src, batch);
+        } else {
+          drawGlyphRuns(app, Render.PictOp.Over, src.id, ctx.picture.id, batch);
+        }
         batch = [];
       };
       for (const r of line.runs) {

--- a/test/glyph-clip.test.js
+++ b/test/glyph-clip.test.js
@@ -1,0 +1,126 @@
+// Text must stay inside the 2d clip. CompositeGlyphs writes straight to the
+// destination picture, so glyph drawing has to be routed through the clip
+// mask by hand — without that, text spills out of clipped boxes while every
+// fill and stroke stays inside (react-x11's <textarea> scrolling showed it).
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+const require = createRequire(import.meta.url);
+const fontDir = join(dirname(require.resolve('katex/package.json')), 'dist', 'fonts');
+
+let server = null;
+let app = null;
+
+before(async () => {
+  server = createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  const source = new StaticFontSource();
+  source.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), { family: 'Test Main' });
+  source.alias('sans-serif', 'Test Main');
+  app = await createClient({ stream: clientEnd, fontSource: source });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+const W = 160;
+const H = 80;
+
+const readPixels = (ctx) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, data) => (err ? reject(err) : resolve(data)))
+  );
+
+/** Count pixels darker than white in a band of rows. */
+function inkInRows(image, y0, y1) {
+  let n = 0;
+  for (let y = y0; y < y1; y++) {
+    for (let x = 0; x < W; x++) {
+      const i = (y * W + x) * 4;
+      // BGRA; anything appreciably darker than the white background is ink
+      if (image.data[i] < 200 || image.data[i + 1] < 200 || image.data[i + 2] < 200) n++;
+    }
+  }
+  return n;
+}
+
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+const CLIP_TOP = 30;
+const CLIP_BOTTOM = 60;
+
+test('fillText stays inside the clip', async () => {
+  const ctx = freshCtx();
+  ctx.font = '20px sans-serif';
+  ctx.fillStyle = 'black';
+
+  // baseline chosen so the text would land well above the clip band
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, CLIP_TOP, W, CLIP_BOTTOM - CLIP_TOP);
+  ctx.clip();
+  ctx.fillText('Hgjy', 4, 20);
+  ctx.restore();
+
+  const image = await readPixels(ctx);
+  assert.equal(
+    inkInRows(image, 0, CLIP_TOP),
+    0,
+    'no glyph ink above the clip band',
+  );
+});
+
+test('TextLayout.draw stays inside the clip, and still paints within it', async () => {
+  const ctx = freshCtx();
+  const layout = app.fonts.layout(
+    [{ text: 'Clipping', family: 'sans-serif', size: 20, color: 'black' }],
+    { family: 'sans-serif', size: 20 },
+  );
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, CLIP_TOP, W, CLIP_BOTTOM - CLIP_TOP);
+  ctx.clip();
+  // drawn near the top: most of it falls outside the clip band
+  layout.draw(ctx, 4, 4);
+  // and again inside it, so the test also proves text still renders
+  layout.draw(ctx, 4, CLIP_TOP + 2);
+  ctx.restore();
+
+  const image = await readPixels(ctx);
+  assert.equal(inkInRows(image, 0, CLIP_TOP), 0, 'nothing above the clip');
+  assert.equal(inkInRows(image, CLIP_BOTTOM, H), 0, 'nothing below the clip');
+  assert.ok(
+    inkInRows(image, CLIP_TOP, CLIP_BOTTOM) > 0,
+    'text inside the clip still paints',
+  );
+});
+
+test('without a clip, text paints where it is drawn', async () => {
+  const ctx = freshCtx();
+  const layout = app.fonts.layout(
+    [{ text: 'Clipping', family: 'sans-serif', size: 20, color: 'black' }],
+    { family: 'sans-serif', size: 20 },
+  );
+  layout.draw(ctx, 4, 4);
+  const image = await readPixels(ctx);
+  assert.ok(inkInRows(image, 0, CLIP_TOP) > 0, 'unclipped text is not suppressed');
+});


### PR DESCRIPTION
`CompositeGlyphs` writes straight to the destination picture, so it has no way to consult the context's clip mask:

- `_fillPolys` / `_strokePolys` intersect their coverage with `clipMask` before compositing → **shapes clip correctly**
- `TextLayout.draw` and `fillText` called `drawGlyphRuns(app, op, src.id, ctx.picture.id, …)` → **text ignored the clip entirely**

So any clipped region containing text leaked. It has been invisible wherever the clip coincides with an X window edge — which is why popup-based widgets (menus, dropdowns) always looked right — but shows up immediately in a clipped box inside a larger window.

## The symptom

Found via react-x11's `<textarea>`: its scrolled-away lines painted **over the label above it**, outside the widget entirely.

Before — note the stray text over the heading:

![textarea](https://github.com/user-attachments/assets/8f73c6cb-41f4-4f0c-8b3c-df018b6d7f6a)

After:

![textarea-fixed](https://github.com/user-attachments/assets/cb0369df-3a58-4101-90df-965251c7d9d9)

Same code both times; only ntk differs. It also affected a horizontally scrolled single-line input and any `overflow: hidden` box containing text.

## The fix

New `ctx.drawGlyphs(op, src, positioned)`:

- **no clip** → composites exactly as before, no extra work on the common path
- **clip active** → renders the glyph coverage into the scratch a8 mask, `In`-composites that with `clipMask`, then paints the real source through the result — the same shape `_fillPolys` already uses

`TextLayout.draw` and `fillText` both route through it. `TextLayout.draw` keeps a fallback to the direct call if handed a context without the method.

## Tests

`test/glyph-clip.test.js` — pixel readback against node-x11's in-process pure-JS X server, so it runs in CI with no `$DISPLAY`:

- no ink above/below the clip band for **both** entry points (`fillText` and `TextLayout.draw`)
- ink still present **inside** the band, so the fix can't pass by suppressing text
- an unclipped control, green either way

Reverting either routing change fails the two clip tests and leaves the control passing — verified.

Full suite: **304/304**.
