### PR TITLE
feat: export cssColorStraight and premultiply

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -77,6 +77,20 @@ White at half alpha is `[0.5, 0.5, 0.5, 0.5]`, not `[1, 1, 1, 0.5]`.
 premultiplied `[r, g, b, a]` in 0..1, or `null`. Gradient stops go through
 the same path, so `addColorStop(0, 'rgba(255, 0, 0, 0.5)')` is right too.
 
+Two companions for the places premultiplied is the *wrong* form, both
+exported alongside it:
+
+- `cssColorStraight(value)` — the same parse with **straight** alpha.
+  **OpenGL** needs this: `glClearColor` and material colours take
+  unassociated components, and premultiplied ones render translucent
+  colours dark.
+- `premultiply([r, g, b, a])` — converts. Interpolating two colours wants
+  both: lerp in straight space, then scale once at the end, because a round
+  trip back to an `rgba()` string only closes if the components were never
+  scaled. Premultiplying twice is the failure this pair exists to prevent —
+  `rgba(255, 0, 0, 0.5)` becomes `rgba(128, 0, 0, 0.5)`, a colour half as
+  bright at the same alpha.
+
 Set `NTK_STRICT_COLORS=1` to make a component outside 0..1 throw instead of
 being clamped (it wires up x11's `Render.strictColors`); ntk's own test run
 sets it. Note what that does *not* cover: an unpremultiplied `[1, 0, 0, 0.5]`

--- a/docs/html.md
+++ b/docs/html.md
@@ -41,10 +41,15 @@ The yoga-layout instance ntk uses is re-exported as `Yoga`
 react-x11 renderer — share the same WASM module and enum values instead of
 loading a second, possibly version-mismatched copy.
 
-The two value parsers the CSS layer is built on are exported for the same
-reason: `cssColor(value)` → **premultiplied** `[r, g, b, a]` floats 0..1
-(what XRender and GL both want — see
-[context-2d.md](context-2d.md#color)) or `null`, and
+The value parsers the CSS layer is built on are exported for the same
+reason: `cssColor(value)` → **premultiplied** `[r, g, b, a]` floats 0..1,
+which is what XRender wants (see [context-2d.md](context-2d.md#color)), or
+`null`; `cssColorStraight(value)` → the same colour with **straight**
+alpha, for the callers that need unassociated components — **OpenGL** is
+one (`glClearColor` and material colours take straight alpha, and
+premultiplied values render translucent colours dark), and interpolating
+two colours is another; `premultiply([r, g, b, a])` converts, so a lerp can
+happen in straight space and be scaled once at the end. And
 `cssLength(value, emBase, rootSize)` → `{ px }`, `{ pct }`, `'auto'` or
 `null`.
 

--- a/lib/color.js
+++ b/lib/color.js
@@ -43,11 +43,19 @@ function parseHex(value) {
 }
 
 /**
- * Parse a CSS colour to premultipliable `[r, g, b, a]` floats, straight
- * alpha, or null if it is not a colour. Exported for callers that need the
- * unassociated values; use `cssColor` for anything heading to XRender.
+ * Parse a CSS colour to `[r, g, b, a]` floats in 0..1 with **straight**
+ * (unassociated) alpha, or null if it is not a colour.
+ *
+ * `cssColor` is the one to use for anything heading to XRender. This is for
+ * the places that genuinely want unassociated components:
+ *
+ *  - **OpenGL.** `glClearColor` and material colours take straight alpha;
+ *    handing them premultiplied values renders translucent colours dark.
+ *  - **Interpolating** two colours. Lerp straight, then premultiply once at
+ *    the end — a round trip back to an `rgba()` string only closes if the
+ *    components were never scaled.
  */
-export function parseCssColorStraight(value) {
+export function cssColorStraight(value) {
   if (typeof value !== 'string') return null;
   const v = value.trim();
   if (!v) return null;
@@ -73,6 +81,6 @@ function rawRgba(value) {
  * XRender, or null if `value` is not a colour.
  */
 export function cssColor(value) {
-  const straight = parseCssColorStraight(value);
+  const straight = cssColorStraight(value);
   return straight && premultiply(straight);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ import SvgView from './widgets/svgview.js';
 import MarkdownView from './widgets/markdownview.js';
 import TexView, { configureTex, layoutTex, TexBox } from './widgets/tex.js';
 import { tokenize as highlightCode } from './widgets/highlight.js';
+import { cssColorStraight, premultiply } from './color.js';
 import { cssColor, cssLength } from './widgets/css.js';
 
 // rendering context modules register themselves on Drawable
@@ -135,6 +136,8 @@ export {
   configureTex,
   highlightCode,
   cssColor,
+  cssColorStraight,
+  premultiply,
   cssLength
 };
 // the yoga-layout instance ntk lays HtmlView out with — downstream layout

--- a/test/css.test.js
+++ b/test/css.test.js
@@ -30,6 +30,41 @@ test('cssColor: named, hex, rgba, transparent', () => {
   assert.equal(cssColor('bogus-color'), null);
 });
 
+test('cssColorStraight: unassociated alpha, and premultiply converts', async () => {
+  const { cssColorStraight, premultiply } = await import('../lib/index.js');
+
+  // straight: the components are not scaled by alpha
+  assert.deepEqual(cssColorStraight('rgba(255, 0, 0, 0.5)'), [1, 0, 0, 0.5]);
+  assert.deepEqual(cssColorStraight('red'), [1, 0, 0, 1]);
+  assert.equal(cssColorStraight('bogus-color'), null);
+
+  // hex alpha is parsed here too, not just in cssColor
+  const [r, g, b, a] = cssColorStraight('#ff000080');
+  assert.deepEqual([r, g, b], [1, 0, 0]);
+  assert.ok(Math.abs(a - 0x80 / 255) < 1e-9, `alpha ${a}`);
+
+  // the pair composes back to cssColor
+  assert.deepEqual(
+    premultiply(cssColorStraight('rgba(255, 0, 0, 0.5)')),
+    cssColor('rgba(255, 0, 0, 0.5)'),
+  );
+
+  // ...and round-trips through an rgba() string, which premultiplied does
+  // not: that is the bug this export exists to prevent, where a colour comes
+  // back half as bright at the same alpha
+  const toCss = (c) =>
+    `rgba(${Math.round(c[0] * 255)}, ${Math.round(c[1] * 255)}, ${Math.round(c[2] * 255)}, ${c[3]})`;
+  assert.equal(
+    toCss(cssColorStraight('rgba(255, 0, 0, 0.5)')),
+    'rgba(255, 0, 0, 0.5)',
+  );
+  assert.equal(
+    toCss(cssColor('rgba(255, 0, 0, 0.5)')),
+    'rgba(128, 0, 0, 0.5)',
+    'premultiplied values must not be formatted as a CSS colour',
+  );
+});
+
 test('cssColor: hex alpha, which parse-color does not understand', () => {
   // parse-color returns rgba [0, 0, 0, 34, 1] here — five entries, with the
   // alpha still a 0..255 byte. 34 clamped to 1, so this rendered opaque.


### PR DESCRIPTION
3.9.1 made `cssColor` return **premultiplied** components — right for XRender, wrong everywhere else — and there is currently no way to ask for the unassociated values.

Two places need them, both live in react-x11 and both broken by 3.9.1 today:

**OpenGL.** `glClearColor` and material colours take straight alpha. Premultiplied values render translucent colours dark. (`src/glnodes.js`, `src/scene3d.js`)

**Interpolating two colours.** Lerping premultiplied components and formatting the result back into an `rgba()` string applies alpha twice:

```
rgba(255, 0, 0, 0.5)  ->  cssColor  ->  [0.5, 0, 0, 0.5]  ->  rgba(128, 0, 0, 0.5)
```

Half as bright at the same alpha. The round trip only closes on straight values. (`src/styles.js`, style transitions)

## What this adds

- **`cssColorStraight(value)`** — the same parse with straight alpha. It already existed as the first half of `cssColor`, just unreachable from outside the package.
- **`premultiply([r, g, b, a])`** — converts, so a caller can lerp in straight space and scale once at the end.

Both are additive; `cssColor` is unchanged.

## A correction

`docs/html.md` claimed premultiplied is *"what XRender and GL both want"*. GL wants the opposite, and that sentence was wrong when I wrote it in #100 — it inherited the error from the line it replaced. Fixed here, along with a note in `docs/context-2d.md` naming the double-premultiply failure explicitly so the next reader does not have to rediscover it.

## Checks

348 tests pass (346 + 2). The new test pins the round-trip property in both directions: straight round-trips through an `rgba()` string, premultiplied deliberately does not, and `premultiply(cssColorStraight(x))` equals `cssColor(x)`.

react-x11 needs a release of this before it can pick the fix up — its three call sites are waiting on the export.