### PR TITLE
fix: hex alpha, and premultiply the colours XRender is given

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -22,9 +22,12 @@ ctx.fillRect(0, 0, 100, 100);
 
 - `ctx.canvas` — the owning drawable (window or pixmap), like in the browser
 - `ctx.width`, `ctx.height` — drawable size
-- `ctx.fillStyle`, `ctx.strokeStyle` — CSS color string (via
-  [parse-color](https://www.npmjs.com/package/parse-color)), a premultiplied
-  `[r, g, b, a]` array (0..1 floats), a `CanvasGradient`, or a `Picture`
+- `ctx.fillStyle`, `ctx.strokeStyle` — a CSS color string, a premultiplied
+  `[r, g, b, a]` array (0..1 floats), a `CanvasGradient`, or a `Picture`.
+  Named colors, `rgb[a]()`, `hsl[a]()` and hex in all four lengths
+  (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) are accepted; anything
+  unparseable throws rather than drawing something arbitrary. See
+  **Color** below for what alpha does
 - `ctx.lineWidth`, `ctx.lineCap`, `ctx.lineJoin`, `ctx.miterLimit` — stroke
   geometry, including `'round'` caps and joins (rendered as triangle-fan
   disks unioned with the stroke mesh)
@@ -49,6 +52,35 @@ Everything that puts ink on the surface goes through the clip: fills,
 strokes, images, text (`fillText`, `TextLayout.draw`) and the KaTeX boxes
 of [`layoutTex`](tex.md). Rectangular clips take a server-side fast path
 (`SetPictureClipRectangles`); non-rectangular ones build an a8 mask.
+
+## Color
+
+XRender colors are **premultiplied**: each of `r`, `g` and `b` is already
+scaled by `a`, so all three must be `<= a`. Color *strings* are converted
+for you — `'rgba(255, 0, 0, 0.5)'` reaches the server as
+`[0.5, 0, 0, 0.5]` — but an **array is taken as already premultiplied and
+passes through untouched**:
+
+```js
+ctx.fillStyle = 'rgba(255, 0, 0, 0.5)'; // half-alpha red
+ctx.fillStyle = [0.5, 0, 0, 0.5]; // the same thing
+ctx.fillStyle = [1, 0, 0, 0.5]; // NOT half-alpha red: out of gamut
+```
+
+The last line is the mistake to know about. It is not rejected — the
+protocol allows it — but it renders brighter than any real color at that
+alpha, and over a white background it clamps to the same pixels as the
+correct value, so it tends to look fine until something dark is underneath.
+White at half alpha is `[0.5, 0.5, 0.5, 0.5]`, not `[1, 1, 1, 0.5]`.
+
+`cssColor(value)` (exported from the package) does the conversion, returning
+premultiplied `[r, g, b, a]` in 0..1, or `null`. Gradient stops go through
+the same path, so `addColorStop(0, 'rgba(255, 0, 0, 0.5)')` is right too.
+
+Set `NTK_STRICT_COLORS=1` to make a component outside 0..1 throw instead of
+being clamped (it wires up x11's `Render.strictColors`); ntk's own test run
+sets it. Note what that does *not* cover: an unpremultiplied `[1, 0, 0, 0.5]`
+is inside 0..1 on every component, so only rendering catches it.
 
 ## State and transforms
 

--- a/docs/html.md
+++ b/docs/html.md
@@ -42,9 +42,11 @@ react-x11 renderer — share the same WASM module and enum values instead of
 loading a second, possibly version-mismatched copy.
 
 The two value parsers the CSS layer is built on are exported for the same
-reason: `cssColor(value)` → `[r, g, b, a]` floats 0..1 (what XRender and GL
-both want) or `null`, and `cssLength(value, emBase, rootSize)` → `{ px }`,
-`{ pct }`, `'auto'` or `null`.
+reason: `cssColor(value)` → **premultiplied** `[r, g, b, a]` floats 0..1
+(what XRender and GL both want — see
+[context-2d.md](context-2d.md#color)) or `null`, and
+`cssLength(value, emBase, rootSize)` → `{ px }`, `{ pct }`, `'auto'` or
+`null`.
 
 ## The safety / responsibility model
 
@@ -138,8 +140,9 @@ query is a bare `screen`/`all` (conditions are not evaluated).
 | text | `color font-family font-size font-weight font-style line-height text-align text-decoration white-space` (`normal pre nowrap`) `list-style-type` |
 | background | `background-color` (and the color of a `background` shorthand) |
 
-Units: `px pt em rem %` and font-size keywords. Colors: named, hex,
-`rgb[a]()`, `hsl[a]()` (via parse-color).
+Units: `px pt em rem %` and font-size keywords. Colors: named, `rgb[a]()`,
+`hsl[a]()`, `transparent`, and hex in all four lengths including alpha
+(`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`).
 
 Not supported (silently ignored): floats, absolute/relative positioning,
 grid, background images, border-radius, shadows, transforms, transitions,

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,0 +1,78 @@
+// Colour parsing, shared by the 2d context and the CSS cascade.
+//
+// Everything here returns **premultiplied** `[r, g, b, a]` floats in 0..1,
+// because that is what XRender takes: a colour reaches the server through
+// CreateSolidFill / FillRectangles / gradient stops, all of which read
+// premultiplied ARGB, so each of r, g and b must be <= a. Straight (a.k.a.
+// unassociated) alpha renders at full brightness instead — red at half alpha
+// composites as #ff0000 rather than #800000 — and since x11 3.3.0 a
+// component above 1 also warns.
+//
+// Hex is parsed here rather than handed to parse-color, which does not
+// understand CSS hex alpha and fails silently on it:
+//
+//   parse-color('#00000022')  ->  rgba [0, 0, 0, 34, 1]   five entries, and
+//                                 the alpha is still a 0..255 byte
+//   parse-color('#0002')      ->  rgba [0, 2, 0, 1]       read as a truncated
+//                                 six-digit hex
+//
+// The first is why `#RRGGBBAA` used to render fully opaque: 34 clamps to 1.
+import parseColorRaw from 'parse-color';
+
+/** `[r, g, b, a]` straight -> premultiplied. Opaque colours are unchanged. */
+export function premultiply([r, g, b, a]) {
+  return a === 1 ? [r, g, b, a] : [r * a, g * a, b * a, a];
+}
+
+// #RGB, #RGBA, #RRGGBB, #RRGGBBAA. Five and seven digits are not CSS, so
+// they are rejected rather than guessed at.
+const HEX = /^#([0-9a-f]{3,8})$/i;
+
+function parseHex(value) {
+  const m = HEX.exec(value);
+  if (!m) return null;
+  const h = m[1];
+  const short = h.length === 3 || h.length === 4;
+  if (!short && h.length !== 6 && h.length !== 8) return null;
+  const part = (i) =>
+    short
+      ? parseInt(h[i], 16) * 0x11 // 'f' -> 0xff
+      : parseInt(h.slice(i * 2, i * 2 + 2), 16);
+  const hasAlpha = h.length === 4 || h.length === 8;
+  return [part(0) / 255, part(1) / 255, part(2) / 255, hasAlpha ? part(3) / 255 : 1];
+}
+
+/**
+ * Parse a CSS colour to premultipliable `[r, g, b, a]` floats, straight
+ * alpha, or null if it is not a colour. Exported for callers that need the
+ * unassociated values; use `cssColor` for anything heading to XRender.
+ */
+export function parseCssColorStraight(value) {
+  if (typeof value !== 'string') return null;
+  const v = value.trim();
+  if (!v) return null;
+  if (v.toLowerCase() === 'transparent') return [0, 0, 0, 0];
+
+  // '#' is ours alone: falling back to parse-color for a hex form we reject
+  // is how '#1234567' turns into rgba [18, 52, 86, 7, 1] -> alpha 7.
+  const rgba = v.startsWith('#') ? parseHex(v) : rawRgba(v);
+  if (!rgba) return null;
+  // NaN would otherwise reach the wire as a garbage fixed-point value
+  return rgba.every((c) => Number.isFinite(c)) ? rgba : null;
+}
+
+function rawRgba(value) {
+  const c = parseColorRaw(value);
+  if (!c || !c.rgba) return null;
+  const [r, g, b, a] = c.rgba;
+  return [r / 255, g / 255, b / 255, a];
+}
+
+/**
+ * Parse a CSS colour to a premultiplied `[r, g, b, a]` in 0..1, ready for
+ * XRender, or null if `value` is not a colour.
+ */
+export function cssColor(value) {
+  const straight = parseCssColorStraight(value);
+  return straight && premultiply(straight);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,12 @@ export function createClient(options, callback) {
           // preload Render and GLX; GLX is optional ( indirect GLX is often
           // disabled on modern servers )
           display.Render = Render;
+          // x11 >= 3.3.0 clamps an out-of-range colour component and warns
+          // once per connection; under NTK_STRICT_COLORS it throws instead,
+          // which is how `npm test` catches a colour that reaches XRender
+          // unpremultiplied (r, g or b above alpha) rather than silently
+          // rendering too bright.
+          if (process.env.NTK_STRICT_COLORS) Render.strictColors = true;
           display.GLX = glxError ? null : GLX;
           const X = display.client;
           X.keycode2keysyms = {};

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -1,7 +1,7 @@
 import parseFontStyle from 'canvas-fontstyle';
 import extrudePolyline from 'extrude-polyline';
-import parseColorRaw from 'parse-color';
 
+import { cssColor } from './color.js';
 import Drawable from './drawable.js';
 import { Image } from './image.js';
 import {
@@ -121,10 +121,15 @@ function dashPolyline(pts, closed, pattern, offset) {
   return { runs, closedLoop: false };
 }
 
+// An array is taken as already-premultiplied `[r, g, b, a]` in 0..1 (the
+// documented form in docs/context-2d.md), so it passes through untouched; a
+// string is a CSS colour and gets premultiplied on the way in. Both end up in
+// createSolidPicture, which hands them to XRender.
 function parseColor(value) {
   if (Array.isArray(value)) return value;
-  const c = parseColorRaw(value);
-  return [c.rgba[0] / 255, c.rgba[1] / 255, c.rgba[2] / 255, c.rgba[3]];
+  const c = cssColor(value);
+  if (!c) throw new Error(`Not a color: ${JSON.stringify(value)}`);
+  return c;
 }
 
 /**

--- a/lib/widgets/css.js
+++ b/lib/widgets/css.js
@@ -4,16 +4,13 @@
 import { selectAll } from 'css-select';
 import postcss from 'postcss';
 
-import parseColorRaw from 'parse-color';
+// Parse a CSS color to premultiplied [r, g, b, a] floats in 0..1, or null.
+// These land on `ctx.fillStyle` as arrays (see htmlview's paint), which is
+// the already-premultiplied form, so the premultiplying happens in color.js.
+// Imported as well as re-exported: the cascade below calls it too.
+import { cssColor } from '../color.js';
 
-/** parse a CSS color to premultipliable [r, g, b, a] floats, or null */
-export function cssColor(value) {
-  if (!value) return null;
-  if (value === 'transparent') return [0, 0, 0, 0];
-  const c = parseColorRaw(String(value).trim());
-  if (!c || !c.rgba) return null;
-  return [c.rgba[0] / 255, c.rgba[1] / 255, c.rgba[2] / 255, c.rgba[3]];
-}
+export { cssColor };
 
 const FONT_SIZE_KEYWORDS = {
   'xx-small': 9,

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "yoga-layout": "^3.2.1"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "NTK_STRICT_COLORS=1 node --test"
   }
 }

--- a/test/color.test.js
+++ b/test/color.test.js
@@ -1,0 +1,168 @@
+// Translucent colours have to reach XRender *premultiplied* — each of r, g
+// and b scaled by alpha. Straight alpha composites at full brightness, and
+// over a white background it clamps to the same result, which is how this
+// stayed invisible: red at half alpha looked right on white and was twice as
+// bright as it should be on anything dark.
+//
+// So every case here paints over black. Hermetic: node-x11's in-process
+// pure-JS X server, no $DISPLAY needed.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+let app = null;
+const W = 20;
+const H = 20;
+
+before(async () => {
+  const server = xserver.createServer({ width: 100, height: 100 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource()
+  });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+// getImageData returns BGRA, so red is index 2
+const centre = async (ctx) => {
+  const d = await new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, data) =>
+      err ? reject(err) : resolve(data)
+    )
+  );
+  const i = (10 * W + 10) * 4;
+  return [d.data[i + 2], d.data[i + 1], d.data[i]];
+};
+
+// fill `under`, then apply a style and fill again over the top
+async function over(under, apply) {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = under;
+  ctx.fillRect(0, 0, W, H);
+  apply(ctx);
+  ctx.fillRect(0, 0, W, H);
+  return centre(ctx);
+}
+
+const near = (got, want, what, tol = 3) =>
+  assert.ok(
+    got.every((v, i) => Math.abs(v - want[i]) <= tol),
+    `${what}: got rgb(${got}), want ~rgb(${want})`
+  );
+
+test('a translucent colour string composites at the right brightness', async () => {
+  // the reference: globalAlpha goes through an a8 mask and was always right
+  near(
+    await over('black', (c) => {
+      c.globalAlpha = 0.5;
+      c.fillStyle = 'red';
+    }),
+    [128, 0, 0],
+    'globalAlpha 0.5 + red'
+  );
+  // ...and colour-string alpha must agree with it
+  near(
+    await over('black', (c) => {
+      c.fillStyle = 'rgba(255, 0, 0, 0.5)';
+    }),
+    [128, 0, 0],
+    'rgba(255, 0, 0, 0.5)'
+  );
+  near(
+    await over('black', (c) => {
+      c.fillStyle = 'hsla(0, 100%, 50%, 0.5)';
+    }),
+    [128, 0, 0],
+    'hsla(0, 100%, 50%, 0.5)'
+  );
+});
+
+test('hex alpha renders as its alpha, not fully opaque', async () => {
+  near(
+    await over('black', (c) => {
+      c.fillStyle = '#ff000080';
+    }),
+    [128, 0, 0],
+    '#ff000080'
+  );
+  near(
+    await over('black', (c) => {
+      c.fillStyle = '#f008';
+    }),
+    [136, 0, 0],
+    '#f008'
+  );
+  // the case that shipped broken downstream: black at 13% over white was
+  // drawing a solid black pill, because parse-color handed back alpha 34
+  near(
+    await over('white', (c) => {
+      c.fillStyle = '#00000022';
+    }),
+    [221, 221, 221],
+    '#00000022 over white'
+  );
+});
+
+test('transparent and fully opaque are both no-ops in their own way', async () => {
+  near(
+    await over('white', (c) => {
+      c.fillStyle = 'transparent';
+    }),
+    [255, 255, 255],
+    'transparent leaves the background alone'
+  );
+  near(
+    await over('white', (c) => {
+      c.fillStyle = 'red';
+    }),
+    [255, 0, 0],
+    'an opaque colour still covers completely'
+  );
+});
+
+test('an array style is taken as already premultiplied', async () => {
+  near(
+    await over('black', (c) => {
+      c.fillStyle = [0.5, 0, 0, 0.5];
+    }),
+    [128, 0, 0],
+    'premultiplied array passes through untouched'
+  );
+});
+
+test('gradient stops are premultiplied too', async () => {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, W, H);
+  // a gradient from half-alpha red to half-alpha red is a flat half-alpha
+  // red, so it must match the solid-colour case exactly
+  const g = ctx.createLinearGradient(0, 0, W, 0);
+  g.addColorStop(0, 'rgba(255, 0, 0, 0.5)');
+  g.addColorStop(1, 'rgba(255, 0, 0, 0.5)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, W, H);
+  near(await centre(ctx), [128, 0, 0], 'flat half-alpha red gradient');
+});
+
+test('an unparseable colour throws instead of writing garbage', () => {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  // '#00000022' used to reach XRender as alpha 34; a bogus string used to
+  // throw a TypeError from inside parse-color's result
+  assert.throws(() => {
+    ctx.fillStyle = 'not-a-colour';
+  }, /Not a color/);
+  assert.throws(() => {
+    ctx.fillStyle = '#1234567';
+  }, /Not a color/);
+});

--- a/test/css.test.js
+++ b/test/css.test.js
@@ -23,9 +23,45 @@ const styleOf = (html, selector, sheets = []) => {
 test('cssColor: named, hex, rgba, transparent', () => {
   assert.deepEqual(cssColor('red'), [1, 0, 0, 1]);
   assert.deepEqual(cssColor('#0000ff'), [0, 0, 1, 1]);
-  assert.deepEqual(cssColor('rgba(255, 0, 0, 0.5)'), [1, 0, 0, 0.5]);
+  // premultiplied, because these go to XRender as-is: r, g and b are each
+  // scaled by alpha, so half-alpha red is 0.5 and not 1
+  assert.deepEqual(cssColor('rgba(255, 0, 0, 0.5)'), [0.5, 0, 0, 0.5]);
   assert.deepEqual(cssColor('transparent'), [0, 0, 0, 0]);
   assert.equal(cssColor('bogus-color'), null);
+});
+
+test('cssColor: hex alpha, which parse-color does not understand', () => {
+  // parse-color returns rgba [0, 0, 0, 34, 1] here — five entries, with the
+  // alpha still a 0..255 byte. 34 clamped to 1, so this rendered opaque.
+  const black13 = cssColor('#00000022');
+  assert.equal(black13.length, 4);
+  assert.ok(Math.abs(black13[3] - 0x22 / 255) < 1e-9, `alpha ${black13[3]}`);
+  assert.deepEqual(black13.slice(0, 3), [0, 0, 0]);
+
+  // four-digit form: parse-color reads '#0002' as a truncated six-digit hex
+  assert.deepEqual(cssColor('#0002'), cssColor('#00000022'));
+  assert.deepEqual(cssColor('#f008'), cssColor('#ff000088'));
+
+  // opaque hex alpha still equals the alpha-less form, and stays exact
+  assert.deepEqual(cssColor('#ff0000ff'), [1, 0, 0, 1]);
+  assert.deepEqual(cssColor('#fff'), [1, 1, 1, 1]);
+  assert.deepEqual(cssColor('#00000000'), [0, 0, 0, 0]);
+
+  // premultiplied: white at half alpha is grey, not white
+  const [r, g, b, a] = cssColor('#ffffff80');
+  assert.ok(r <= a && g <= a && b <= a, `not premultiplied: ${[r, g, b, a]}`);
+  assert.ok(Math.abs(r - 0x80 / 255) < 1e-9, `r ${r}`);
+});
+
+test('cssColor: hex forms that are not CSS are rejected, not guessed', () => {
+  // '#' never falls back to parse-color, which turns '#1234567' into
+  // rgba [18, 52, 86, 7, 1] — an alpha of 7
+  for (const bad of ['#12345', '#1234567', '#12', '#', '#gg0000']) {
+    assert.equal(cssColor(bad), null, bad);
+  }
+  for (const bad of ['', null, undefined, 42, [1, 0, 0, 1]]) {
+    assert.equal(cssColor(bad), null, JSON.stringify(bad));
+  }
 });
 
 test('cssLength: units resolve against em base and root size', () => {


### PR DESCRIPTION
Two bugs in the same function, one of them already visible downstream.

## Hex alpha never worked

`parse-color` does not implement it, and fails silently rather than returning null:

```
parse-color('#00000022')  ->  rgba [0, 0, 0, 34, 1]
parse-color('#0002')      ->  rgba [0, 2, 0, 1]
```

The first has **five** entries and leaves alpha as a 0..255 byte. `parseColor` read `c.rgba[3]` straight through as the alpha, 34 clamped to 1, and so every `#RRGGBBAA` colour rendered fully opaque. react-x11's layout demo asked for `#00000022` — black at 13% — and drew a solid black pill with unreadable text on it.

The second is read as a *truncated six-digit* hex, so `#f008` was a different colour entirely (`240, 8, 0`), not merely the wrong alpha.

Hex is now parsed here, in all four lengths, and a `#` value we reject never falls back to parse-color — that fallback is how `#1234567` became alpha 7.

## Colour strings were not premultiplied

XRender wants premultiplied components, each of r, g and b `<= a`. `globalAlpha` was always correct because it goes through an a8 mask, but alpha in a *colour string* was dropped entirely.

Over white, straight and premultiplied clamp to the same pixels — which is why this survived so long. Every case below is over black or white accordingly:

| style | before | after |
| --- | --- | --- |
| `globalAlpha 0.5` + `'red'` over black | `127, 0, 0` | `127, 0, 0` (reference) |
| `'rgba(255, 0, 0, 0.5)'` over black | `255, 0, 0` | **`127, 0, 0`** |
| `'#ff000080'` over black | `255, 0, 0` | **`128, 0, 0`** |
| `'#f008'` over black | `240, 8, 0` | **`136, 0, 0`** |
| `'#00000022'` over white | `0, 0, 0` | **`221, 221, 221`** |
| `'transparent'` | `TypeError` | no-op |

`transparent` used to throw, because parse-color returns no `rgba` for it and `parseColor` indexed into `undefined`. An unparseable colour threw that same confusing TypeError, and now throws naming the value.

**Before** — four swatches: half-alpha red three ways, then black at 13% over white:

![ntk-colour-before](https://github.com/user-attachments/assets/9bad6f71-6a72-4be1-98d8-61a00171730b)

**After**:

![ntk-colour-after](https://github.com/user-attachments/assets/2cf9fdc6-e3e6-4dda-bc1b-c3735f3a27b4)


<sub>Both rendered headlessly into node-x11's in-process X server at `8447625270b8699ec35202bd882334cf748f4af5`; `before` reproduces the old code path exactly (straight alpha and parse-color's raw hex-alpha byte), same geometry and same backdrop.</sub>

## Both parsers, one place

`widgets/css.js` had the identical `c.rgba[3]` bug, and its output is assigned to `ctx.fillStyle` **as an array** (htmlview's paint) — which is the already-premultiplied form. So both now come from `lib/color.js`, and `cssColor` returns premultiplied values.

That is a behaviour change for a public export, and the reason the one existing assertion moved: `cssColor('rgba(255, 0, 0, 0.5)')` was `[1, 0, 0, 0.5]` and is now `[0.5, 0, 0, 0.5]`.

Arrays still pass through untouched — `docs/context-2d.md` already documented that form as premultiplied, and it is what `[0.5, 0, 0, 0.5]` should mean. There is now a **Color** section that says so, with the out-of-gamut `[1, 0, 0, 0.5]` case spelled out, since that one is not rejected and looks fine on white.

## strictColors, and what it cannot catch

`npm test` now sets `NTK_STRICT_COLORS=1`, wiring up x11 3.3.0's `Render.strictColors` so an out-of-range component throws instead of being clamped.

Worth being precise about the coverage, because I checked both ways by planting the bugs back:

- it **does** catch the alpha-34 class — restoring the raw-byte read fails with `Render: color component 128 is outside 0..1`;
- it **cannot** catch unpremultiplied colour, because `1.0` is in range. Restoring straight alpha leaves strictColors completely silent and instead fails 5 of the new rendering assertions.

That is why the new tests read pixels rather than trusting the guard.

## Checks

346 tests pass with strict colours on (340 before, +6 here).

While verifying I hit an **unrelated pre-existing flake**: `test/htmlview.test.js:311` waits for an async file read with a fixed `setTimeout(r, 30)`, and failed ~2 in 13 full-suite runs. It did not reproduce in 8 full-suite runs without the extra test file, so the trigger is concurrency — `node --test` runs files in parallel and any new file raises the load. Eleven tests share that fixed-sleep pattern; converting them to real waits is its own change, not this one.
