### PR TITLE
feat: setProperty, the write side of the property API

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -188,10 +188,11 @@ All return `this` unless noted.
 - `setSizeHints(hints)`, `setClass(instance, class)`,
   `setWindowType(type)`, `setAlwaysOnTop(on)` — see
   [Window manager hints](#window-manager-hints) below
-- `getProperty(name, options)`, `getTitle()`, `getSizeHints()`,
-  `getAttributes()`, `atom(name)`, `selectInput(mask)`, `addToSaveSet()`,
-  `sendConfigureNotify(geometry)`, `close()`, `grabButton(options)` — the
-  window manager side, see [Being the window manager](#being-the-window-manager)
+- `getProperty(name, options)`, `setProperty(name, value, options)`,
+  `getTitle()`, `getSizeHints()`, `getAttributes()`, `atom(name)`,
+  `selectInput(mask)`, `addToSaveSet()`, `sendConfigureNotify(geometry)`,
+  `close()`, `grabButton(options)` — the window manager side, see
+  [Being the window manager](#being-the-window-manager)
 - `destroy()` — destroy the window server-side (also `Symbol.dispose`)
 
 ## Window manager hints
@@ -365,6 +366,16 @@ The counterparts of the hint setters, for reading other clients' windows:
 - `getProperty(name, { as })` — any property. `as` is `'buffer'` (default,
   `{ type, data }`), `'string'`, or `'numbers'` for 32-bit lists. Resolves
   to `null` when the property is not set
+- `setProperty(name, value, { type, format })` — the write side, and the
+  general form of `setTitle`/`setClass`. Strings go out as `UTF8_STRING`,
+  arrays of numbers as 32-bit lists; `type` names the property type atom,
+  which is what EWMH readers check:
+
+  ```js
+  root.setProperty('_NET_CLIENT_LIST', ids, { type: 'WINDOW' });
+  root.setProperty('_NET_SUPPORTED', atoms, { type: 'ATOM' });
+  ```
+
 - `atom(name)` — intern an atom id, cached per connection
 
 Title changes arrive as `property` events (`PropertyChange`), so a frame

--- a/lib/window.js
+++ b/lib/window.js
@@ -1100,6 +1100,39 @@ export default class Window extends Drawable {
   }
 
   /**
+   * Write a property — the counterpart of getProperty, and the general form
+   * of setTitle/setClass/setSizeHints. Strings are written as UTF8_STRING,
+   * arrays of numbers as 32-bit lists; `type` names the property type atom
+   * ('ATOM', 'CARDINAL', 'WINDOW', 'UTF8_STRING', 'STRING'), which is what
+   * EWMH properties are picky about.
+   *
+   *   wnd.setProperty('_NET_WM_NAME', 'a title');
+   *   wnd.setProperty('_NET_CLIENT_LIST', ids, { type: 'WINDOW' });
+   *
+   * @param {string} name atom name of the property
+   * @param {string|number[]|Buffer} value
+   * @param {object} [options] `{ type, format }`
+   */
+  async setProperty(name, value, options = {}) {
+    const isList = Array.isArray(value);
+    const { type = isList ? 'CARDINAL' : 'UTF8_STRING', format = isList ? 32 : 8 } =
+      options;
+    const [property, typeAtom] = await Promise.all([this.atom(name), this.atom(type)]);
+    let data = value;
+    if (isList) {
+      const words = new Uint32Array(value);
+      data = Buffer.from(words.buffer, words.byteOffset, words.byteLength);
+    } else if (typeof value === 'string') {
+      data = Buffer.from(value, type === 'STRING' ? 'latin1' : 'utf8');
+    }
+    if (this._destroyed) return this;
+    safeRelease(this.X, () => {
+      this.X.ChangeProperty(0, this.id, property, typeAtom, format, data);
+    });
+    return this;
+  }
+
+  /**
    * Intern an atom by name. node-x11 caches them per connection, so asking
    * again for one already interned costs no round trip.
    * @returns {Promise<number>} the atom id

--- a/test/window-manager.test.js
+++ b/test/window-manager.test.js
@@ -206,6 +206,27 @@ test('getProperty decodes strings, numbers and raw bytes, null when unset', asyn
   assert.deepEqual(protocols, [deleteAtom]);
 });
 
+test('setProperty round-trips through getProperty', async () => {
+  const window = wm.createWindow({ width: 40, height: 30 });
+
+  await window.setProperty('_NET_WM_NAME', 'hello ✻ world');
+  assert.equal(
+    await window.getProperty('_NET_WM_NAME', { as: 'string' }),
+    'hello ✻ world'
+  );
+
+  const ids = [0x123456, 0x789abc];
+  await window.setProperty('_NET_CLIENT_LIST', ids, { type: 'WINDOW' });
+  assert.deepEqual(
+    await window.getProperty('_NET_CLIENT_LIST', { as: 'numbers' }),
+    ids
+  );
+
+  // the type atom is what EWMH readers check, so it has to be right
+  const raw = await window.getProperty('_NET_CLIENT_LIST');
+  assert.equal(raw.type, await window.atom('WINDOW'));
+});
+
 test('close asks politely when the client opted in, kills it when it did not', async () => {
   const polite = client.createWindow({ width: 40, height: 30 });
   polite.setActions();


### PR DESCRIPTION
## Why

#95 added `getProperty` but not its counterpart, so ntk can now read any property and still write only the four that have dedicated setters (`setTitle`, `setClass`, `setSizeHints`, `setWindowType`).

That gap shows up immediately when writing a window manager. The EWMH properties applications look for before they trust that a standards-aware WM is running — `_NET_SUPPORTED`, `_NET_SUPPORTING_WM_CHECK`, `_NET_CLIENT_LIST`, `_NET_ACTIVE_WINDOW` — have no setters, and should not get one each.

## What

```js
wnd.setProperty('_NET_WM_NAME', 'a title');
root.setProperty('_NET_CLIENT_LIST', ids, { type: 'WINDOW' });
root.setProperty('_NET_SUPPORTED', atoms, { type: 'ATOM' });
```

Strings are written as `UTF8_STRING` (pass `{ type: 'STRING' }` for the latin-1 legacy form), arrays of numbers as 32-bit lists, buffers verbatim.

The `type` option matters more than it looks: EWMH readers check the property type atom, and a client list typed `CARDINAL` instead of `WINDOW` is silently ignored by everything that reads it. The test asserts the type atom lands correctly for that reason.

## Tests

One new case in `test/window-manager.test.js` covering the string round-trip through `getProperty`, the 32-bit list round-trip, and the type atom. Full suite: **338 passing, 0 failing.**

## Context

Needed by the reparenting window manager demo in [react-x11](https://github.com/sidorares/react-x11), which publishes the EWMH handshake so GTK and Qt clients behave normally under it.