### PR TITLE
perf(2d): bound fill and stroke mask work to the shape's bounding box

### DIFF
--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -552,6 +552,34 @@ class RenderingContext2d {
    * Core fill: rasterize device-space polys into the scratch a8 mask,
    * scale by globalAlpha, intersect with the clip, composite the source.
    */
+  /**
+   * Device-space bounding box of flattened polys, with a pixel of slack for
+   * the antialiased edge, clamped to the surface. Null when nothing lands
+   * on it.
+   */
+  _polysBBox(polys) {
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const poly of polys) {
+      const pts = poly.pts;
+      for (let i = 0; i < pts.length; i += 2) {
+        if (pts[i] < minX) minX = pts[i];
+        if (pts[i] > maxX) maxX = pts[i];
+        if (pts[i + 1] < minY) minY = pts[i + 1];
+        if (pts[i + 1] > maxY) maxY = pts[i + 1];
+      }
+    }
+    if (maxX === -Infinity) return null;
+    const x = Math.max(0, Math.floor(minX) - 1);
+    const y = Math.max(0, Math.floor(minY) - 1);
+    const w = Math.min(this.width, Math.ceil(maxX) + 1) - x;
+    const h = Math.min(this.height, Math.ceil(maxY) + 1) - y;
+    if (w <= 0 || h <= 0) return null;
+    return { x, y, w, h };
+  }
+
   _fillPolys(polys, rule, { src = null, op = null, alpha = null } = {}) {
     if (!polys.length) return;
     src = src ?? this._backgroundPicture;
@@ -559,26 +587,31 @@ class RenderingContext2d {
     alpha = alpha ?? this.globalAlpha;
     if (alpha <= 0) return;
 
+    // Everything below is bounded to the shape's bounding box rather than
+    // the whole surface. On the wire it makes no difference — a Composite
+    // request is the same size either way — but it is the difference
+    // between the server touching a 34x34 box and a 400x400 one per fill.
+    // Stale mask content outside the box is never composited, so clearing
+    // only the box is safe.
+    const b = this._polysBBox(polys);
+    if (!b) return;
+    const R = this.Render;
+
     this._ensureFillMask();
-    this.Render.FillRectangles(this.Render.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
+    R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [b.x, b.y, b.w, b.h]);
     this._rasterizePolys(this.fillMask, polys, rule);
 
     if (alpha < 1) {
       // In with a constant color scales the a8 coverage by that alpha
-      this.Render.FillRectangles(this.Render.PictOp.In, this.fillMask.id, [0, 0, 0, alpha], [0, 0, this.width, this.height]);
+      R.FillRectangles(R.PictOp.In, this.fillMask.id, [0, 0, 0, alpha], [b.x, b.y, b.w, b.h]);
     }
     if (this.clipMask) {
-      this.Render.Composite(
-        this.Render.PictOp.In,
-        this.clipMask.id,
-        0,
-        this.fillMask.id,
-        0, 0, 0, 0, 0, 0,
-        this.width,
-        this.height
-      );
+      // clipMask is surface-aligned, so it is sampled at the same offset
+      R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, b.x, b.y, 0, 0, b.x, b.y, b.w, b.h);
     }
-    this.Render.Composite(op, src.id, this.fillMask.id, this.picture.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    // src is either a 1x1 repeating solid (offset irrelevant) or a
+    // surface-aligned gradient, so it is sampled at the same offset too
+    R.Composite(op, src.id, this.fillMask.id, this.picture.id, b.x, b.y, b.x, b.y, b.x, b.y, b.w, b.h);
     this._markDirty();
   }
 

--- a/test/fill-bbox.test.js
+++ b/test/fill-bbox.test.js
@@ -1,0 +1,115 @@
+// _fillPolys bounds its mask work to the shape's bounding box rather than
+// the whole surface. Three things that could break: stale mask content
+// from a previous fill leaking in, a shape crossing the surface edge, and
+// the antialiased edge losing its slack.
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+let app = null;
+const W = 120;
+const H = 120;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+const read = (ctx) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d))),
+  );
+
+// BGRA -> [r, g, b]
+const at = (img, x, y) => {
+  const i = (y * W + x) * 4;
+  return [img.data[i + 2], img.data[i + 1], img.data[i]];
+};
+const isWhite = (p) => p[0] > 240 && p[1] > 240 && p[2] > 240;
+
+test('a later fill does not leak the previous shape through a stale mask', async () => {
+  const ctx = freshCtx();
+  // a big shape, then a small one far away: the small fill must not drag
+  // any of the big one's coverage along with it
+  ctx.fillStyle = 'red';
+  ctx.beginPath();
+  ctx.rect(0, 0, 60, 60);
+  ctx.fill();
+  ctx.fillStyle = 'blue';
+  ctx.beginPath();
+  ctx.rect(90, 90, 20, 20);
+  ctx.fill();
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 10, 10), [255, 0, 0], 'first shape still red');
+  assert.deepEqual(at(img, 95, 95), [0, 0, 255], 'second shape blue');
+  assert.ok(isWhite(at(img, 75, 20)), 'gap between them untouched');
+  assert.ok(isWhite(at(img, 20, 75)), 'and below the first shape');
+});
+
+test('a shape crossing the surface edge still fills what is on-surface', async () => {
+  const ctx = freshCtx();
+  ctx.fillStyle = 'green';
+  ctx.beginPath();
+  // starts off-surface on both axes and ends inside it
+  ctx.rect(-30, -30, 70, 70);
+  ctx.fill();
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 0, 0), [0, 128, 0], 'top-left corner filled');
+  assert.deepEqual(at(img, 30, 30), [0, 128, 0], 'interior filled');
+  assert.ok(isWhite(at(img, 60, 60)), 'past the shape is untouched');
+});
+
+test('overlapping fills still composite in order', async () => {
+  const ctx = freshCtx();
+  ctx.fillStyle = 'red';
+  ctx.beginPath();
+  ctx.rect(10, 10, 50, 50);
+  ctx.fill();
+  ctx.fillStyle = 'blue';
+  ctx.beginPath();
+  ctx.rect(35, 35, 50, 50);
+  ctx.fill();
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 20, 20), [255, 0, 0], 'red where only red is');
+  assert.deepEqual(at(img, 45, 45), [0, 0, 255], 'blue wins the overlap');
+  assert.deepEqual(at(img, 75, 75), [0, 0, 255], 'blue where only blue is');
+});
+
+test('a clipped fill is still clipped', async () => {
+  const ctx = freshCtx();
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, 0, W, 40);
+  ctx.clip();
+  ctx.fillStyle = 'red';
+  ctx.beginPath();
+  ctx.rect(10, 10, 60, 80); // extends well past the clip
+  ctx.fill();
+  ctx.restore();
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 20, 20), [255, 0, 0], 'inside the clip is filled');
+  assert.ok(isWhite(at(img, 20, 60)), 'below the clip is untouched');
+});


### PR DESCRIPTION
`_fillPolys` cleared and composited the **entire surface** for every fill, so a 34×34 rounded box cost the same server work as one covering the whole window. It is the single mask path behind `fill()`, `stroke()` and `fillRect()`, so this applied to nearly all drawing.

## Measurement

react-x11's protocol benchmark, 50 small rounded boxes:

```
                          requests   composites      Mpx
before                         175           51     8.16
after                          175           51     0.22
```

**37× less pixel work.** Request count is unchanged — a `Composite` request is the same 36 bytes whatever area it covers, which is exactly why this went unnoticed until the benchmark started totalling composited area.

Combined with #81, the benchmark's drawing scenarios now look like:

```
text: paragraph, no clip              32 reqs   1 composite   0.16 Mpx
text: paragraph, inside a rect clip   43 reqs   1 composite   0.16 Mpx
shapes: 50 filled rounded boxes      175 reqs  51 composites  0.22 Mpx
```

## The change

The clear, the alpha scale, the clip intersection and the final composite are all bounded to the path's bounding box — padded a pixel each side for the antialiased edge, clamped to the surface.

Two things that make it safe:

- **Stale mask content outside the box is never composited**, so clearing only the box is enough.
- **Source and clip are sampled at the same offset as the destination**, keeping gradients and clips aligned. Solid pictures are 1×1 repeating, so their offset is irrelevant either way.

## Tests

310/310, including the existing pixel-readback canvas tests for fills, strokes, gradients, alpha and clipping.

`test/fill-bbox.test.js` adds four **guards**. To be clear about what they are: they pass before *and* after the change, as an optimisation's tests should — they assert the behaviour that must survive, not a bug being fixed. They cover the specific ways bbox-bounding could break:

- a later fill leaking the previous shape's coverage through a stale mask
- a shape crossing the surface edge (negative origin) still filling what is on-surface
- overlapping fills still compositing in order
- a clipped fill still being clipped

Also rendered react-x11's widget gallery and dashboard against the change and compared against the committed screenshots — rounded borders, checkmarks, radio dots, switch and slider thumbs, progress fill and dashed borders all unchanged.