### PR TITLE
feat: keyboard focus events, wnd.focus(), and pointer/keyboard grabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ lib/window.js              Window (extends Drawable): events, geometry, WM bits
 lib/pixmap.js              offscreen drawable
 lib/drawable.js            EventEmitter base + getContext() registry
 lib/events_map.js          X event code <-> browser-ish event name tables
+                           (incl. FocusIn/FocusOut as 'focus'/'blur')
 lib/clipboard.js           app.clipboard: ICCCM selection/clipboard text
                            transfer (CLIPBOARD/PRIMARY, INCR-aware reads)
 lib/renderingcontext_2d.js canvas-like context (XRender); CanvasGradient

--- a/docs/window.md
+++ b/docs/window.md
@@ -170,7 +170,17 @@ All return `this` unless noted.
   focus back, so the authority is the `focus`/`blur` events, not the request
 - `queryFocus(cb)` — `cb(err, { focus, revertTo })`: which window the server
   currently sends key events to
-- `queryPointer(cb)`, `grabPointer()`, `setMouseHintOnly(isOn)`
+- `grabPointer(options, cb)` / `ungrabPointer(time)` — a pointer grab is how
+  menus work on X: while it is held, presses anywhere on the screen are
+  reported to this window instead of the window under the pointer — the
+  window manager's frames included — so a click outside can dismiss the
+  menu. `options`: `{ ownerEvents = true, events = ButtonPress|
+  ButtonRelease|PointerMotion, pointerMode, keyboardMode, confineTo,
+  cursor, time }`; `cb(err, status)` where 0 is Success and 1
+  AlreadyGrabbed. With `ownerEvents` the client's own windows still get
+  their events normally, so a submenu keeps working
+- `grabKeyboard(options, cb)` / `ungrabKeyboard(time)` — the same for keys
+- `queryPointer(cb)`, `setMouseHintOnly(isOn)`
 - `queryTree(cb)` — `cb(err, { parent, root, children })`, all as `Window`s
 - `reparentTo(newParent, x, y)`
 - `setActions()` — opt in to the WM_DELETE_WINDOW protocol (window manager

--- a/docs/window.md
+++ b/docs/window.md
@@ -165,6 +165,11 @@ All return `this` unless noted.
 - `createPixmap(params)` — pixmap defaulting to this window's size, depth 32
 - `setCursor(nameOrShapeId)` — mouse cursor shown over the window (see
   [Cursor](#cursor) below); `setCursor(null)` restores the parent's cursor
+- `focus(revertTo = 2)` — take the keyboard focus (X `SetInputFocus`);
+  `revertTo` is 0 None / 1 PointerRoot / 2 Parent. A window manager may take
+  focus back, so the authority is the `focus`/`blur` events, not the request
+- `queryFocus(cb)` — `cb(err, { focus, revertTo })`: which window the server
+  currently sends key events to
 - `queryPointer(cb)`, `grabPointer()`, `setMouseHintOnly(isOn)`
 - `queryTree(cb)` — `cb(err, { parent, root, children })`, all as `Window`s
 - `reparentTo(newParent, x, y)`
@@ -289,6 +294,7 @@ constructor arg) automatically extends the window's X event mask.
 | `mousemove` | MotionNotify | coalesced per frame; full trail in `ev.coalesced` |
 | `mouseover` / `mouseout` | Enter/LeaveNotify | |
 | `keydown` / `keyup` | KeyPress/Release | `keydown` carries `ev.codepoint` (unicode) |
+| `focus` / `blur` | FocusIn/FocusOut | keyboard focus arrived at or left this window — usually because the window manager moved it. `ev.detail`/`ev.mode` carry the X notify detail and mode |
 | `expose` | Expose | `ev.x/y/width/height` of the damaged area, coalesced per frame (bounding box; rect list in `ev.rects`); on double-buffered windows only emitted when a real repaint is needed (see above) |
 | `draw` | — | synthetic repaint request on double-buffered windows (same payload as the accompanying `expose`) |
 | `resize` | ConfigureNotify | coalesced per frame (last state wins); updates `wnd.width/height/x/y` first |

--- a/lib/events_map.js
+++ b/lib/events_map.js
@@ -9,6 +9,10 @@ eventName[5] = 'mouseup';
 eventName[6] = 'mousemove';
 eventName[7] = 'mouseover';
 eventName[8] = 'mouseout';
+// FocusIn/FocusOut: keyboard focus arriving at or leaving this window,
+// usually because the window manager moved it
+eventName[9] = 'focus';
+eventName[10] = 'blur';
 eventName[12] = 'expose';
 eventName[17] = 'destroy';
 eventName[18] = 'unmap';
@@ -40,6 +44,8 @@ export const mask = {
   resize: x11.eventMask.StructureNotify,
   reparent: x11.eventMask.StructureNotify,
   keydown: x11.eventMask.KeyPress,
+  focus: x11.eventMask.FocusChange,
+  blur: x11.eventMask.FocusChange,
   expose: x11.eventMask.Exposure,
   map_request: x11.eventMask.SubstructureRedirect,
   configure_request: x11.eventMask.SubstructureRedirect,
@@ -74,6 +80,8 @@ export const toSnake = {
   onResize: 'resize',
   onReparent: 'reparent',
   onKeyDown: 'keydown',
+  onFocus: 'focus',
+  onBlur: 'blur',
   onExpose: 'expose',
   onMapRequest: 'map_request',
   onConfigureRequest: 'configure_request',

--- a/lib/window.js
+++ b/lib/window.js
@@ -941,8 +941,58 @@ export default class Window extends Drawable {
     return this;
   }
 
-  grabPointer() {
-    this.X.GrabPointer(this.id, true, x11.eventMask.PointerMotion, 0, 1, 0, 0, 0);
+  /**
+   * Take a pointer grab (X GrabPointer). This is how menus work on X: while
+   * the grab is held, presses anywhere on the screen are reported to this
+   * window instead of going to the window under the pointer — including the
+   * window manager's frames — so a click outside can dismiss the menu.
+   *
+   * With `ownerEvents` (the default) events over the client's *own* windows
+   * are still delivered to them normally, so a submenu keeps working.
+   *
+   * @param {object} [options] { ownerEvents, events, cursor, confineTo, time }
+   * @param {function} [callback] cb(err, status) — 0 is Success, 1 is
+   *   AlreadyGrabbed by another client
+   */
+  grabPointer(options = {}, callback) {
+    const {
+      ownerEvents = true,
+      events = x11.eventMask.ButtonPress | x11.eventMask.ButtonRelease | x11.eventMask.PointerMotion,
+      pointerMode = 1, // Asynchronous
+      keyboardMode = 1,
+      confineTo = 0,
+      cursor = 0,
+      time = 0 // CurrentTime
+    } = options;
+    this.X.GrabPointer(
+      this.id,
+      ownerEvents,
+      events,
+      pointerMode,
+      keyboardMode,
+      confineTo,
+      cursor,
+      time,
+      callback ?? (() => {})
+    );
+    return this;
+  }
+
+  ungrabPointer(time = 0) {
+    safeRelease(this.X, () => this.X.UngrabPointer(time));
+    return this;
+  }
+
+  /** Keyboard counterpart: keys go here while the grab is held. */
+  grabKeyboard(options = {}, callback) {
+    const { ownerEvents = true, pointerMode = 1, keyboardMode = 1, time = 0 } = options;
+    this.X.GrabKeyboard(this.id, ownerEvents, time, pointerMode, keyboardMode, callback ?? (() => {}));
+    return this;
+  }
+
+  ungrabKeyboard(time = 0) {
+    safeRelease(this.X, () => this.X.UngrabKeyboard(time));
+    return this;
   }
 
   reparentTo(newParent, x, y) {

--- a/lib/window.js
+++ b/lib/window.js
@@ -922,6 +922,25 @@ export default class Window extends Drawable {
     return this;
   }
 
+  /**
+   * Take the keyboard focus (X SetInputFocus). `revertTo` says where focus
+   * goes if this window becomes unviewable: 0 None, 1 PointerRoot,
+   * 2 Parent (the default, and the sane choice for a child window).
+   *
+   * Note a window manager may take focus back — the authority is the
+   * 'focus'/'blur' events, not the request.
+   */
+  focus(revertTo = 2) {
+    safeRelease(this.X, () => this.X.SetInputFocus(this.id, revertTo));
+    return this;
+  }
+
+  /** Which window the server currently gives keyboard input to. */
+  queryFocus(callback) {
+    this.X.GetInputFocus(callback);
+    return this;
+  }
+
   grabPointer() {
     this.X.GrabPointer(this.id, true, x11.eventMask.PointerMotion, 0, 1, 0, 0, 0);
   }

--- a/test/window-focus.test.js
+++ b/test/window-focus.test.js
@@ -81,3 +81,45 @@ test('queryFocus reports the window the server gives keys to', async () => {
   assert.equal(focus, wnd.id);
   wnd.destroy();
 });
+
+// Pointer grabs: the mechanism menus are built on. The in-process server
+// implements grab delivery, including owner-events, so this is end to end.
+test('a pointer grab redirects presses outside the client to the grabbing window', async () => {
+  const server = createServer({ width: 320, height: 240 });
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  const client = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+  try {
+    const menu = client.createWindow({ x: 10, y: 10, width: 60, height: 60 });
+    menu.map();
+    const presses = [];
+    menu.on('mousedown', (ev) => presses.push([ev.x, ev.y]));
+    await new Promise((resolve) => client.X.GetInputFocus(() => resolve()));
+
+    const status = await new Promise((resolve, reject) =>
+      menu.grabPointer({}, (err, res) => (err ? reject(err) : resolve(res)))
+    );
+    assert.equal(status, 0, 'grab succeeded');
+
+    // press far away from the menu — with no grab this would go nowhere
+    server.injectPointerMove(250, 200);
+    server.injectButton(1, true);
+    await new Promise((resolve) => client.X.GetInputFocus(() => setImmediate(resolve)));
+
+    assert.equal(presses.length, 1, 'the press was redirected to the grab window');
+    assert.deepEqual(presses[0], [240, 190], 'coordinates relative to it, outside its bounds');
+
+    // release first: a press holds an implicit grab until the button is up
+    server.injectButton(1, false);
+    menu.ungrabPointer();
+    await new Promise((resolve) => client.X.GetInputFocus(() => setImmediate(resolve)));
+
+    server.injectButton(1, true);
+    await new Promise((resolve) => client.X.GetInputFocus(() => setImmediate(resolve)));
+    assert.equal(presses.length, 1, 'nothing reaches it after the ungrab');
+
+    menu.destroy();
+  } finally {
+    await client.close();
+  }
+});

--- a/test/window-focus.test.js
+++ b/test/window-focus.test.js
@@ -1,0 +1,83 @@
+// Keyboard focus: X FocusIn/FocusOut arriving as 'focus'/'blur' events, and
+// wnd.focus() taking it. Hermetic — node-x11's in-process pure-JS X server
+// tracks the focus window and delivers the events, so no display is needed.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import x11 from 'x11';
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+let app = null;
+
+before(async () => {
+  const server = createServer({ width: 320, height: 240 });
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+const settle = () =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+const focusedWindow = () =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err, res) => (err ? reject(err) : resolve(res.focus)))
+  );
+
+test('focus and blur events follow the input focus', async () => {
+  const log = [];
+  const a = app.createWindow({ width: 60, height: 40, onFocus: () => log.push('a:focus') });
+  const b = app.createWindow({ width: 60, height: 40 });
+  a.on('blur', () => log.push('a:blur'));
+  b.on('focus', () => log.push('b:focus'));
+  a.map();
+  b.map();
+  await settle();
+
+  a.focus();
+  await settle();
+  assert.equal(await focusedWindow(), a.id, 'the server moved the focus');
+  assert.deepEqual(log, ['a:focus']);
+
+  b.focus();
+  await settle();
+  assert.deepEqual(log, ['a:focus', 'a:blur', 'b:focus'], 'blur then focus');
+
+  a.destroy();
+  b.destroy();
+});
+
+test('the FocusChange mask is selected by the handler, at creation or later', async () => {
+  const created = app.createWindow({ width: 40, height: 30, onBlur: () => {} });
+  assert.ok(created.eventMask & x11.eventMask.FocusChange, 'from the onBlur arg');
+
+  const later = app.createWindow({ width: 40, height: 30 });
+  assert.equal(later.eventMask & x11.eventMask.FocusChange, 0, 'not before');
+  later.on('focus', () => {});
+  assert.ok(later.eventMask & x11.eventMask.FocusChange, 'after on("focus")');
+
+  created.destroy();
+  later.destroy();
+});
+
+test('queryFocus reports the window the server gives keys to', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.map();
+  await settle();
+  wnd.focus();
+  await settle();
+
+  const focus = await new Promise((resolve, reject) =>
+    wnd.queryFocus((err, res) => (err ? reject(err) : resolve(res.focus)))
+  );
+  assert.equal(focus, wnd.id);
+  wnd.destroy();
+});


### PR DESCRIPTION
A client could not tell when the window manager moved keyboard focus. `lib/events_map.js` had no entry for X events **9 (FocusIn)** and **10 (FocusOut)** and no `FocusChange` mask, so nothing selected them and nothing named them.

That is a real hole for anything with widgets: react-x11 keeps its own per-window focus state, and without these events a focus ring stays lit, a text caret keeps blinking and no blur fires when the user switches windows — it is the blocker under NEXT_STEPS §11.2 there.

- `focus` / `blur` events, browser-ish names like the rest of the map. An `onFocus`/`onBlur` constructor argument selects the mask, and so does a later `.on('focus')` through the existing `newListener` hook.
- `wnd.focus(revertTo = 2)` wraps `SetInputFocus` — node-x11 has the request, nothing exposed it. `revertTo` is 0 None / 1 PointerRoot / 2 Parent.
- `wnd.queryFocus(cb)` → `cb(err, { focus, revertTo })`.

The request is only a request: a window manager may take focus straight back, so the authority is the events, not the call. Documented that way.

Tests are hermetic — node-x11's in-process X server already tracks the focus window and delivers FocusIn/FocusOut to windows selecting `FocusChange`, so: focusing one window then another logs `focus`, `blur`, `focus` in that order; the mask is selected both from the constructor argument and from a later `.on`; and `queryFocus` reports what the server thinks.