### PR TITLE
ci: check that release-please can read the squash commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,29 @@ on:
   pull_request:
 
 jobs:
+  # Squash-merge builds the commit from the PR title and description, and a
+  # message release-please cannot parse is skipped silently — green workflow,
+  # no release PR. That has cost two releases, so it is checked here.
+  release-message:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Will release-please be able to read the squash commit?
+        # via env, never inline: the body is untrusted text and must not be
+        # interpolated into a shell command
+        env:
+          MESSAGE: |
+            ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
+        run: node scripts/check-release-message.mjs
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,8 +161,15 @@ release and publishes to npm via OIDC trusted publishing (no token secrets).
   with a callback in it is enough to break it. A commit it cannot parse is
   **silently skipped**: the workflow goes green, `commits: 0`, and no
   release PR appears (this happened to #85 → the empty re-record commit
-  e523667). Squash-merge puts the PR description in the body, so this
-  applies to PR descriptions too.
+  e523667, and again to #103 → 9fdbe38). Squash-merge puts the PR
+  description in the body, so this applies to PR descriptions too.
+- **CI checks this for you** — the `release-message` job runs
+  `npm run check-release-message` over the title and body the squash would
+  produce, using release-please's own parser, and names the line and column
+  it chokes on. Whether a given nested call trips the grammar depends on its
+  surroundings, so do not try to predict it from the rule above: the same
+  construct that broke #103 parses fine inside a fenced block. Run the
+  script locally against a file if you want to check before pushing.
 
 ## Gotchas
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "x11": "^3.3.0",
         "yoga-layout": "^3.2.1"
       },
+      "devDependencies": {
+        "@conventional-commits/parser": "^0.4.1"
+      },
       "engines": {
         "node": ">=20.19.0"
       }
@@ -58,6 +61,17 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@conventional-commits/parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@conventional-commits/parser/-/parser-0.4.1.tgz",
+      "integrity": "sha512-H2ZmUVt6q+KBccXfMBhbBF14NlANeqHTXL4qCL6QGbMzrc4HDXyzWuxPxPNbz71f/5UkR5DrycP5VO9u7crahg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unist-util-visit": "^2.0.3",
+        "unist-util-visit-parents": "^3.1.1"
+      }
     },
     "node_modules/@dagrejs/dagre": {
       "version": "3.0.0",
@@ -374,6 +388,13 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@upsetjs/venn.js": {
       "version": "2.0.0",
@@ -1641,6 +1662,48 @@
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
     "yoga-layout": "^3.2.1"
   },
   "scripts": {
-    "test": "NTK_STRICT_COLORS=1 node --test"
+    "test": "NTK_STRICT_COLORS=1 node --test",
+    "check-release-message": "node scripts/check-release-message.mjs"
+  },
+  "devDependencies": {
+    "@conventional-commits/parser": "^0.4.1"
   }
 }

--- a/scripts/check-release-message.mjs
+++ b/scripts/check-release-message.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Will release-please be able to read this commit message?
+//
+// Squash-merge composes the commit from the PR title and description, and
+// release-please parses the whole thing with @conventional-commits/parser. A
+// message the grammar rejects is **silently skipped**: the Release workflow
+// goes green, logs "No user facing commits found", and no release PR appears.
+// That has now cost two releases — #85 and #103 — so this checks it in CI
+// rather than trusting anyone to remember the rule.
+//
+// The usual offender is nested parentheses, which the grammar does not
+// accept: `foo(a, b)` is fine, `premultiply(cssColorStraight(x))` is not.
+// Whether a given line trips it depends on the surrounding context, which is
+// exactly why this runs the real parser instead of a regex.
+//
+//   node scripts/check-release-message.mjs <file>
+//   MESSAGE="..." node scripts/check-release-message.mjs
+import { readFileSync } from 'node:fs';
+
+import { parser, toConventionalChangelogFormat } from '@conventional-commits/parser';
+
+const file = process.argv[2];
+const message = file ? readFileSync(file, 'utf8') : (process.env.MESSAGE ?? '');
+
+if (!message.trim()) {
+  console.error('check-release-message: nothing to check (pass a file or set MESSAGE)');
+  process.exit(2);
+}
+
+let ast;
+try {
+  ast = parser(message);
+} catch (err) {
+  const text = String(err.message);
+  console.error('release-please could not parse this commit message.\n');
+  console.error(text.split('\n')[0]);
+
+  // point at the line the parser named, since the column alone is no help
+  const at = /at (\d+):(\d+)/.exec(text);
+  if (at) {
+    const lines = message.split('\n');
+    const n = Number(at[1]);
+    const line = lines[n - 1];
+    if (line !== undefined) {
+      console.error(`\n  ${n} | ${line}`);
+      console.error(`  ${' '.repeat(String(n).length)} | ${' '.repeat(Math.max(0, Number(at[2]) - 1))}^`);
+    }
+  }
+  console.error(
+    '\nA message it cannot read is skipped silently: the Release workflow goes\n' +
+      'green and no release PR appears. Nested parentheses are the usual cause —\n' +
+      'rewrite them, e.g. "premultiply of cssColorStraight" rather than\n' +
+      'premultiply wrapping a call. See the Releases section of AGENTS.md.',
+  );
+  process.exit(1);
+}
+
+const commit = toConventionalChangelogFormat(ast);
+const RELEASING = new Set(['feat', 'fix', 'perf', 'revert']);
+const breaking = commit.notes.some((n) => n.title === 'BREAKING CHANGE');
+const bumps = breaking || RELEASING.has(commit.type);
+
+console.log(`parses: type=${commit.type}${breaking ? ' (breaking)' : ''}`);
+console.log(
+  bumps
+    ? '  -> release-please will cut a version for this'
+    : `  -> no version bump for "${commit.type}", which is expected for docs/chore/test/ci`,
+);


### PR DESCRIPTION
#103 added `cssColorStraight` and `premultiply`, and no release PR appeared. The Release workflow went green and logged:

```
Considering: 1 commits
No user facing commits found since 97bba72 - skipping
```

A `feat:` that release-please cannot parse is skipped **silently**. This is the second time — #85 was the first — and the rule was already written down in AGENTS.md, including the part about PR descriptions. Documentation is evidently not enough, so this checks it.

## What the guard does

`scripts/check-release-message.mjs` composes the message squash-merge would produce, from the PR title and body, and runs it through `@conventional-commits/parser` — the same parser release-please uses, so the check cannot drift from the real behaviour. It reports the offending line and column:

```
release-please could not parse this commit message.

unexpected token '(' at 48:30, valid tokens [)]

  48 | `premultiply(cssColorStraight(x))` equals `cssColor(x)`.
     |                              ^
```

It also prints whether the type will actually cut a version, so a `docs:` PR does not look like a failure.

## Diagnosis, corrected

My first guess was that nested parentheses always break the grammar. That is not quite it, and I checked: the same nested call in a short body parses fine. It only trips in context — dropping line 48 from the real message makes it parse as `feat`, and putting it back throws. Which is the argument for running the parser rather than writing a regex: the rule is not expressible as one.

The offending line is now the guard's own fixture.

## Wiring

A `release-message` job on `pull_request` only. The body reaches the script through an environment variable rather than shell interpolation, because a PR description is untrusted text and must not be spliced into a command line.

## Checks

348 tests still pass. The guard was run against the real #103 message, which fails, and against the same message minus one line, which passes.