### PR TITLE
fix(tex): TeX boxes honour the 2d clip

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -45,6 +45,11 @@ ctx.fillRect(0, 0, 100, 100);
 - `ctx.font` — CSS-ish font string (`'bold italic 40px "DejaVu Sans"'`),
   resolved through fontconfig; see [fonts.md](fonts.md)
 
+Everything that puts ink on the surface goes through the clip: fills,
+strokes, images, text (`fillText`, `TextLayout.draw`) and the KaTeX boxes
+of [`layoutTex`](tex.md). Rectangular clips take a server-side fast path
+(`SetPictureClipRectangles`); non-rectangular ones build an a8 mask.
+
 ## State and transforms
 
 - `save()` / `restore()` — full state stack: styles, line settings, font,

--- a/docs/tex.md
+++ b/docs/tex.md
@@ -63,7 +63,9 @@ configureTex({
   align formulas to surrounding text with `y = textBaseline - box.baseline`
 - `draw(ctx, x, y)` — draw with the top-left corner at (x, y). The context
   `fillStyle` is used for items without an explicit color and left
-  untouched.
+  untouched. Everything it draws — glyph runs, rules and the vector shapes
+  of radicals — honours the context's `clip()`, so a formula inside a
+  clipped box stays inside it.
 
 ## `TexView`
 

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -17,7 +17,7 @@ import {
 } from './path.js';
 import Picture from './picture.js';
 import Pixmap from './pixmap.js';
-import { drawGlyphRuns } from './text/glyphs.js';
+import { compositeTraps, drawGlyphRuns } from './text/glyphs.js';
 import { TextLayout } from './text/layout.js';
 import { reorderRuns } from './text/shape.js';
 import { trapezoidize } from './trapezoid.js';
@@ -805,6 +805,39 @@ class RenderingContext2d {
     R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
     // solid white through the glyphs leaves their coverage in the a8 mask
     drawGlyphRuns(app, R.PictOp.Over, this._glyphSource.id, this.fillMask.id, positioned);
+    R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    R.Composite(op, src.id, this.fillMask.id, this.picture.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    this._markDirty();
+  }
+
+  /**
+   * Trapezoid coverage under the clip — `drawGlyphs` for vector shapes that
+   * are already trapezoidized (KaTeX radicals and rules go this way).
+   * Without it they composite straight to the destination picture and spill
+   * out of clipped boxes, which is what glyphs used to do.
+   */
+  drawTraps(op, src, traps) {
+    if (!traps.length) return;
+    const app = this.window.app;
+    const R = this.Render;
+    if (!this.clipMask) {
+      compositeTraps(app, op, src.id, this.picture.id, traps);
+      this._markDirty();
+      return;
+    }
+    const rect = this._clipRect();
+    if (rect) {
+      if (rect.w === 0 || rect.h === 0) return;
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+      compositeTraps(app, op, src.id, this.picture.id, traps);
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+      this._markDirty();
+      return;
+    }
+    this._ensureFillMask();
+    this._glyphSource ??= this.createSolidPicture(1, 1, 1, 1);
+    R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
+    compositeTraps(app, R.PictOp.Over, this._glyphSource.id, this.fillMask.id, traps);
     R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
     R.Composite(op, src.id, this.fillMask.id, this.picture.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
     this._markDirty();

--- a/lib/widgets/tex.js
+++ b/lib/widgets/tex.js
@@ -22,7 +22,6 @@ import { parseSvgPath } from '../path.js';
 import { flatten } from '../rasterize.js';
 import { trapezoidize } from '../trapezoid.js';
 import Font from '../text/font.js';
-import { compositeTraps, drawGlyphRuns } from '../text/glyphs.js';
 
 // node builtins are fetched lazily so browser bundles never resolve them;
 // there, inject the assets with configureTex() instead.
@@ -571,7 +570,7 @@ export class TexBox {
       Render.Composite(
         Render.PictOp.Over,
         src.id,
-        ctx.clipMask ? ctx.clipMask.id : 0,
+        ctx._compositeMask(),
         ctx.picture.id,
         Math.round(x + item.x),
         Math.round(base + item.y),
@@ -598,7 +597,9 @@ export class TexBox {
         }
         trapezoidize([clipped], x + item.x, base + item.y, traps);
       }
-      compositeTraps(app, Render.PictOp.Over, src.id, ctx.picture.id, traps);
+      // through the context, so the clip applies — compositing straight to
+      // ctx.picture spills out of scrollviews and clipped boxes
+      ctx.drawTraps(Render.PictOp.Over, src, traps);
     }
 
     // batch every run of the same color into a single CompositeGlyphs
@@ -612,7 +613,7 @@ export class TexBox {
     }
     for (const { color, runs } of byColor.values()) {
       const src = color ? ctx._stylePicture(color) : ctx._backgroundPicture;
-      drawGlyphRuns(app, Render.PictOp.Over, src.id, ctx.picture.id, runs);
+      ctx.drawGlyphs(Render.PictOp.Over, src, runs);
     }
 
     ctx._markDirty();

--- a/test/glyph-clip.test.js
+++ b/test/glyph-clip.test.js
@@ -183,3 +183,33 @@ test('rect fast path and mask path clip text identically', async () => {
   assert.equal(diff, 0, 'both clip paths produce the same pixels');
   assert.ok(inkInRows(a, CLIP_TOP, CLIP_BOTTOM) > 0, 'and both actually drew');
 });
+
+// KaTeX content draws its own glyph runs and trapezoidized vector shapes
+// (radicals, fraction rules) rather than going through fillText, so it had
+// to be routed through the clip separately — react-x11's rich-content demo
+// showed formulas painting outside the scrollview they were scrolled out of.
+test('a TeX box stays inside the clip', async () => {
+  const { layoutTex } = await import('../lib/widgets/tex.js');
+  const ctx = freshCtx();
+  // a radical and a fraction: glyph runs plus vector paths and rules
+  const box = layoutTex('\\sqrt{\\frac{x+1}{2}}', { size: 26, color: '#000000' });
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, CLIP_TOP, W, CLIP_BOTTOM - CLIP_TOP);
+  ctx.clip();
+  box.draw(ctx, 6, 2); // drawn high, so most of it lands above the band
+  ctx.restore();
+
+  const image = await readPixels(ctx);
+  assert.equal(inkInRows(image, 0, CLIP_TOP), 0, 'nothing above the clip band');
+  assert.equal(
+    inkInRows(image, CLIP_BOTTOM, H),
+    0,
+    'nothing below the clip band',
+  );
+  assert.ok(
+    inkInRows(image, CLIP_TOP, CLIP_BOTTOM) > 0,
+    'and the part inside the band did draw',
+  );
+});


### PR DESCRIPTION
Reported against react-x11: scroll the rich-content demo so a math fence leaves the `<scrollview>` and the formula keeps painting — over whatever is above it.

`TexBox.draw` puts three kinds of thing on the surface, and only one of them was clipped:

| item | drawn by | clipped before |
| --- | --- | --- |
| rects (fraction rules, overlines) | `Render.Composite` with `ctx.clipMask` | yes |
| vector shapes (radicals, stretchy delimiters) | `compositeTraps` straight to `ctx.picture` | **no** |
| glyph runs | `drawGlyphRuns` straight to `ctx.picture` | **no** |

The 2d context already knew how to clip glyphs — that was sidorares/ntk#79 and #81, including the `SetPictureClipRectangles` fast path for rectangular clips — but `TexBox` called the render helpers itself and bypassed all of it. Same class of bug, one layer up.

- `drawTraps(op, src, traps)` on the context: the trapezoid counterpart of `drawGlyphs`, with the same three paths (no clip, rectangular clip server-side, mask clip through the scratch a8 mask).
- `TexBox.draw` now goes through `ctx.drawGlyphs` and `ctx.drawTraps`, and its rect pass takes `ctx._compositeMask()` so `globalAlpha` applies too.

Everything that renders TeX inherits the fix — `TexView`, `MarkdownView` math fences, `HtmlView`.

Pixel-tested in `test/glyph-clip.test.js` next to the text cases: a radical over a fraction, drawn across a clip band, leaves nothing above or below and still paints inside.