### PR TITLE
feat(glx): context tag, GLX visuals for windows, server-side visual discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ lib/clipboard.js           app.clipboard: ICCCM selection/clipboard text
 lib/renderingcontext_2d.js canvas-like context (XRender); CanvasGradient
 lib/path.js                Path2D, SVG path-data parser, affine matrices,
                            adaptive bezier flattening
-lib/renderingcontext_opengl.js  indirect GLX context
+lib/renderingcontext_opengl.js  indirect GLX context (queues GL commands
+                           until MakeCurrent's context tag arrives)
+lib/glx.js                 GLX visual/fbconfig discovery (app.chooseGLXConfig)
 lib/renderingcontext_x11.js     raw core-X drawing context
 lib/picture.js             XRender Picture wrapper (+ blur filter)
 lib/glyphset.js            XRender GlyphSet wrapper

--- a/README.md
+++ b/README.md
@@ -132,10 +132,12 @@ Note that on many systems indirect GLX is disabled by default —
 import { createClient } from 'ntk';
 
 const app = await createClient();
-const wnd = app.createWindow({ width: 300, height: 300 });
+// GLX drawables need a GLX-capable visual, chosen before the window exists
+const glx = await app.chooseGLXConfig({ DEPTH_SIZE: 24 });
+const wnd = app.createWindow({ width: 300, height: 300, visual: glx.visual, depth: glx.depth });
 wnd.map();
 
-const gl = wnd.getContext('opengl');
+const gl = wnd.getContext('opengl', glx);
 gl.ClearColor(0.3, 0.3, 0.3, 0.0);
 gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 gl.Begin(gl.TRIANGLES);

--- a/docs/app.md
+++ b/docs/app.md
@@ -15,9 +15,8 @@ const app2 = await createClient({ display: ':1' });
   ntk additionally understands:
   - `fontSource` — pluggable system-font lookup for `app.fonts`
     (see [fonts.md](fonts.md#pluggable-font-sources));
-  - `glxVisual` — visual id used by `getContext('opengl')` in environments
-    where `glxinfo` cannot be shelled out to
-    (see [context-opengl.md](context-opengl.md));
+  - `glxVisual` — visual id `getContext('opengl')` should use instead of
+    querying the server for one (see [context-opengl.md](context-opengl.md));
   - `onXError` — called with X protocol errors that no request callback
     claimed (races like a request landing after its window was destroyed).
     Defaults to a `console.warn`; without any listener node-x11's error
@@ -42,6 +41,13 @@ const app2 = await createClient({ display: ':1' });
 - `app.createWindow(args) → Window` — see [window.md](window.md)
 - `app.rootWindow() → Window` — wrapper for the first screen's root window
 - `app.createPixmap(args) → Pixmap` — see [pixmap.md](pixmap.md)
+- `app.createColormap(visual, screen = 0) → id` — allocate a colormap for a
+  visual (alloc None). Windows created with an explicit `visual` get one
+  automatically, so this is only needed to share one between windows
+- `app.chooseGLXConfig(spec) → Promise<config>` — pick a GLX-capable visual
+  by querying the server; `config.visual`/`config.depth` feed `createWindow`
+  and the whole object feeds `getContext('opengl', config)`. See
+  [context-opengl.md](context-opengl.md)
 - `app.close() → Promise` — flush pending requests, then close the connection
 
 ## Resource management

--- a/docs/context-opengl.md
+++ b/docs/context-opengl.md
@@ -1,6 +1,6 @@
 # OpenGL rendering context
 
-`wnd.getContext('opengl' [, visual])` returns a context exposing most of the
+`wnd.getContext('opengl' [, config])` returns a context exposing most of the
 OpenGL 1.4 fixed-function API over **indirect GLX** — GL commands are
 serialized to the X server, no client-side GL library needed.
 
@@ -10,7 +10,13 @@ serialized to the X server, no client-side GL library needed.
 > `app.display.GLX` is `null` when the extension is unavailable.
 
 ```js
-const gl = wnd.getContext('opengl');
+// a GLX drawable must use a visual the context was created for — choose it
+// before the window exists
+const glx = await app.chooseGLXConfig({ DEPTH_SIZE: 24 });
+const wnd = app.createWindow({ width: 400, height: 300, visual: glx.visual, depth: glx.depth });
+wnd.map();
+
+const gl = wnd.getContext('opengl', glx);
 gl.ClearColor(0.3, 0.3, 0.3, 0.0);
 gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 gl.Begin(gl.TRIANGLES);
@@ -22,19 +28,76 @@ gl.End();
 gl.SwapBuffers();
 ```
 
+## Choosing a visual
+
+`app.chooseGLXConfig(spec)` resolves with
+
+```js
+{ visual, depth, class, doubleBuffer, depthSize, fbconfig, screen, config }
+```
+
+`visual` and `depth` go to `createWindow` (which also creates a matching
+colormap, see [window.md](window.md)); the whole object goes to
+`getContext('opengl', config)`.
+
+`spec` holds GLX attribute constraints by name — `DEPTH_SIZE`,
+`DOUBLEBUFFER`, `RED_SIZE`, `ALPHA_SIZE`, `STENCIL_SIZE`, `SAMPLES`, … Size
+attributes mean "at least"; `null` means "don't care". The defaults are
+`{ DOUBLEBUFFER: true, DEPTH_SIZE: 16, RED_SIZE: 8, GREEN_SIZE: 8, BLUE_SIZE: 8 }`.
+Two more keys are ntk's own: `screen` (default 0) and `visual` (pin a visual
+id and skip the search).
+
+The search asks the server: `GetFBConfigs` first, falling back to the GLX 1.2
+`GetVisualConfigs` — no `glxinfo` shell-out, so it works headlessly and in CI.
+It rejects with a message naming the constraints when nothing matches.
+
+`getContext('opengl')` without a config picks one itself, preferring a config
+for the visual the window already has. That keeps the short form working, but
+a window created without a GLX visual can be rejected by strict servers —
+choose the visual first when you can.
+
+## Setup is asynchronous, the API is not
+
+Two round trips stand between `getContext('opengl')` and a usable context:
+the visual query, and `MakeCurrent` — whose reply is the **context tag** that
+every GLX `Render` request has to carry (passing the context XID instead
+fails every draw with `GLXBadContextTag`).
+
+GL calls made before that are queued and replayed, in order, as soon as the
+context is current, so the example above needs no `await`. When you do want
+to know:
+
+```js
+await gl.ready; // resolves with the context, rejects if setup failed
+gl.contextTag; // the tag MakeCurrent returned (0 until ready)
+gl.contextId; // the GLX context XID
+gl.config; // the config in use
+```
+
+A failed setup (no GLX, no matching visual, indirect GLX disabled) rejects
+`gl.ready`, records `gl.error`, drops the queued commands and warns on the
+console.
+
 ## Notes
 
 - Method names follow the GL C API without the `gl` prefix (`gl.Vertex3f`,
   `gl.MatrixMode`, …); constants likewise (`gl.TRIANGLES`).
-- If `visual` is not passed, it defaults to `createClient({ glxVisual })`
-  when given, else it is discovered by running `glxinfo -i -b` (requires
-  `glxinfo`/mesa-utils installed). Environments that cannot shell out must
-  supply the visual one of those two ways.
 - Queries with replies take a node-style callback:
   `gl.GenTextures(1, (err, textures) => ...)`, `gl.Finish(cb)`.
+- Commands are buffered and flushed as few `Render` requests as possible;
+  `gl.Render()` flushes explicitly, and requests with replies
+  (`SwapBuffers`, `Finish`, display-list calls) flush first.
 - `gl.SwapBuffers()` swaps the owning window.
-- `gl.CreateGLXPixmap(pixmapId)` / `gl.BindTexImage(glxPixmap, buffer)` —
-  render-to-texture helpers (experimental).
+- Display lists (`gl.NewList`/`gl.EndList`/`gl.CallList`) are the way to keep
+  geometry server-side — immediate-mode vertices cost one command each, per
+  frame, on the wire.
+- `gl.CreateGLXPixmap(pixmapId)` / `gl.BindTexImage(glxPixmap, buffer)` /
+  `gl.ReleaseTexImage(glxPixmap, buffer)` — render-to-texture helpers
+  (experimental).
+- `gl.destroy()` (or `Symbol.dispose`) releases the context; the window keeps
+  its drawable.
+- `createClient({ glxVisual })` still pins a visual id for environments that
+  want to bypass the query entirely.
 
 See `examples/gradient.js`, `examples/glclock.js`, `examples/teapot.js`,
 `examples/simpletex.js`.

--- a/docs/window.md
+++ b/docs/window.md
@@ -33,6 +33,18 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
   the computed mask). Note the X *backing-store* attribute is **not**
   forwarded: the `backingStore` option name is taken by ntk's double
   buffering opt-out above, which is an unrelated client-side concept.
+- `visual`, `depth`, `windowClass`, `borderWidth` — `CreateWindow` header
+  fields rather than attributes. They default to `0`, i.e. CopyFromParent /
+  InputOutput. A window on a non-default visual (a GLX drawable, an ARGB
+  visual) needs all of `visual` + `depth` **and** a colormap for that visual:
+  ntk creates one with `app.createColormap(visual)` and frees it in
+  `destroy()` unless you pass your own `colormap`, and sets `borderPixel: 0`
+  because inheriting a border pixmap across depths is a `BadMatch`. See
+  [context-opengl.md](context-opengl.md) for choosing a GLX visual:
+  ```js
+  const glx = await app.chooseGLXConfig({ DEPTH_SIZE: 24 });
+  const wnd = app.createWindow({ width: 400, height: 300, visual: glx.visual, depth: glx.depth });
+  ```
 - `coalesceEvents: false` — deliver every noisy event individually (see
   [Frames, coalescing and slow connections](#frames-coalescing-and-slow-connections))
 - `frameSync: false` — don't pace frames with a server round-trip fence

--- a/examples/gradient.js
+++ b/examples/gradient.js
@@ -24,9 +24,20 @@ function draw(gl) {
 }
 
 const app = await createClient();
-const wnd = app.createWindow({ title: 'simple opengl gradient', x: 100, y: 100, width, height });
+// a GLX drawable must use a visual the context was created for, so the
+// visual is chosen before the window exists
+const glx = await app.chooseGLXConfig({ DEPTH_SIZE: 24 });
+const wnd = app.createWindow({
+  title: 'simple opengl gradient',
+  x: 100,
+  y: 100,
+  width,
+  height,
+  visual: glx.visual,
+  depth: glx.depth
+});
 wnd.map();
-const gl = wnd.getContext('opengl');
+const gl = wnd.getContext('opengl', glx);
 gl.Enable(gl.POINT_SMOOTH);
 wnd.on('resize', (ev) => {
   width = ev.width;

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,5 +1,6 @@
 import Clipboard from './clipboard.js';
 import { CursorCache } from './cursor.js';
+import { chooseGLXConfig } from './glx.js';
 import Pixmap from './pixmap.js';
 import FontManager from './text/fontmanager.js';
 import Window from './window.js';
@@ -13,7 +14,7 @@ export default class App {
    * @param {object} display node-x11 display
    * @param {object} [options] environment hooks: { fontSource (see
    *   text/fontsource.js), glxVisual (visual id for getContext('opengl')
-   *   when glxinfo can't be shelled out to) }
+   *   instead of querying the server for one) }
    */
   constructor(display, options = {}) {
     this.display = display;
@@ -54,6 +55,30 @@ export default class App {
 
   createWindow(args) {
     return new Window(this, args);
+  }
+
+  /**
+   * Allocate a colormap for `visual` (X CreateColormap, alloc None — the
+   * only legal value for the TrueColor visuals we use). Windows created
+   * with an explicit `visual` get one of these automatically.
+   * @returns {number} the colormap id
+   */
+  createColormap(visual, screen = 0) {
+    const mid = this.X.AllocID();
+    this.X.CreateColormap(mid, this.display.screen[screen].root, visual, 0);
+    return mid;
+  }
+
+  /**
+   * Pick a GLX-capable visual (docs/context-opengl.md). Resolves with
+   * `{ visual, depth, class, doubleBuffer, depthSize, fbconfig, screen }` —
+   * pass `visual`/`depth` to `createWindow` and the whole object to
+   * `wnd.getContext('opengl', config)`.
+   * @param {object} [spec] GLX attributes, e.g.
+   *   `{ DEPTH_SIZE: 24, DOUBLEBUFFER: true, ALPHA_SIZE: 8 }`
+   */
+  chooseGLXConfig(spec) {
+    return chooseGLXConfig(this, spec);
   }
 
   rootWindow() {

--- a/lib/glx.js
+++ b/lib/glx.js
@@ -1,0 +1,195 @@
+// GLX visual/fbconfig discovery.
+//
+// A GLX drawable has to use a visual the GL context was created for, so the
+// visual must be known *before* CreateWindow. This module asks the server
+// (GetFBConfigs, falling back to the GLX 1.2 GetVisualConfigs) instead of
+// shelling out to `glxinfo`, so it works headlessly and in CI.
+
+// defaults applied on top of the caller's spec; `null` means "don't care"
+const DEFAULT_SPEC = {
+  DOUBLEBUFFER: true,
+  DEPTH_SIZE: 16,
+  RED_SIZE: 8,
+  GREEN_SIZE: 8,
+  BLUE_SIZE: 8
+};
+
+// GLX 1.2 GetVisualConfigs property names for the attributes we filter on
+const legacyProps = {
+  DOUBLEBUFFER: 'doubleBufferMode',
+  STEREO: 'stereoMode',
+  BUFFER_SIZE: 'rgbBits',
+  DEPTH_SIZE: 'depthBits',
+  STENCIL_SIZE: 'stencilBits',
+  RED_SIZE: 'redBits',
+  GREEN_SIZE: 'greenBits',
+  BLUE_SIZE: 'blueBits',
+  ALPHA_SIZE: 'alphaBits',
+  AUX_BUFFERS: 'numAuxBuffers',
+  LEVEL: 'level'
+};
+
+// attributes compared as "at least this much"; the rest must match exactly
+const minimums = new Set([
+  'BUFFER_SIZE',
+  'DEPTH_SIZE',
+  'STENCIL_SIZE',
+  'RED_SIZE',
+  'GREEN_SIZE',
+  'BLUE_SIZE',
+  'ALPHA_SIZE',
+  'AUX_BUFFERS',
+  'SAMPLE_BUFFERS',
+  'SAMPLES'
+]);
+
+function toNumber(value) {
+  if (typeof value === 'boolean') return value ? 1 : 0;
+  return value;
+}
+
+// the X depth and visual info for a visual id, or null if the screen has no
+// such visual (fbconfigs with VISUAL_ID 0 are pbuffer/pixmap only)
+function visualInfo(screen, visualId) {
+  if (!visualId) return null;
+  for (const depth in screen.depths) {
+    const visual = screen.depths[depth][visualId];
+    if (visual) return { depth: Number(depth), visual };
+  }
+  return null;
+}
+
+function describe(spec) {
+  return (
+    Object.entries(spec)
+      .filter(([, v]) => v !== null && v !== undefined)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ') || '(no constraints)'
+  );
+}
+
+function fbConfigs(GLX, screen, spec) {
+  return new Promise((resolve, reject) => {
+    // ChooseFBConfig filters and sorts per the GLX 1.4 selection rules
+    GLX.ChooseFBConfig(screen, spec, (err, configs) => {
+      // a bad attribute name is the caller's bug, not a missing feature —
+      // everything else means "this server has no fbconfigs for us"
+      if (err instanceof TypeError) return reject(err);
+      resolve(err ? [] : configs);
+    });
+  });
+}
+
+function visualConfigs(GLX, screen) {
+  return new Promise((resolve) => {
+    GLX.GetVisualConfigs(screen, (err, configs) => resolve(err ? [] : configs));
+  });
+}
+
+// GLX 1.2 fallback: filter GetVisualConfigs results by the same spec
+function matchLegacy(configs, spec) {
+  return configs.filter((cfg) => {
+    if (!cfg.rgbMode) return false;
+    for (const key in spec) {
+      const want = toNumber(spec[key]);
+      if (want === null || want === undefined) continue;
+      const prop = legacyProps[key];
+      // attributes GetVisualConfigs doesn't report (RENDER_TYPE,
+      // DRAWABLE_TYPE, ...) can't be checked — RGBA windows are all this
+      // path can offer anyway
+      if (!prop) continue;
+      const have = cfg[prop] || 0;
+      if (minimums.has(key) ? have < want : have !== want) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Choose a GLX-capable visual on `app`'s display.
+ *
+ * @param {import('./app.js').default} app
+ * @param {object} [spec] GLX attribute constraints by name (see
+ *   `GLX.glxAttrib`), e.g. `{ DEPTH_SIZE: 24, DOUBLEBUFFER: true }`;
+ *   `null` means "don't care". `screen` picks the X screen (default 0),
+ *   `visual` pins a specific visual id and skips the search.
+ * @returns {Promise<{visual: number, depth: number, class: number,
+ *   doubleBuffer: boolean, depthSize: number, fbconfig: number|null,
+ *   config: object}>}
+ */
+export async function chooseGLXConfig(app, spec = {}) {
+  const GLX = app.display.GLX;
+  if (!GLX) {
+    throw new Error(
+      'GLX: extension not available on this display — indirect GLX is often disabled (X server flag +iglx / AllowIndirectGLX)'
+    );
+  }
+
+  const { screen: screenNum = 0, preferVisual, ...wanted } = spec;
+  const want = { ...DEFAULT_SPEC, ...wanted };
+  const screen = app.display.screen[screenNum];
+  // a candidate list is searched for `preferVisual` first: a context must
+  // be created for the visual its drawable already has
+  const pick = (candidates) =>
+    (preferVisual && candidates.find((c) => c.visual === preferVisual)) || candidates[0];
+
+  if (want.visual) {
+    const info = visualInfo(screen, want.visual);
+    if (!info) throw new Error(`GLX: visual 0x${want.visual.toString(16)} is not on screen ${screenNum}`);
+    return {
+      visual: want.visual,
+      depth: info.depth,
+      class: info.visual.class,
+      doubleBuffer: !!toNumber(want.DOUBLEBUFFER),
+      depthSize: toNumber(want.DEPTH_SIZE) || 0,
+      screen: screenNum,
+      fbconfig: null,
+      config: {}
+    };
+  }
+
+  // GLX >= 1.3 fbconfigs first; they carry the attributes we care about
+  const fromFbConfigs = [];
+  for (const cfg of await fbConfigs(GLX, screenNum, want)) {
+    const info = visualInfo(screen, cfg.VISUAL_ID);
+    if (!info) continue; // no X visual: pbuffer/pixmap-only config
+    fromFbConfigs.push({
+      visual: cfg.VISUAL_ID,
+      depth: info.depth,
+      class: info.visual.class,
+      doubleBuffer: !!cfg.DOUBLEBUFFER,
+      depthSize: cfg.DEPTH_SIZE || 0,
+      screen: screenNum,
+      fbconfig: cfg.FBCONFIG_ID,
+      config: cfg
+    });
+  }
+  const best = pick(fromFbConfigs);
+  if (best) return best;
+
+  // GLX 1.2 servers (and servers that report no usable fbconfig)
+  const legacy = await visualConfigs(GLX, screenNum);
+  const fromVisuals = [];
+  for (const cfg of matchLegacy(legacy, want)) {
+    const info = visualInfo(screen, cfg.visualID);
+    if (!info) continue;
+    fromVisuals.push({
+      visual: cfg.visualID,
+      depth: info.depth,
+      class: info.visual.class,
+      doubleBuffer: !!cfg.doubleBufferMode,
+      depthSize: cfg.depthBits || 0,
+      screen: screenNum,
+      fbconfig: null,
+      config: cfg
+    });
+  }
+  const legacyBest = pick(fromVisuals);
+  if (legacyBest) return legacyBest;
+
+  throw new Error(
+    `GLX: no visual on screen ${screenNum} matches ${describe(want)} (server offered ${legacy.length} GLX visuals)`
+  );
+}
+
+export default chooseGLXConfig;

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,8 +40,8 @@ import './renderingcontext_opengl.js';
  * @param {object} [options] passed through to x11.createClient
  *   (e.g. { display: ':1' }); ntk additionally understands
  *   { fontSource } — a pluggable system-font lookup (see docs/fonts.md) —
- *   { glxVisual } — the visual id for getContext('opengl') in
- *   environments where `glxinfo` cannot be shelled out to — and
+ *   { glxVisual } — a visual id for getContext('opengl') to use instead of
+ *   querying the server for one — and
  *   { onXError } — called with X protocol errors no request callback
  *   claimed (default: console.warn)
  * @param {function} [callback] optional node-style callback

--- a/lib/renderingcontext_opengl.js
+++ b/lib/renderingcontext_opengl.js
@@ -1,53 +1,143 @@
 import Drawable from './drawable.js';
+import { chooseGLXConfig } from './glx.js';
 
 // Indirect GLX rendering context exposing an OpenGL 1.4-style api.
 // Note: many modern X servers ship with indirect GLX disabled — see README.
+//
+// Setting up a context is asynchronous by protocol: the visual has to be
+// discovered (GetFBConfigs) and, above all, GLX Render requests carry the
+// *context tag* the server returns from MakeCurrent — not the context XID.
+// The api stays synchronous by queueing GL calls until the tag arrives and
+// replaying them in order; `await gl.ready` waits for the setup instead.
 class RenderingContextOpenGL {
-  constructor(window, visual) {
-    // TODO: use glx api to query the best visual instead of shelling out
-    if (typeof visual === 'undefined') visual = window.app?.options?.glxVisual;
-    if (typeof visual === 'undefined') {
-      // lazy builtin lookup: browser bundles must not depend on child_process
-      const cp = globalThis.process?.getBuiltinModule?.('node:child_process');
-      if (!cp) {
-        throw new Error(
-          "getContext('opengl'): no visual id — pass one explicitly or via createClient({ glxVisual }) when glxinfo cannot be run"
-        );
-      }
-      visual = parseInt(cp.execSync('glxinfo -i -b').toString(), 10);
-    }
-
+  constructor(window, config) {
     const X = window.X;
     const GLX = window.display.GLX;
-    this.window = window;
-
-    const ctx = X.AllocID();
-    GLX.CreateContext(ctx, visual, 0, 0, 0);
-    GLX.MakeCurrent(window.id, ctx, 0, () => {});
-
-    const gl = GLX.renderPipeline(ctx);
-    for (const key in gl) {
-      if (key === 'SwapBuffers') continue;
-      const val = gl[key];
-      this[key] = typeof val === 'function' ? val.bind(gl) : val;
+    if (!GLX) {
+      throw new Error(
+        "getContext('opengl'): the X server has no GLX extension — indirect GLX is often disabled (+iglx / AllowIndirectGLX)"
+      );
     }
 
-    const windowId = window.id;
-    this.SwapBuffers = () => gl.SwapBuffers.call(gl, windowId);
+    this.window = window;
+    this.X = X;
+    this.GLX = GLX;
+    /** the MakeCurrent context tag every Render request carries; 0 until ready */
+    this.contextTag = 0;
+    /** the GLX context XID */
+    this.contextId = 0;
+    /** the config chosen (or passed in), see app.chooseGLXConfig */
+    this.config = null;
+    this.visual = 0;
+    this.error = null;
+
+    // GL commands land here until the tag is known, then in the real
+    // pipeline. renderPipeline() issues no traffic, so a throwaway one is a
+    // safe source of the method names and GL constants.
+    let pipeline = null;
+    const queue = [];
+    const template = GLX.renderPipeline(0);
+    for (const key in template) {
+      if (typeof template[key] !== 'function') {
+        this[key] = template[key];
+        continue;
+      }
+      this[key] = (...args) => {
+        if (pipeline) return pipeline[key](...args);
+        queue.push([key, args]);
+      };
+    }
+
+    // SwapBuffers swaps the owning window
+    const swapBuffers = this.SwapBuffers;
+    this.SwapBuffers = () => swapBuffers(window.id);
+
+    const afterReady = (fn) => {
+      if (this.contextTag) return fn();
+      this.ready.then(fn, () => {});
+    };
 
     this.CreateGLXPixmap = (pixmapId) => {
       const glxpixmapId = X.AllocID();
-      GLX.CreateGLXPixmap(0, visual, pixmapId, glxpixmapId);
+      afterReady(() => GLX.CreateGLXPixmap(0, this.visual, pixmapId, glxpixmapId));
       return glxpixmapId;
     };
-    this.BindTexImage = (pixmap, buffer) => {
-      GLX.BindTexImage(ctx, pixmap, buffer);
+    this.BindTexImage = (pixmap, buffer, attribs) => {
+      afterReady(() => GLX.BindTexImage(this.contextTag, pixmap, buffer, attribs));
     };
+    this.ReleaseTexImage = (pixmap, buffer) => {
+      afterReady(() => GLX.ReleaseTexImage(this.contextTag, pixmap, buffer));
+    };
+
+    /** resolves with this context once it is current, rejects on failure */
+    this.ready = (async () => {
+      const cfg = await this._resolveConfig(config);
+      this.config = cfg;
+      this.visual = cfg.visual;
+      if (window.visual && window.visual !== cfg.visual) {
+        console.warn(
+          `ntk: getContext('opengl') is using visual 0x${cfg.visual.toString(16)} on a window created with visual 0x${window.visual.toString(16)} — create the window with the visual from app.chooseGLXConfig()`
+        );
+      }
+
+      const ctx = X.AllocID();
+      this.contextId = ctx;
+      GLX.CreateContext(ctx, cfg.visual, cfg.screen ?? 0, 0, 0);
+      const tag = await new Promise((resolve, reject) => {
+        GLX.MakeCurrent(window.id, ctx, 0, (err, contextTag) => (err ? reject(err) : resolve(contextTag)));
+      });
+
+      this.contextTag = tag;
+      pipeline = GLX.renderPipeline(tag);
+      for (const [key, args] of queue) pipeline[key](...args);
+      queue.length = 0;
+      return this;
+    })();
+
+    this.ready.catch((err) => {
+      this.error = err;
+      queue.length = 0;
+      console.warn(
+        `ntk: getContext('opengl') failed: ${err.message} (await gl.ready to handle this yourself)`
+      );
+    });
+  }
+
+  // an explicit config object or visual id wins; otherwise ask the server
+  // for one, preferring a config for the visual the window already has
+  async _resolveConfig(config) {
+    if (config && typeof config === 'object') {
+      if (!config.visual)
+        throw new Error("getContext('opengl'): config has no visual — use app.chooseGLXConfig()");
+      return config;
+    }
+    const app = this.window.app;
+    const visual = config ?? app?.options?.glxVisual;
+    if (visual) return chooseGLXConfig(app, { visual });
+    const screen = app.display.screen[0];
+    return chooseGLXConfig(app, {
+      preferVisual: this.window.visual || screen.root_visual
+    });
+  }
+
+  /** release the context (the window keeps its drawable) */
+  destroy() {
+    if (!this.contextId) return;
+    const { GLX } = this;
+    const ctx = this.contextId;
+    const tag = this.contextTag;
+    this.contextId = 0;
+    this.contextTag = 0;
+    if (tag) GLX.MakeCurrent(0, 0, tag, () => {});
+    GLX.DestroyContext(ctx);
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
   }
 }
 
 // register context
-Drawable.renderingContextFactory['opengl'] = (window, visual) =>
-  new RenderingContextOpenGL(window, visual);
+Drawable.renderingContextFactory['opengl'] = (window, config) => new RenderingContextOpenGL(window, config);
 
 export default RenderingContextOpenGL;

--- a/lib/window.js
+++ b/lib/window.js
@@ -15,6 +15,8 @@ import * as xevents from './events_map.js';
 //    client-side double buffering (see docs/window.md) and predates this
 //    list — it is a different concept from the X backing-store attribute,
 //    which is therefore not forwarded to avoid a silent collision
+// `visual`, `depth`, `windowClass` and `borderWidth` are CreateWindow header
+// fields rather than attributes, and are handled separately below
 const forwardedXAttributes = [
   'backgroundPixmap',
   'backgroundPixel',
@@ -113,10 +115,29 @@ export default class Window extends Drawable {
       for (const name of forwardedXAttributes) {
         if (args[name] !== undefined) values[name] = args[name];
       }
-      X.CreateWindow(this.id, parentId, this.x, this.y, this.width, this.height, 0, 0, 0, 0, values);
+      // a window on a non-default visual (GLX, ARGB) also needs its own
+      // colormap and an explicit border pixel: inheriting either from a
+      // parent of a different depth is a BadMatch (X11 CreateWindow)
+      this.visual = args.visual ?? 0;
+      this.depth = args.depth ?? 0;
+      this.windowClass = args.windowClass ?? 0;
+      if (this.visual) {
+        if (values.colormap === undefined) {
+          this._ownedColormap = app.createColormap(this.visual);
+          values.colormap = this._ownedColormap;
+        }
+        if (values.borderPixel === undefined && values.borderPixmap === undefined) values.borderPixel = 0;
+      }
+      const borderWidth = args.borderWidth ?? 0;
+      X.CreateWindow(
+        this.id, parentId, this.x, this.y, this.width, this.height,
+        borderWidth, this.depth, this.windowClass, this.visual, values
+      );
     } else {
       this.id = args.id;
       this.eventMask = 0;
+      this.visual = 0;
+      this.depth = 0;
       // populate width and height
       X.GetGeometry(this.id, (err, res) => {
         if (!err) {
@@ -124,6 +145,7 @@ export default class Window extends Drawable {
           this.height = res.height;
           this.x = res.xPos;
           this.y = res.yPos;
+          this.depth = res.depth;
         }
         this._readyPromiseResolve();
       });
@@ -293,7 +315,9 @@ export default class Window extends Drawable {
       parent: this,
       width: newW,
       height: newH,
-      depth: this.display.screen[0].root_depth
+      // must match the window's depth: CopyArea between drawables of
+      // different depths is a BadMatch
+      depth: this.depth || this.display.screen[0].root_depth
     });
     if (!this._clearGc) {
       // reusable across reallocs: a GC is valid for any drawable of the
@@ -974,6 +998,11 @@ export default class Window extends Drawable {
       this._backing = null;
     }
     safeRelease(this.X, () => this.X.DestroyWindow(this.id));
+    if (this._ownedColormap) {
+      const colormap = this._ownedColormap;
+      this._ownedColormap = null;
+      safeRelease(this.X, () => this.X.FreeColormap(colormap));
+    }
   }
 
   [Symbol.dispose]() {

--- a/test/glx.test.js
+++ b/test/glx.test.js
@@ -1,0 +1,253 @@
+// Indirect GLX: visual discovery, GLX-visual windows, and the context tag.
+// Hermetic — node-x11's in-process pure-JS X server with its GLX emulator
+// (browser/glx) registered as an extension, so GL commands that reach the
+// server show up as calls on a RecordingBackend. No $DISPLAY, no GL.
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { after, before, describe, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const require = createRequire(import.meta.url);
+const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
+const { createServer, createStreamPair } = xserver;
+
+let app = null;
+let backend = null;
+let xErrors = [];
+let requests = [];
+
+// requests ntk sends, decoded from the client stream: the JS X server keeps
+// no visual/depth of its own for a window, so the CreateWindow header is
+// checked on the wire
+function decodeRequests(chunks) {
+  const out = [];
+  for (const chunk of chunks) {
+    let offset = 0;
+    while (offset + 4 <= chunk.length) {
+      const words = chunk.readUInt16LE(offset + 2);
+      if (words === 0) break; // BigRequests form: not used by these tests
+      const end = offset + words * 4;
+      if (end > chunk.length) break;
+      out.push({ opcode: chunk[offset], body: chunk.subarray(offset, end) });
+      offset = end;
+    }
+  }
+  return out;
+}
+
+const createWindowRequests = () =>
+  decodeRequests(requests)
+    .filter((r) => r.opcode === 1)
+    .map(({ body }) => ({
+      depth: body[1],
+      window: body.readUInt32LE(4),
+      class: body.readUInt16LE(22),
+      visual: body.readUInt32LE(24),
+      valueMask: body.readUInt32LE(28)
+    }));
+
+// CreateWindow value-list bits (x11 protocol)
+const VALUE_BORDER_PIXEL = 0x8;
+const VALUE_COLORMAP = 0x2000;
+
+// drain the connection: everything queued has been processed by the server
+const settle = () =>
+  new Promise((resolve) =>
+    app.X.GetInputFocus(() => setImmediate(() => app.X.GetInputFocus(() => resolve())))
+  );
+
+before(async () => {
+  const server = createServer({ width: 320, height: 240 });
+  backend = new RecordingBackend();
+  const surfaces = new Map();
+  server.registerExtension(
+    'GLX',
+    createGlxExtension({
+      backend,
+      getDrawableSurface: (xid) => surfaces.get(xid) || null
+    })
+  );
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: (err) => xErrors.push(err)
+  });
+
+  // record requests from here on (the connection setup is already past)
+  const write = clientEnd.write.bind(clientEnd);
+  clientEnd.write = (chunk, ...rest) => {
+    requests.push(Buffer.from(chunk));
+    return write(chunk, ...rest);
+  };
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+describe('GLX config discovery', () => {
+  test('chooseGLXConfig finds a depth-buffered visual without shelling out', async () => {
+    const config = await app.chooseGLXConfig();
+    const screen = app.display.screen[0];
+    assert.equal(config.visual, screen.root_visual, "the server's GL-capable visual");
+    assert.equal(config.depth, screen.root_depth, 'X depth for that visual, ready for CreateWindow');
+    assert.ok(config.depthSize >= 16, `depth buffer requested by default, got ${config.depthSize}`);
+    assert.equal(config.doubleBuffer, true);
+    assert.equal(config.screen, 0);
+  });
+
+  test('an impossible spec fails with a message naming the constraints', async () => {
+    await assert.rejects(
+      () => app.chooseGLXConfig({ SAMPLES: 16, DEPTH_SIZE: 64 }),
+      /SAMPLES=16.*DEPTH_SIZE=64|DEPTH_SIZE=64.*SAMPLES=16/s
+    );
+  });
+
+  test('an unknown attribute name is reported, not silently ignored', async () => {
+    await assert.rejects(() => app.chooseGLXConfig({ DEPTH_SIZEE: 24 }), /unknown GLX attribute/);
+  });
+});
+
+describe('GLX windows', () => {
+  test('createWindow carries the chosen visual, depth and a colormap', async () => {
+    const config = await app.chooseGLXConfig();
+    requests = [];
+    const wnd = app.createWindow({
+      width: 64,
+      height: 48,
+      visual: config.visual,
+      depth: config.depth
+    });
+    await settle();
+
+    const created = createWindowRequests().find((r) => r.window === wnd.id);
+    assert.ok(created, 'CreateWindow for the new window');
+    assert.equal(created.visual, config.visual, 'visual reaches the server (was hardcoded 0)');
+    assert.equal(created.depth, config.depth, 'depth reaches the server (was hardcoded 0)');
+    assert.ok(created.valueMask & VALUE_COLORMAP, 'a colormap for that visual is created and attached');
+    assert.ok(created.valueMask & VALUE_BORDER_PIXEL, 'border pixel set: inheriting one is a BadMatch');
+    assert.equal(xErrors.length, 0, `no X errors: ${xErrors.map((e) => e.message).join(', ')}`);
+    wnd.destroy();
+  });
+
+  test('windows without a visual are unchanged (CopyFromParent)', async () => {
+    requests = [];
+    const wnd = app.createWindow({ width: 32, height: 32 });
+    await settle();
+
+    const created = createWindowRequests().find((r) => r.window === wnd.id);
+    assert.equal(created.visual, 0, 'CopyFromParent');
+    assert.equal(created.depth, 0);
+    assert.equal(created.class, 0);
+    assert.ok(!(created.valueMask & VALUE_COLORMAP), 'no colormap of its own');
+    wnd.destroy();
+  });
+});
+
+describe("getContext('opengl')", () => {
+  test("renders with MakeCurrent's context tag, not the context XID", async () => {
+    const config = await app.chooseGLXConfig();
+    const wnd = app.createWindow({
+      width: 64,
+      height: 48,
+      visual: config.visual,
+      depth: config.depth
+    });
+    const gl = wnd.getContext('opengl', config);
+
+    // drawing before the context is current is allowed: the calls queue
+    gl.ClearColor(0.2, 0.4, 0.6, 1);
+    gl.Clear(gl.COLOR_BUFFER_BIT);
+    gl.Begin(gl.TRIANGLES);
+    gl.Vertex3f(-1, -1, 0);
+    gl.Vertex3f(1, -1, 0);
+    gl.Vertex3f(0, 1, 0);
+    gl.End();
+    gl.Render(); // flush the pipeline
+
+    await gl.ready;
+    await settle();
+
+    assert.ok(gl.contextTag > 0, 'MakeCurrent replied with a context tag');
+    assert.notEqual(gl.contextTag, gl.contextId, 'the tag is not the context XID');
+    assert.equal(xErrors.length, 0, `no GLXBadContextTag: ${xErrors.map((e) => e.message).join(', ')}`);
+
+    const names = backend.calls.map((c) => c[0]);
+    assert.deepEqual(
+      names.filter((n) => n !== 'resize'),
+      ['clearColor', 'clear', 'begin', 'vertex', 'vertex', 'vertex', 'end'],
+      'the whole command stream reached the server'
+    );
+    const [, ...rgba] = backend.calls.find((c) => c[0] === 'clearColor');
+    // float32 on the wire
+    rgba.forEach((c, i) =>
+      assert.ok(Math.abs(c - [0.2, 0.4, 0.6, 1][i]) < 1e-6, `clear colour component ${i}`)
+    );
+
+    gl.destroy();
+    wnd.destroy();
+  });
+
+  test('calls made after the context is current go straight out', async () => {
+    const config = await app.chooseGLXConfig();
+    const wnd = app.createWindow({
+      width: 32,
+      height: 32,
+      visual: config.visual,
+      depth: config.depth
+    });
+    const gl = wnd.getContext('opengl', config);
+    await gl.ready;
+
+    backend.calls.length = 0;
+    gl.MatrixMode(gl.MODELVIEW);
+    gl.LoadIdentity();
+    gl.Render();
+    await settle();
+
+    assert.deepEqual(
+      backend.calls.map((c) => c[0]),
+      ['matrixMode', 'loadIdentity']
+    );
+    assert.equal(xErrors.length, 0, `no X errors: ${xErrors.map((e) => e.message).join(', ')}`);
+    gl.destroy();
+    wnd.destroy();
+  });
+
+  test('display lists compile and replay server-side', async () => {
+    const config = await app.chooseGLXConfig();
+    const wnd = app.createWindow({
+      width: 32,
+      height: 32,
+      visual: config.visual,
+      depth: config.depth
+    });
+    const gl = wnd.getContext('opengl', config);
+    await gl.ready;
+
+    backend.calls.length = 0;
+    gl.NewList(1, gl.COMPILE);
+    gl.Begin(gl.TRIANGLES);
+    gl.Vertex3f(0, 0, 0);
+    gl.End();
+    gl.EndList();
+    gl.CallList(1);
+    gl.Render();
+    await settle();
+
+    // the geometry is sent once; the second draw is a single CallList
+    assert.deepEqual(
+      backend.calls.map((c) => c[0]),
+      ['begin', 'vertex', 'end'],
+      'the list body runs once, on CallList — not on compile'
+    );
+    assert.equal(xErrors.length, 0, `no X errors: ${xErrors.map((e) => e.message).join(', ')}`);
+    gl.destroy();
+    wnd.destroy();
+  });
+});


### PR DESCRIPTION
Phase 0 of the react-x11 3D plan ([docs/glx-plan.md](https://github.com/sidorares/react-x11/blob/master/docs/glx-plan.md)): three fixes that together make indirect GLX usable. Each one was, on its own, enough to break `getContext('opengl')` on a correct X server.

### 1. Use MakeCurrent's context tag

`MakeCurrent`'s reply **is** the context tag, and every GLX `Render` request has to carry it. ntk threw the reply away and passed the context XID:

```js
GLX.MakeCurrent(window.id, ctx, 0, () => {}); // reply discarded
const gl = GLX.renderPipeline(ctx);           // XID, not the tag
```

so every draw failed with `GLXBadContextTag` (XID `10485762` vs tag `1`).

Setup is asynchronous by protocol — a visual query and `MakeCurrent` — so the context **queues GL calls and replays them in order** once it is current. The synchronous API is unchanged; `await gl.ready` is there when the outcome matters, along with `gl.contextTag`, `gl.contextId`, `gl.config` and `gl.error`.

`BindTexImage` had the same bug (it takes a tag too); `ReleaseTexImage`, `destroy()` and `Symbol.dispose` are new.

### 2. `createWindow` takes `visual` / `depth` / `windowClass` / `borderWidth`

`CreateWindow` hardcoded `0, 0, 0, 0`, so every window was CopyFromParent — but a GLX drawable needs the visual its context was created for. A window on a non-default visual also needs a colormap for that visual (created automatically and freed in `destroy()`, or pass your own `colormap`) and an explicit border pixel, since inheriting a border pixmap across depths is a `BadMatch`. The double-buffering backing pixmap now follows the window's depth instead of the root's.

### 3. Ask the server for the visual, don't shell out to `glxinfo`

New `app.chooseGLXConfig(spec)` → `{ visual, depth, class, doubleBuffer, depthSize, fbconfig, screen, config }`, over `GetFBConfigs` with a `GetVisualConfigs` fallback. `spec` takes GLX attribute names (`DEPTH_SIZE`, `DOUBLEBUFFER`, `SAMPLES`, …), defaults to a double-buffered RGB8 config with a depth buffer, and rejects with a message naming the constraints when nothing matches. The old `glxinfo -i -b` probe could not work headlessly, in CI, or in a browser bundle (the `child_process` dependency is gone).

```js
const glx = await app.chooseGLXConfig({ DEPTH_SIZE: 24 });
const wnd = app.createWindow({ width: 400, height: 300, visual: glx.visual, depth: glx.depth });
const gl = wnd.getContext('opengl', glx);
```

`getContext('opengl')` with no config still works: it picks a config itself, preferring one for the visual the window already has.

### Testing

New `test/glx.test.js` is hermetic — node-x11's in-process pure-JS X server with its GLX emulator (`x11/browser/glx`) registered as an extension, so GL commands that reach the server show up as calls on a `RecordingBackend`:

- the full command stream arrives (impossible with a bad tag — the emulator answers `GLXBadContextTag` exactly like a real server), queued-before-ready and after-ready paths both
- display lists compile and replay server-side
- `chooseGLXConfig` finds a depth-buffered visual; bad specs and unknown attribute names are reported
- `CreateWindow` carries visual, depth, colormap and border pixel on the wire; windows without a visual are unchanged

Also verified by hand on XQuartz: `examples/gradient.js` (explicit config, updated to the new pattern) and `examples/glclock.js` (auto-discovery) both render.

Docs: `docs/context-opengl.md` rewritten, `docs/window.md` and `docs/app.md` updated, README sample fixed.