### PR TITLE
fix: a squeezed markdown table column keeps its longest word whole

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,23 @@ release and publishes to npm via OIDC trusted publishing (no token secrets).
   point and **mutates** the glyph objects passed to it (divides by 64, pads
   rows) — `GlyphPage.ensure` builds fresh one-shot objects for each upload
   for this reason.
+- **Never recover a content width by subtracting a padding you added.**
+  `width + pad - pad` is not the identity in floating point: at size 16 a
+  natural width of 48.953125 comes back as 48.95312499999999. A layout handed a
+  `maxWidth` a few ULPs below a token's own measured width sees a token *wider
+  than its container* and force-breaks it, so a `value` header renders as
+  `valu` over `e` — on some fonts and not others, depending on nothing but
+  whether the width survives the round trip. Carry the content width alongside
+  the outer width instead. `MarkdownView._layoutTable` does, with the invariant
+  under test in `test/text.test.js`.
+- **`TextLayout`'s width is not monotonic in `maxWidth`,** so laying a cell out
+  at a tiny `maxWidth` is *not* a min-content probe. `_forceBreak`
+  (`lib/text/layout.js:131`) splits a token wider than the container whenever a
+  single cluster fits and lets it overflow whole when none does, so KaTeX Main
+  at 16px measuring `value` reports 42.1 at `maxWidth` 1–8 and 13.4 at 16 — a
+  fragment. For min-content, measure each whitespace-delimited token
+  unconstrained; an unconstrained token cannot be broken. Pinned by a test, so
+  the probe does not come back as an obvious simplification.
 - `getImageData` returns BGRA byte order.
 - Colors in XRender are premultiplied `[r, g, b, a]` floats 0..1.
 - A `Window` constructed with an existing `{ id }` returns a cached instance

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -352,30 +352,38 @@ export default class MarkdownView {
       }
     }
 
+    // Two widths per column from here on: `cols` is the outer width the grid
+    // is drawn at, `inner` is what a cell is laid out at. `inner` is kept
+    // alongside rather than derived as `cols[c] - hpad * 2`, and that is not
+    // tidiness. Adding a padding and subtracting it again is not the identity
+    // in binary floating point — for a natural width of 48.953125 at size 16
+    // the round trip returns 48.95312499999999 — and a token handed a maxWidth
+    // a few ULPs below its own measured width is *wider than its container*,
+    // so TextLayout force-breaks it. That is a `value` header rendered as
+    // `valu` over `e`, on some fonts and not others, depending on nothing more
+    // than whether the width happens to survive the round trip.
     const cols = natural.map((w) => w + hpad * 2);
+    const inner = natural.slice();
     const total = cols.reduce((a, b) => a + b, 0);
     if (total > width) {
       // Shrink towards each column's *min-content* width — the widest word it
       // holds that cannot be broken — and never past it. The floor used to be
       // a flat 2.5em guess with no relation to the content, so a column whose
-      // longest word was wider than that got a maxWidth below the word and
-      // TextLayout broke the word itself: a `value` header rendered as `valu`
-      // over `e`.
+      // longest word was wider than that got a maxWidth below the word and the
+      // word came apart.
       //
       // Min-content is the widest whitespace-delimited token, each measured
-      // *unconstrained*. Measuring the whole cell at a tiny maxWidth looks
+      // *unconstrained*. Laying the whole cell out at a tiny maxWidth looks
       // like the obvious probe and is not one: a token wider than the
-      // container gets force-broken rather than overflowing whenever a single
-      // cluster fits, so the probe returns a fragment's width and the floor
-      // comes out below the very word it exists to protect. Whether that
-      // happens depends on the font, which is a bad thing for a layout floor
-      // to depend on. An unconstrained token cannot be broken at all.
+      // container is force-broken rather than left to overflow whenever a
+      // single cluster fits, so the probe reports a fragment's width. It is
+      // not even monotonic in maxWidth — see the test that pins that. An
+      // unconstrained token cannot be broken at all.
       //
-      // A token split across spans — `**val**ue` — is measured as its two
-      // halves and so under-measured. Rare, and still far above the flat
-      // guess this replaced. Only measured here: a table that fits needs no
-      // minimums.
-      const mins = new Array(ncols).fill(0);
+      // A token split across spans — `**val**ue` — is measured as its halves
+      // and so under-measured. Rare, and still far above the flat guess this
+      // replaced. Only measured here: a table that fits needs no minimums.
+      const content = new Array(ncols).fill(0);
       for (const row of cellSpans) {
         for (let c = 0; c < ncols; c++) {
           for (const span of row[c]) {
@@ -384,15 +392,12 @@ export default class MarkdownView {
               const measure = new TextLayout(fonts, [{ ...span, text: token }], styles.base, {
                 lineHeight: t.lineHeight
               });
-              mins[c] = Math.max(mins[c], measure.width);
+              content[c] = Math.max(content[c], measure.width);
             }
           }
         }
       }
-      // Rounded up so a column is never handed a maxWidth equal to the very
-      // width it has to fit, which leaves the outcome to the last bit of a
-      // float.
-      for (let c = 0; c < ncols; c++) mins[c] = Math.ceil(mins[c]) + hpad * 2;
+      const mins = content.map((w) => w + hpad * 2);
       // Space above the minimums is shared in proportion to how much each
       // column asked for, so a wide column gives up more than a narrow one.
       // When the minimums themselves do not fit, the table overflows rather
@@ -405,6 +410,8 @@ export default class MarkdownView {
           slack <= 0 || want <= 0
             ? mins[c]
             : mins[c] + (Math.max(0, cols[c] - mins[c]) / want) * slack;
+        // Never below min-content, whatever the arithmetic above produced.
+        inner[c] = Math.max(content[c], cols[c] - hpad * 2);
       }
     }
     const tableW = cols.reduce((a, b) => a + b, 0);
@@ -414,7 +421,7 @@ export default class MarkdownView {
     for (let r = 0; r < cellSpans.length; r++) {
       const layouts = cellSpans[r].map((spans, c) =>
         new TextLayout(fonts, spans.length ? spans : '', styles.base, {
-          maxWidth: cols[c] - hpad * 2,
+          maxWidth: inner[c],
           align: block.align[c] ?? 'left',
           lineHeight: t.lineHeight
         })

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -355,11 +355,44 @@ export default class MarkdownView {
     const cols = natural.map((w) => w + hpad * 2);
     const total = cols.reduce((a, b) => a + b, 0);
     if (total > width) {
-      // proportional shrink; the floor keeps narrow columns readable even
-      // if wide neighbors then push the table slightly past the container
-      const minCol = Math.min(t.size * 2.5 + hpad * 2, width / ncols);
+      // Shrink towards each column's *min-content* width — the widest word it
+      // holds that cannot be broken — and never past it. The floor used to be
+      // a flat 2.5em guess with no relation to the content, so a column whose
+      // longest word was wider than that got a maxWidth below the word and
+      // TextLayout broke the word itself: a `value` header rendered as `valu`
+      // over `e`.
+      //
+      // Min-content comes from laying the cell out at maxWidth 1, which takes
+      // every break opportunity and so measures the widest unbreakable chunk.
+      // Only measured here: a table that already fits needs no minimums.
+      const mins = new Array(ncols).fill(0);
+      for (const row of cellSpans) {
+        for (let c = 0; c < ncols; c++) {
+          if (!row[c].length) continue;
+          const measure = new TextLayout(fonts, row[c], styles.base, {
+            lineHeight: t.lineHeight,
+            maxWidth: 1
+          });
+          mins[c] = Math.max(mins[c], measure.width);
+        }
+      }
+      // Rounded up: when the minimums do not fit, a column gets exactly
+      // `mins[c]` and the cell is laid out at exactly its longest word's
+      // width, so a whole pixel of headroom costs nothing and removes a
+      // sub-pixel edge case from the arithmetic.
+      for (let c = 0; c < ncols; c++) mins[c] = Math.ceil(mins[c]) + hpad * 2;
+      // Space above the minimums is shared in proportion to how much each
+      // column asked for, so a wide column gives up more than a narrow one.
+      // When the minimums themselves do not fit, the table overflows rather
+      // than breaking words — which is what a browser does with the same
+      // content, and is the lesser of the two evils.
+      const slack = width - mins.reduce((a, b) => a + b, 0);
+      const want = cols.reduce((a, w, c) => a + Math.max(0, w - mins[c]), 0);
       for (let c = 0; c < ncols; c++) {
-        cols[c] = Math.max(minCol, (cols[c] / total) * width);
+        cols[c] =
+          slack <= 0 || want <= 0
+            ? mins[c]
+            : mins[c] + (Math.max(0, cols[c] - mins[c]) / want) * slack;
       }
     }
     const tableW = cols.reduce((a, b) => a + b, 0);

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -362,24 +362,36 @@ export default class MarkdownView {
       // TextLayout broke the word itself: a `value` header rendered as `valu`
       // over `e`.
       //
-      // Min-content comes from laying the cell out at maxWidth 1, which takes
-      // every break opportunity and so measures the widest unbreakable chunk.
-      // Only measured here: a table that already fits needs no minimums.
+      // Min-content is the widest whitespace-delimited token, each measured
+      // *unconstrained*. Measuring the whole cell at a tiny maxWidth looks
+      // like the obvious probe and is not one: a token wider than the
+      // container gets force-broken rather than overflowing whenever a single
+      // cluster fits, so the probe returns a fragment's width and the floor
+      // comes out below the very word it exists to protect. Whether that
+      // happens depends on the font, which is a bad thing for a layout floor
+      // to depend on. An unconstrained token cannot be broken at all.
+      //
+      // A token split across spans — `**val**ue` — is measured as its two
+      // halves and so under-measured. Rare, and still far above the flat
+      // guess this replaced. Only measured here: a table that fits needs no
+      // minimums.
       const mins = new Array(ncols).fill(0);
       for (const row of cellSpans) {
         for (let c = 0; c < ncols; c++) {
-          if (!row[c].length) continue;
-          const measure = new TextLayout(fonts, row[c], styles.base, {
-            lineHeight: t.lineHeight,
-            maxWidth: 1
-          });
-          mins[c] = Math.max(mins[c], measure.width);
+          for (const span of row[c]) {
+            for (const token of String(span.text ?? '').split(/\s+/)) {
+              if (!token) continue;
+              const measure = new TextLayout(fonts, [{ ...span, text: token }], styles.base, {
+                lineHeight: t.lineHeight
+              });
+              mins[c] = Math.max(mins[c], measure.width);
+            }
+          }
         }
       }
-      // Rounded up: when the minimums do not fit, a column gets exactly
-      // `mins[c]` and the cell is laid out at exactly its longest word's
-      // width, so a whole pixel of headroom costs nothing and removes a
-      // sub-pixel edge case from the arithmetic.
+      // Rounded up so a column is never handed a maxWidth equal to the very
+      // width it has to fit, which leaves the outcome to the last bit of a
+      // float.
       for (let c = 0; c < ncols; c++) mins[c] = Math.ceil(mins[c]) + hpad * 2;
       // Space above the minimums is shared in proportion to how much each
       // column asked for, so a wide column gives up more than a narrow one.

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -331,6 +331,41 @@ test('MarkdownView: table layout places cells and grid', needsFonts, () => {
   assert.ok(Math.abs(right(texts[3]) - right(texts[5])) < 0.5, 'right-aligned column');
 });
 
+test('MarkdownView: a squeezed column never narrows past its longest word', needsFonts, () => {
+  const fonts = new FontManager();
+  // Every cell is a single unbreakable word, so no column can give up width by
+  // wrapping. The floor used to be a flat 2.5em guess unrelated to the content,
+  // which handed TextLayout a maxWidth narrower than the word itself — and
+  // TextLayout force-breaks a token wider than its container, so a `value`
+  // header rendered as `valu` over `e`. Overflowing is the right answer here,
+  // and it is what a browser does with the same table.
+  //
+  // The assertion is on the *text*, not the line count: a cell can land on a
+  // second line that holds nothing, which is not a broken word. Whatever fails
+  // here has to say what it actually saw, because the only way it fails is a
+  // font whose metrics differ from the one you ran it with.
+  const md = '| column | value |\n| ------ | ----: |\n| alpha | 12 |\n| beta | 345 |';
+  for (const width of [400, 200, 120, 90, 60, 30]) {
+    const view = new MarkdownView(null, { fonts });
+    view.setMarkdown(md);
+    view.layout(width);
+    for (const item of view._items.filter((i) => i.kind === 'text')) {
+      // _text is the layout's full string; line.start/end index into it
+      const full = item.layout._text;
+      const pieces = item.layout.lines
+        .map((l) => full.slice(l.start, l.end).trim())
+        .filter((t) => t !== '');
+      assert.deepEqual(
+        pieces,
+        pieces.length ? [full.trim()] : [],
+        `at width ${width} a cell was split into ${JSON.stringify(pieces)}; ` +
+          `it holds ${JSON.stringify(full)} and was laid out at ` +
+          `maxWidth ${item.layout.options?.maxWidth}`
+      );
+    }
+  }
+});
+
 test('MarkdownView: wide table shrinks columns to the container', needsFonts, () => {
   const fonts = new FontManager();
   const view = new MarkdownView(null, { fonts });

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -331,6 +331,35 @@ test('MarkdownView: table layout places cells and grid', needsFonts, () => {
   assert.ok(Math.abs(right(texts[3]) - right(texts[5])) < 0.5, 'right-aligned column');
 });
 
+test('TextLayout: a narrow maxWidth is not a min-content probe', needsFonts, () => {
+  const fonts = new FontManager();
+  const style = { family: 'sans-serif', size: 16 };
+  const span = { text: 'value', ...style };
+  const whole = new TextLayout(fonts, [span], style, {}).width;
+
+  // Laying a single token out at a tiny maxWidth looks like a way to measure
+  // min-content, and is not one. `_forceBreak` splits a token wider than the
+  // container whenever a single cluster fits, so the reported width is a
+  // *fragment* — and whether a cluster fits at a given maxWidth depends on the
+  // font, which is how a table column floor built on this probe came out below
+  // the word it existed to protect on one machine and not another.
+  //
+  // The width is therefore not monotonic in maxWidth. This pins that, so the
+  // probe does not come back as an obvious simplification.
+  const widths = [1, 16].map(
+    (maxWidth) => new TextLayout(fonts, [span], style, { maxWidth }).width
+  );
+  assert.equal(widths[0], whole, 'at maxWidth 1 no cluster fits, so it overflows whole');
+  assert.ok(
+    widths[1] < whole,
+    `at maxWidth 16 the token force-breaks and reports a fragment, got ${widths[1]} of ${whole}`
+  );
+
+  // Measuring one token unconstrained is the reliable answer, and is what
+  // MarkdownView's table layout uses.
+  assert.equal(new TextLayout(fonts, [span], style, {}).width, whole);
+});
+
 test('MarkdownView: a squeezed column never narrows past its longest word', needsFonts, () => {
   const fonts = new FontManager();
   // Every cell is a single unbreakable word, so no column can give up width by

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -395,6 +395,43 @@ test('MarkdownView: a squeezed column never narrows past its longest word', need
   }
 });
 
+test('MarkdownView: no table cell is laid out below its widest token', needsFonts, () => {
+  const fonts = new FontManager();
+  // The invariant behind the test above, checked directly instead of through a
+  // symptom that only appears on an unlucky font. A cell handed a maxWidth
+  // below the measured width of a word it holds is a word wider than its
+  // container, and TextLayout force-breaks those.
+  //
+  // It used to be violated by arithmetic alone: the content width was derived
+  // as `cols[c] - hpad * 2` from a `cols[c]` that had just had `hpad * 2`
+  // added, and that round trip is not the identity in floating point. At size
+  // 16, a natural width of 48.953125 comes back as 48.95312499999999 — seven
+  // ULPs low, and enough.
+  const md = '| column | value |\n| ------ | ----: |\n| alpha | 12 |\n| beta | 345 |';
+  for (const size of [12, 13, 16, 19]) {
+    for (const width of [400, 220, 140, 80, 40]) {
+      const view = new MarkdownView(null, { fonts, theme: { size } });
+      view.setMarkdown(md);
+      view.layout(width);
+      for (const item of view._items.filter((i) => i.kind === 'text')) {
+        const maxWidth = item.layout.options?.maxWidth;
+        if (maxWidth === undefined) continue;
+        const text = item.layout._text;
+        for (const token of text.split(/\s+/)) {
+          if (!token) continue;
+          const style = { family: 'sans-serif', size, weight: item.layout.lines[0]?.runs[0]?.span.weight };
+          const tokenWidth = new TextLayout(fonts, [{ ...style, text: token }], style, {}).width;
+          assert.ok(
+            maxWidth >= tokenWidth,
+            `size ${size} width ${width}: "${token}" measures ${tokenWidth} but its ` +
+              `cell was laid out at maxWidth ${maxWidth}`
+          );
+        }
+      }
+    }
+  }
+});
+
 test('MarkdownView: wide table shrinks columns to the container', needsFonts, () => {
   const fonts = new FontManager();
   const view = new MarkdownView(null, { fonts });


### PR DESCRIPTION
A `value` header rendered as `valu` over `e`. **Two independent causes**, and the second is the one that made this pass on one machine and fail on another.

## 1. The column floor ignored the content

When a table's natural width does not fit, columns shrink proportionally with a floor — and the floor was a flat `2.5em`, a guess unrelated to what the column held. A column whose longest word was wider got a `maxWidth` narrower than the word, and `TextLayout` force-breaks a token wider than its container (`lib/text/layout.js:131`).

The floor is now the column's **min-content width**: the widest whitespace-delimited token, each measured *unconstrained*. Space above the minimums is shared in proportion to what each column asked for. When the minimums themselves do not fit, the table overflows rather than breaking words — what a browser does with the same content. Minimums are measured only when shrinking is needed.

With this reverted, at width 120: `["col","um","n"]` for `column`.

## 2. The cell's width was recovered by subtracting the padding back

This is what failed CI while passing locally, and it is not really about fonts.

The width a cell was laid out at came from `cols[c] - hpad * 2`, where `cols[c]` had just had `hpad * 2` **added**. That round trip is not the identity in binary floating point:

```
natural                     = 48.953125
natural + hpad*2 - hpad*2   = 48.95312499999999     ← seven ULPs low
```

Seven ULPs low is still low, and a token handed a `maxWidth` below its own measured width is a token *wider than its container* — so it force-breaks. Font-dependent only because some widths survive the round trip and others do not: `48.953125` undershoots, `42.09375` does not. CI's font landed on one that undershoots.

The content width is now carried alongside the column width instead of recovered from it: the measured natural width itself where nothing shrinks, clamped to min-content where it does.

## Tests

Three, and the middle one is the one that should have been written first — it pins the **invariant** rather than a symptom, so it fails on the reverted code with any font:

```
"value" measures 56.60099999999999
but its cell was laid out at maxWidth 56.600999999999985
```

The third pins something worth knowing on its own: **`TextLayout`'s width is not monotonic in `maxWidth`.** KaTeX Main at 16px measuring `value` reports the whole 42.1px at `maxWidth` 1–8, then 13.4px at 16, because `_forceBreak` splits a token whenever a single cluster fits and lets it overflow whole when none does. That makes "lay it out at a tiny maxWidth" a *bad* min-content probe — it was my first attempt at the floor above, and it sent this down the wrong path for two rounds.

Split out of #107 so the clip-performance work there was not blocked on this.

---

Found by manually testing a markdown table in react-x11's stress app.