### PR TITLE
test: wait for async content instead of sleeping at it

### DIFF
--- a/test/helpers/async.js
+++ b/test/helpers/async.js
@@ -1,0 +1,74 @@
+// Waiting for async content in tests.
+//
+// HtmlView and MarkdownView load images, SVGs and mermaid models in the
+// background. A fixed `setTimeout` sleep is a race against that work rather
+// than a wait for it: `node --test` runs test files in parallel, so under load
+// the sleep can expire first and the assertions then see `img.w === 0`. That
+// was a real intermittent failure, not a theoretical one.
+//
+// Which helper applies depends on whether the widget signals completion:
+//
+//   - the success paths call `onInvalidate` (ntk >= 3.4.0) when content
+//     arrives, so `invalidation()` turns that into a promise — exact, and no
+//     slower than the work itself;
+//   - the failure paths do not all notify. MarkdownView leaves an unsupported
+//     mermaid fence as `entry.failed` without invalidating, so there is no
+//     event to await and `until()` polls the real predicate instead. Still
+//     deterministic: it settles when the parse rejects, not on a clock.
+//
+// Timeouts here are generous and exist only so a genuine hang fails with a
+// message that names what it was waiting for.
+
+const TIMEOUT = 10000;
+
+/** Reject after `ms` unless `promise` settles first. */
+export function withTimeout(promise, ms, what) {
+  let timer;
+  const limit = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timeout after ${ms}ms: ${what}`)), ms);
+    timer.unref?.();
+  });
+  return Promise.race([promise, limit]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Widget options plus an awaitable for their async content:
+ *
+ *   const load = invalidation();
+ *   const view = new HtmlView(null, { fonts, ...load.opts });
+ *   view.setHtml('<img src="pic.svg">');
+ *   await load.settled();
+ *
+ * `onInvalidate` fires once per resource that resolves *or* fails, so pass a
+ * count to wait for a page with more than one.
+ */
+export function invalidation() {
+  let seen = 0;
+  let waiters = [];
+  return {
+    opts: {
+      onInvalidate: () => {
+        seen++;
+        const wake = waiters;
+        waiters = [];
+        for (const resolve of wake) resolve();
+      }
+    },
+    /** Resolve once `onInvalidate` has fired at least `count` times. */
+    settled(count = 1, what = 'async content', ms = TIMEOUT) {
+      const wait = async () => {
+        while (seen < count) await new Promise((resolve) => waiters.push(resolve));
+      };
+      return withTimeout(wait(), ms, what);
+    }
+  };
+}
+
+/** Poll `predicate` until it holds — for the paths that never notify. */
+export async function until(predicate, what = 'condition', ms = TIMEOUT) {
+  const deadline = Date.now() + ms;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timeout after ${ms}ms: ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+}

--- a/test/htmlview.test.js
+++ b/test/htmlview.test.js
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 
 import FontManager from '../lib/text/fontmanager.js';
 import HtmlView from '../lib/widgets/htmlview.js';
+import { invalidation } from './helpers/async.js';
 
 let hasFontconfig = true;
 try {
@@ -98,9 +99,10 @@ test('img: data URI loads, natural size, shrinks to container width', needsFonts
   const { PNG } = await import('pngjs');
   const png = new PNG({ width: 200, height: 100 });
   const uri = 'data:image/png;base64,' + PNG.sync.write(png).toString('base64');
-  const view = new HtmlView(null, { fonts });
+  const load = invalidation();
+  const view = new HtmlView(null, { fonts, ...load.opts });
   view.setHtml(`<div style="width: 100px; margin: 0"><img src="${uri}"></div>`);
-  await new Promise((r) => setTimeout(r, 20));
+  await load.settled(1, 'data: URI png');
   view.layout(400);
   const img = byName(view, 'img')[0];
   assert.equal(Math.round(img.w), 100, 'clamped to container');
@@ -108,24 +110,29 @@ test('img: data URI loads, natural size, shrinks to container width', needsFonts
 });
 
 test('images: no baseUrl means relative sources do not load', needsFonts, async () => {
-  const view = new HtmlView(null, { fonts });
+  const load = invalidation();
+  const view = new HtmlView(null, { fonts, ...load.opts });
   view.setHtml('<img src="../../etc/passwd">');
-  await new Promise((r) => setTimeout(r, 20));
+  // a refused load still invalidates, so this waits for the real answer
+  // rather than for long enough to assume one
+  await load.settled(1, 'relative src refused');
   const entry = view._images.values().next().value;
   assert.equal(entry.image, null);
 });
 
 test('images: custom loadResource hook is used and can veto', needsFonts, async () => {
   const asked = [];
+  const load = invalidation();
   const view = new HtmlView(null, {
     fonts,
+    ...load.opts,
     loadResource: async (url) => {
       asked.push(url);
       return null;
     }
   });
   view.setHtml('<img src="http://example.com/x.png">');
-  await new Promise((r) => setTimeout(r, 20));
+  await load.settled(1, 'loadResource veto');
   assert.deepEqual(asked, ['http://example.com/x.png']);
 });
 
@@ -278,12 +285,14 @@ test('inline svg: display none hides it; children never join text flow', needsFo
 });
 
 test('img: svg source via loadResource buffer is sniffed and adopted', needsFonts, async () => {
+  const load = invalidation();
   const view = new HtmlView(null, {
     fonts,
+    ...load.opts,
     loadResource: async () => Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="30" height="60"><circle r="5"/></svg>')
   });
   view.setHtml('<img src="pic.svg">');
-  await new Promise((r) => setTimeout(r, 20));
+  await load.settled(1, 'svg buffer sniffed');
   view.layout(400);
   const img = byName(view, 'img')[0];
   const entry = view._images.get(img.element);
@@ -298,9 +307,10 @@ test('img: data:image/svg+xml URI (utf8 and base64) loads', needsFonts, async ()
   const utf8 = 'data:image/svg+xml,' + encodeURIComponent(svgText);
   const b64 = 'data:image/svg+xml;base64,' + Buffer.from(svgText).toString('base64');
   for (const uri of [utf8, b64]) {
-    const view = new HtmlView(null, { fonts });
+    const load = invalidation();
+    const view = new HtmlView(null, { fonts, ...load.opts });
     view.setHtml(`<img src="${uri}">`);
-    await new Promise((r) => setTimeout(r, 20));
+    await load.settled(1, `data: svg URI ${uri.slice(0, 30)}`);
     view.layout(400);
     const img = byName(view, 'img')[0];
     assert.equal(img.w, 24, uri.slice(0, 30));
@@ -315,9 +325,12 @@ test('img: svg file loads through baseUrl and draws', needsFonts, async () => {
   const dir = await mkdtemp(join(tmpdir(), 'ntk-svg-'));
   await writeFile(join(dir, 'icon.svg'), '<svg viewBox="0 0 2 2" width="20" height="20"><rect width="2" height="2" fill="#0000ff"/></svg>');
   try {
-    const view = new HtmlView(null, { fonts, baseUrl: dir });
+    const load = invalidation();
+    const view = new HtmlView(null, { fonts, baseUrl: dir, ...load.opts });
     view.setHtml('<div style="margin:0;padding:0"><img src="icon.svg"></div>');
-    await new Promise((r) => setTimeout(r, 30));
+    // this one used to sleep 30ms and lost the race under a parallel run:
+    // a file read plus an SVG parse, with img.w still 0 when it woke
+    await load.settled(1, 'svg read through baseUrl');
     view.layout(400);
     const img = byName(view, 'img')[0];
     assert.equal(img.w, 20);
@@ -333,9 +346,10 @@ test('img: svg file loads through baseUrl and draws', needsFonts, async () => {
 test('img: raster decoding is untouched by svg sniffing', needsFonts, async () => {
   const { PNG } = await import('pngjs');
   const png = new PNG({ width: 12, height: 8 });
-  const view = new HtmlView(null, { fonts, loadResource: async () => PNG.sync.write(png) });
+  const load = invalidation();
+  const view = new HtmlView(null, { fonts, ...load.opts, loadResource: async () => PNG.sync.write(png) });
   view.setHtml('<img src="x.png">');
-  await new Promise((r) => setTimeout(r, 20));
+  await load.settled(1, 'raster png decoded');
   view.layout(400);
   const entry = view._images.values().next().value;
   assert.ok(entry.image, 'decoded as raster');

--- a/test/mermaid.test.js
+++ b/test/mermaid.test.js
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import FontManager from '../lib/text/fontmanager.js';
 import { layoutMermaid, parseMermaid } from '../lib/widgets/mermaid.js';
 import MarkdownView from '../lib/widgets/markdownview.js';
+import { invalidation, until } from './helpers/async.js';
 
 let hasFontconfig = true;
 try {
@@ -142,10 +143,11 @@ test('layoutMermaid validates its input', needsFonts, () => {
 // markdown integration
 
 test('markdown: mermaid fence becomes a diagram box after async parse', needsFonts, async () => {
-  const view = new MarkdownView(null, { fonts });
+  const load = invalidation();
+  const view = new MarkdownView(null, { fonts, ...load.opts });
   view.setMarkdown('```mermaid\nflowchart LR\n A[Hello] --> B[World]\n```');
   view.layout(500); // kicks off the async parse; fence is a code block for now
-  await new Promise((r) => setTimeout(r, 2000));
+  await load.settled(1, 'mermaid parse');
   view.layout(500);
   const diagram = view._items.find((i) => i.kind === 'tex' && i.box.type === 'flowchart');
   assert.ok(diagram, 'diagram item present after parse resolves');
@@ -170,7 +172,13 @@ test('markdown: unsupported mermaid stays a code block', needsFonts, async () =>
   const view = new MarkdownView(null, { fonts });
   view.setMarkdown('```mermaid\ngantt\n title x\n```');
   view.layout(500);
-  await new Promise((r) => setTimeout(r, 2000));
+  // no onInvalidate to wait on here: an unsupported fence takes the rejection
+  // path, which sets entry.failed and deliberately does *not* invalidate
+  // (nothing changed on screen). So poll the flag the parse actually sets.
+  await until(
+    () => [...view._mermaid.values()].every((e) => e.failed || e.model),
+    'mermaid parse rejected'
+  );
   view.layout(500);
   assert.ok(!view._items.some((i) => i.kind === 'tex'), 'no diagram box');
   assert.ok(view._items.some((i) => i.kind === 'rect'), 'code block background present');

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -5,12 +5,7 @@ import assert from 'node:assert/strict';
 import { after, before, test } from 'node:test';
 
 import { createClient, HtmlView, MarkdownView, Path2D, SvgView } from '../lib/index.js';
-
-const withTimeout = (promise, ms, what) =>
-  Promise.race([
-    promise,
-    new Promise((_, reject) => setTimeout(() => reject(new Error(`timeout: ${what}`)), ms).unref())
-  ]);
+import { invalidation, until, withTimeout } from './helpers/async.js';
 
 let app = null;
 let skip = false;
@@ -242,14 +237,17 @@ test('HtmlView: inline <svg> and svg <img> render as vectors', async (t) => {
   const uri =
     'data:image/svg+xml,' +
     encodeURIComponent('<svg viewBox="0 0 4 4"><rect width="4" height="4" fill="#0000ff"/></svg>');
-  const view = new HtmlView(null);
+  const load = invalidation();
+  const view = new HtmlView(null, load.opts);
   view.setHtml(
     `<div style="margin:0;padding:0">
        <svg width="32" height="32" viewBox="0 0 4 4"><rect width="4" height="4" fill="#ff0000"/></svg>
        <img width="16" height="16" src="${uri}">
      </div>`
   );
-  await new Promise((r) => setTimeout(r, 20)); // let the data: URI resolve
+  // the inline <svg> is adopted synchronously; only the <img> data: URI is
+  // async, so one invalidation is the whole wait
+  await load.settled(1, 'data: URI svg');
   view.layout(64);
   view.draw(ctx, 0, 0);
 
@@ -270,13 +268,7 @@ test('MarkdownView: mermaid fence renders diagram pixels', async (t) => {
   const view = new MarkdownView(null, { fonts: app.fonts });
   view.setMarkdown('```mermaid\nflowchart LR\n A[Hello] --> B[World]\n```');
   view.layout(280);
-  await withTimeout(
-    (async () => {
-      while (![...view._mermaid.values()][0]?.model) await new Promise((r) => setTimeout(r, 50));
-    })(),
-    10000,
-    'mermaid parse'
-  );
+  await until(() => [...view._mermaid.values()][0]?.model, 'mermaid parse');
   view.layout(280);
   view.draw(ctx, 10, 10);
 


### PR DESCRIPTION
Eleven tests across three files waited for background image, SVG and mermaid work with a fixed `setTimeout`. That is a race, not a wait: `node --test` runs test files in parallel, so under load the sleep can expire first and the assertions then read `img.w === 0`.

Not theoretical. `htmlview.test.js`'s *"svg file loads through baseUrl and draws"* — a temp-file read plus an SVG parse behind a 30 ms sleep — failed intermittently, and adding any new test file was enough to tip it, because that raises the concurrent load.

| | svg-baseUrl failures | measured over |
| --- | --- | --- |
| master | **3 / 23 runs** | full suite, two invocations |
| this branch | **0 / 30 runs** | full suite, two invocations |

## The widgets already tell you when they are done

`onInvalidate` (ntk >= 3.4.0) fires when async content arrives — and one test in `mermaid.test.js` was already using it. `test/helpers/async.js` makes that reusable:

- **`invalidation()`** returns widget options plus an awaitable, turning the hook into a promise. It counts calls, so a page with several resources can wait for all of them. This covers all seven `htmlview` sites, including the two *negative* ones — a refused load invalidates too, so "did not load" is now a real answer rather than an assumption.
- **`until()`** polls a predicate, for paths that never notify. Exactly one case needs it, and it is not an oversight: an unsupported mermaid fence takes the rejection path, which sets `entry.failed` and deliberately does **not** invalidate, because nothing changed on screen. That test now waits on the flag the parse actually sets.
- **`withTimeout()`** already existed in `smoke-canvas.test.js` with this signature; it moves here, and that copy goes along with the hand-rolled poll loop beside it.

Timeouts are generous and exist only to turn a hang into a message naming what it was waiting for.

## Side effect worth having

The two mermaid tests slept 2000 ms each whether the parse needed it or not. That file now runs in **1.3 s instead of 4 s+**.

## One thing I did not fix

`test/frame-pacing.test.js:195` (*"frameInterval paces flushes when the fence is disabled"*) failed **once in ~40 runs** and is the same class of bug — it emits two events, `await tick()`, and asserts a paced flush has *not* happened yet, which is only true while the tick stays under the 25 ms `frameInterval`. Under load it does not.

It is a different file, and unlike these it cannot simply wait on an event: pacing *is* its subject, so fixing it properly means injectable time rather than a real clock. It did not reproduce on master in 10 runs either, so I have one observation and no attribution — flagging it rather than guessing.

## Checks

346 tests pass. Full suite run 30 times on this branch with zero failures of any kind.