### PR TITLE
feat(css): export cssColor and cssLength

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -41,6 +41,11 @@ The yoga-layout instance ntk uses is re-exported as `Yoga`
 react-x11 renderer — share the same WASM module and enum values instead of
 loading a second, possibly version-mismatched copy.
 
+The two value parsers the CSS layer is built on are exported for the same
+reason: `cssColor(value)` → `[r, g, b, a]` floats 0..1 (what XRender and GL
+both want) or `null`, and `cssLength(value, emBase, rootSize)` → `{ px }`,
+`{ pct }`, `'auto'` or `null`.
+
 ## The safety / responsibility model
 
 The API is deliberately split so that a document can never act on its own:

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ import SvgView from './widgets/svgview.js';
 import MarkdownView from './widgets/markdownview.js';
 import TexView, { configureTex, layoutTex, TexBox } from './widgets/tex.js';
 import { tokenize as highlightCode } from './widgets/highlight.js';
+import { cssColor, cssLength } from './widgets/css.js';
 
 // rendering context modules register themselves on Drawable
 import './renderingcontext_x11.js';
@@ -126,7 +127,9 @@ export {
   TexBox,
   layoutTex,
   configureTex,
-  highlightCode
+  highlightCode,
+  cssColor,
+  cssLength
 };
 // the yoga-layout instance ntk lays HtmlView out with — downstream layout
 // consumers (e.g. the react-x11 renderer) must share it to avoid loading a


### PR DESCRIPTION
This commit was pushed to `feat/glx-phase0` about 90 seconds after #85 was merged, so it never made it into the squash — master has the GLX work but not this export. Same change, cherry-picked onto master.

`cssColor(value)` → `[r, g, b, a]` floats 0..1 or `null`, `cssLength(value, emBase, rootSize)` → `{ px }` / `{ pct }` / `'auto'` / `null`. Both already back the 2d context and HtmlView; downstream renderers need the same conversion — GL wants colours as floats too — and cannot deep-import past the package exports map.

react-x11's `<glarea>` element uses `cssColor` for its `clearColor` prop, so it needs this in the release alongside #85.