### PR TITLE
fix(text): an empty span list is a layout, not a crash

### DIFF
--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -47,7 +47,12 @@ export class TextLayout {
     // ---- normalize spans, resolve fonts eagerly ----
     // unknown span fields ride along untouched (widgets attach markers like
     // MarkdownView's _deco/_href and read them back from line runs)
-    const spans = (typeof content === 'string' ? [{ text: content }] : content).map((s) => {
+    // An empty span list is a legitimate thing to lay out — MarkdownView
+    // reaches it for a blank paragraph while a document is being typed —
+    // and every line still needs a style to take its metrics from, so
+    // stand one in rather than crashing on the first empty line.
+    const given = typeof content === 'string' ? [{ text: content }] : content;
+    const spans = (given.length ? given : [{ text: '' }]).map((s) => {
       const merged = {
         ...s,
         text: String(s.text ?? ''),

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -162,6 +162,18 @@ test('TextLayout honors explicit newlines', needsFonts, () => {
   assert.equal(layout.lines[2].runs.length, 0); // blank paragraph
 });
 
+test('TextLayout copes with an empty span list', needsFonts, () => {
+  const fonts = new FontManager();
+  // MarkdownView hands over an empty span list for a blank block, which
+  // happens while a document is being typed — every line still needs a
+  // style to take its metrics from, and this used to throw on the first
+  // one ("undefined is not an object (evaluating 'baseSpan.font')")
+  const layout = new TextLayout(fonts, [], { family: 'sans-serif', size: 16 }, {});
+  assert.equal(layout.lines.length, 1);
+  assert.equal(layout.lines[0].runs.length, 0);
+  assert.ok(layout.height > 0, 'the empty line still has the base line height');
+});
+
 test('TextLayout strips trailing whitespace at line ends', needsFonts, () => {
   const fonts = new FontManager();
   const wrapped = new TextLayout(


### PR DESCRIPTION
```
TypeError: undefined is not an object (evaluating 'baseSpan.font')
    at new TextLayout (lib/text/layout.js:191)
    at _layoutBlocks (lib/widgets/markdownview.js:190)
```

`TextLayout` takes the fallback metrics for a line with no runs from `spans[0]` — the base style — and `spans[0]` is `undefined` when the content has no spans at all. `MarkdownView` reaches that state for a blank block, which is easy to hit while a document is being typed: react-x11's widget gallery grew a live `<markdown>` preview of a `<textarea>`, and typing into it crashed the frame.

An empty list now stands in one empty span, resolved through the same style as any other, so the line takes the base style's metrics exactly like every other blank line. Two-line change plus a regression test asserting the layout comes back with one empty line and a non-zero height instead of throwing.