### PR TITLE
perf(2d): server-side clip for glyphs, and one glyph batch per layout

### DIFF
--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -754,6 +754,19 @@ class RenderingContext2d {
       this._markDirty();
       return;
     }
+    // Fast path: a rectangular clip is something the server can do itself.
+    // Two small requests around the ordinary glyph composite, instead of
+    // clearing and compositing a full-surface a8 mask three times — which
+    // costs the same on the wire but many times the pixel work.
+    const rect = this._clipRect();
+    if (rect) {
+      if (rect.w === 0 || rect.h === 0) return;
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+      drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+      this._markDirty();
+      return;
+    }
     this._ensureFillMask();
     this._glyphSource ??= this.createSolidPicture(1, 1, 1, 1);
     R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
@@ -841,9 +854,66 @@ class RenderingContext2d {
    * Cleared by restore() to the state at the matching save() — like the
    * browser canvas, there is no other way to widen the clip again.
    */
+  /**
+   * The axis-aligned rectangle a flattened path describes, or null. Clips
+   * in practice are almost always rectangles — a content box, a scroll
+   * viewport, `overflow: hidden` — and a rectangular clip can be pushed
+   * to the server instead of rasterized into a mask.
+   */
+  static _rectOfPolys(polys) {
+    if (polys.length !== 1) return null;
+    const { pts } = polys[0];
+    if (pts.length !== 8) return null;
+    const [x0, y0, x1, y1, x2, y2, x3, y3] = pts;
+    const axis =
+      (y0 === y1 && x1 === x2 && y2 === y3 && x3 === x0) ||
+      (x0 === x1 && y1 === y2 && x2 === x3 && y3 === y0);
+    if (!axis) return null;
+    const xs = [x0, x1, x2, x3];
+    const ys = [y0, y1, y2, y3];
+    const x = Math.min(...xs);
+    const y = Math.min(...ys);
+    const w = Math.max(...xs) - x;
+    const h = Math.max(...ys) - y;
+    if (!(w > 0 && h > 0)) return null;
+    // Server clip rectangles are integers, so a fractional edge could only
+    // be honoured by rounding — which would differ from the mask path's
+    // antialiased edge by up to a pixel. Rare, so leave those to the mask
+    // rather than quietly changing what they look like.
+    const integral = (v) => Math.abs(v - Math.round(v)) < 1e-6;
+    if (![x, y, w, h].every(integral)) return null;
+    return { x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h) };
+  }
+
+  /** Intersection of the whole clip stack, or null if any part is not a
+   *  rectangle (or the stack is empty). */
+  _clipRect() {
+    if (!this._clips.length) return null;
+    let out = null;
+    for (const entry of this._clips) {
+      const r = entry.rect;
+      if (!r) return null;
+      if (!out) {
+        out = { ...r };
+        continue;
+      }
+      const x = Math.max(out.x, r.x);
+      const y = Math.max(out.y, r.y);
+      const right = Math.min(out.x + out.w, r.x + r.w);
+      const bottom = Math.min(out.y + out.h, r.y + r.h);
+      out = { x, y, w: Math.max(0, right - x), h: Math.max(0, bottom - y) };
+    }
+    // clamp into the surface: the server rejects out-of-range rectangles
+    const x = Math.max(0, Math.min(out.x, this.width));
+    const y = Math.max(0, Math.min(out.y, this.height));
+    const w = Math.max(0, Math.min(out.x + out.w, this.width) - x);
+    const h = Math.max(0, Math.min(out.y + out.h, this.height) - y);
+    return { x, y, w, h };
+  }
+
   clip(...args) {
     const { polys, rule } = this._polysFor(args);
-    const entry = { polys, rule };
+    const entry = { polys, rule, rect: RenderingContext2d._rectOfPolys(polys) };
     // copy-on-write: earlier save() snapshots keep their own clip list
     this._clips = this._clips.concat([entry]);
 

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -328,29 +328,33 @@ export class TextLayout {
   draw(ctx, x = 0, y = 0) {
     const app = ctx.window.app;
     const Render = app.display.Render;
+    // One batch for the whole layout, not one per line: every positioned
+    // run carries its own absolute baseline, so a uniformly coloured
+    // paragraph becomes a single glyph composite instead of one per line.
+    // Only a colour change forces a flush.
+    let batch = [];
+    let batchColor;
+    const flush = () => {
+      if (batch.length === 0) return;
+      const src = batchColor ? ctx._stylePicture(batchColor) : ctx._backgroundPicture;
+      // via the context so the clip is applied (drawGlyphRuns composites
+      // straight onto the picture and cannot see it)
+      if (typeof ctx.drawGlyphs === 'function') {
+        ctx.drawGlyphs(Render.PictOp.Over, src, batch);
+      } else {
+        drawGlyphRuns(app, Render.PictOp.Over, src.id, ctx.picture.id, batch);
+      }
+      batch = [];
+    };
     for (const line of this.lines) {
-      let batch = [];
-      let batchColor;
-      const flush = () => {
-        if (batch.length === 0) return;
-        const src = batchColor ? ctx._stylePicture(batchColor) : ctx._backgroundPicture;
-        // via the context so the clip mask is applied (drawGlyphRuns
-        // composites straight onto the picture and cannot see it)
-        if (typeof ctx.drawGlyphs === 'function') {
-          ctx.drawGlyphs(Render.PictOp.Over, src, batch);
-        } else {
-          drawGlyphRuns(app, Render.PictOp.Over, src.id, ctx.picture.id, batch);
-        }
-        batch = [];
-      };
       for (const r of line.runs) {
         const color = r.span.color;
         if (batch.length && color !== batchColor) flush();
         batchColor = color;
         batch.push({ run: r.run, x: x + line.x + r.x, y: y + line.baseline });
       }
-      flush();
     }
+    flush();
     ctx._markDirty();
     return this;
   }

--- a/test/glyph-clip.test.js
+++ b/test/glyph-clip.test.js
@@ -124,3 +124,62 @@ test('without a clip, text paints where it is drawn', async () => {
   const image = await readPixels(ctx);
   assert.ok(inkInRows(image, 0, CLIP_TOP) > 0, 'unclipped text is not suppressed');
 });
+
+// The rectangular-clip fast path pushes the clip to the server instead of
+// rasterizing a mask. It must produce the same result as the mask path,
+// and must not be taken when it would change what the edge looks like.
+
+test('a fractional clip rect falls back to the mask path', async () => {
+  const ctx = freshCtx();
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, CLIP_TOP + 0.5, W, CLIP_BOTTOM - CLIP_TOP);
+  ctx.clip();
+  // server clip rectangles are integers, so a fractional edge stays on the
+  // mask path rather than being silently rounded
+  assert.equal(ctx._clipRect(), null, 'fractional rect is not a fast-path rect');
+  ctx.restore();
+});
+
+test('rect fast path and mask path clip text identically', async () => {
+  const layoutOf = (c) =>
+    c.window.app.fonts.layout(
+      [{ text: 'Clipping', family: 'sans-serif', size: 20, color: 'black' }],
+      { family: 'sans-serif', size: 20 },
+    );
+
+  // integral rect -> server-side clip
+  const fast = freshCtx();
+  fast.save();
+  fast.beginPath();
+  fast.rect(0, CLIP_TOP, W, CLIP_BOTTOM - CLIP_TOP);
+  fast.clip();
+  assert.ok(fast._clipRect(), 'integral rect takes the fast path');
+  layoutOf(fast).draw(fast, 4, 4);
+  layoutOf(fast).draw(fast, 4, CLIP_TOP + 2);
+  fast.restore();
+
+  // same clip expressed as a non-rectangular path -> mask
+  const slow = freshCtx();
+  slow.save();
+  slow.beginPath();
+  slow.moveTo(0, CLIP_TOP);
+  slow.lineTo(W, CLIP_TOP);
+  slow.lineTo(W, CLIP_BOTTOM);
+  slow.lineTo(W / 2, CLIP_BOTTOM);
+  slow.lineTo(0, CLIP_BOTTOM);
+  slow.closePath();
+  slow.clip();
+  assert.equal(slow._clipRect(), null, 'five-point path is not a fast-path rect');
+  layoutOf(slow).draw(slow, 4, 4);
+  layoutOf(slow).draw(slow, 4, CLIP_TOP + 2);
+  slow.restore();
+
+  const [a, b] = await Promise.all([readPixels(fast), readPixels(slow)]);
+  let diff = 0;
+  for (let i = 0; i < a.data.length; i += 4) {
+    if (Math.abs(a.data[i] - b.data[i]) > 8) diff++;
+  }
+  assert.equal(diff, 0, 'both clip paths produce the same pixels');
+  assert.ok(inkInRows(a, CLIP_TOP, CLIP_BOTTOM) > 0, 'and both actually drew');
+});


### PR DESCRIPTION
Clipping text became *correct* in #79 but expensive. I flagged at the time that I wasn't sure the implementation was efficient; react-x11's new protocol benchmark says it wasn't.

## The measurement

```
text: paragraph, no clip              43 requests   1 composite    0.16 Mpx
text: paragraph, inside a rect clip   91 requests  25 composites   4.00 Mpx
```

**25× the pixel work**, for a 12-line paragraph whose ink covers 0.08 Mpx — because the mask path clears and composites the whole surface three times, per line.

Nothing on the wire showed this: a Render `Composite` request is 36 bytes whether it touches ten pixels or 160,000. It only became visible once the benchmark started totalling composited area.

## Two changes

**1. A rectangular clip is something the server can do itself.** `SetPictureClipRectangles` on the destination, around an ordinary glyph composite, replaces the mask entirely — two small requests, no scratch pixmap, no extra pixel work. Clips are rectangles in practice: a content box, a scroll viewport, `overflow: hidden`. Non-rectangular clips keep the mask path.

Only **integral** rectangles take the fast path. Server clip rectangles are integers, so a fractional edge could only be honoured by rounding, which would differ from the mask's antialiased edge by up to a pixel — rare enough to leave alone rather than quietly change how it looks.

**2. `TextLayout.draw` batches the whole layout** instead of flushing per line. Every positioned run already carries its absolute baseline, so a uniformly coloured paragraph is a single glyph composite; only a colour change forces a flush. This helps the unclipped path too.

## Result

```
text: paragraph, no clip              43 -> 32 requests,  1 composite,  0.16 Mpx
text: paragraph, inside a rect clip   91 -> 43 requests,  1 composite,  0.16 Mpx
```

Clipping text is now free relative to not clipping it, and the unclipped case got cheaper as well.

## Tests

304/304, plus two new ones in `test/glyph-clip.test.js`:

- **both clip paths produce identical pixels** — the same region expressed as an integral rect (fast path) and as a five-point path (mask path), compared pixel by pixel. This is the assertion that matters: the fast path is only safe if it's indistinguishable.
- **a fractional clip rect falls back to the mask**, asserted directly on `_clipRect()`.

Also verified end-to-end on real XQuartz through react-x11: a scrolled `<textarea>` clips mid-glyph at its boundary with no bleed onto the widgets above.

## Still open

`_fillPolys` has the same full-surface pattern — 50 small rounded boxes cost 8.16 Mpx in the same benchmark. Same fix (bound the mask to the path's bounding box), but a separate change with a wider blast radius, so not bundled here.