### PR TITLE
perf: copy only the region a frame changed, not the whole window

### DIFF
--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -236,7 +236,14 @@ class RenderingContext2d {
 
   // notify a double-buffered window that its backing content changed
   _markDirty() {
-    if (typeof this.window._markDirty === 'function') this.window._markDirty();
+    if (typeof this.window._markDirty !== 'function') return;
+    // The clip bounds everything this operation could have touched, so it is
+    // also the region the window has to blit. Reporting it lets the present
+    // copy the part of the backing store that changed instead of all of it —
+    // a hover repaint of two tab headers used to blit the whole window. A
+    // context with no rectangular clip reports nothing, and the window falls
+    // back to a full blit, which is what any drawing outside a clip needs.
+    this.window._markDirty(this._clips.length ? this._clipRect() : null);
   }
 
   // html context2d compatibility: canvas.getContext('2d').canvas == canvas

--- a/lib/window.js
+++ b/lib/window.js
@@ -6,6 +6,26 @@ import Drawable from './drawable.js';
 import Pixmap from './pixmap.js';
 import * as xevents from './events_map.js';
 
+/**
+ * Union two dirty regions, where `undefined` is "nothing yet" and `null` is
+ * "unbounded".
+ *
+ * The asymmetry is the whole point: once any operation declines to say where it
+ * drew, the region cannot be trusted to bound the frame, and it has to stay
+ * unbounded no matter what is unioned into it afterwards. Getting that
+ * backwards means blitting less than was drawn, which leaves stale pixels on
+ * screen — so the absorbing state is the safe one.
+ */
+function unionDirty(current, add) {
+  if (current === null || add === null || add === undefined) return null;
+  if (current === undefined) return { x: add.x, y: add.y, w: add.w, h: add.h };
+  const x = Math.min(current.x, add.x);
+  const y = Math.min(current.y, add.y);
+  const right = Math.max(current.x + current.w, add.x + add.w);
+  const bottom = Math.max(current.y + current.h, add.y + add.h);
+  return { x, y, w: right - x, h: bottom - y };
+}
+
 // X window attributes forwarded verbatim from constructor args into the
 // CreateWindow value list (node-x11 valueMask names, see x11
 // lib/corereqs.js). Deliberately not forwarded:
@@ -397,9 +417,22 @@ export default class Window extends Drawable {
     this._scheduleFrame();
   }
 
-  // called by rendering contexts after each drawing operation
-  _markDirty() {
+  /**
+   * Called by rendering contexts after each drawing operation.
+   *
+   * `bounds` is the region that operation could have touched — a context
+   * reports its clip rectangle, which by definition contains everything it
+   * drew. The regions accumulate, and the next blit copies just their union
+   * instead of the whole backing store: a repaint of two tab headers is a
+   * 125x31 CopyArea rather than a 1000x700 one. An operation that reports
+   * nothing, because it was not clipped, gives up the optimisation for this
+   * frame and the blit covers everything — the safe direction, and the reason
+   * this needs no cooperation from the caller to be correct.
+   */
+  _markDirty(bounds) {
     if (!this._backing) return;
+    if (!this._dirty) this._dirtyRect = undefined;
+    this._dirtyRect = unionDirty(this._dirtyRect, bounds);
     this._dirty = true;
     this._backingValid = true;
     if (this._presentScheduled) return;
@@ -591,11 +624,21 @@ export default class Window extends Drawable {
     this._presentPending = false;
     if (!this._backing) return;
     this._dirty = false;
+    const rect = this._dirtyRect;
+    this._dirtyRect = undefined;
     const w = Math.min(this.width, this._backing.width);
     const h = Math.min(this.height, this._backing.height);
+    // Clamped to both drawables: CopyArea outside either is a no-op region at
+    // best, and the backing store is grow-only so it can be larger than the
+    // window after a shrink.
+    const x0 = rect ? Math.max(0, Math.floor(rect.x)) : 0;
+    const y0 = rect ? Math.max(0, Math.floor(rect.y)) : 0;
+    const x1 = rect ? Math.min(w, Math.ceil(rect.x + rect.w)) : w;
+    const y1 = rect ? Math.min(h, Math.ceil(rect.y + rect.h)) : h;
+    if (x1 <= x0 || y1 <= y0) return;
     // a paced frame can fire after the connection started closing
     safeRelease(this.X, () => {
-      this.X.CopyArea(this._backing.id, this.id, this._presentGc, 0, 0, 0, 0, w, h);
+      this.X.CopyArea(this._backing.id, this.id, this._presentGc, x0, y0, x0, y0, x1 - x0, y1 - y0);
     });
   }
 

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -14,7 +14,7 @@ import Window from '../lib/window.js';
 let nextId = 0xa000;
 
 function makeMockApp() {
-  const calls = { CopyArea: 0 };
+  const calls = { CopyArea: 0, copies: [] };
   const fences = []; // pending GetInputFocus callbacks, released by tests
   const X = {
     _closing: false,
@@ -32,8 +32,9 @@ function makeMockApp() {
     CreatePixmap() {},
     FreePixmap() {},
     PolyFillRectangle() {},
-    CopyArea() {
+    CopyArea(src, dst, gc, sx, sy, dx, dy, width, height) {
       calls.CopyArea++;
+      calls.copies.push({ x: dx, y: dy, w: width, h: height });
     },
     GetInputFocus(cb) {
       fences.push(cb);
@@ -243,4 +244,90 @@ test('interactive resize drives one paced draw per frame', async () => {
   assert.equal(draws, 2, 'one catch-up redraw at the final size');
   assert.equal(wnd.width, 180);
   wnd.destroy();
+});
+
+
+// --- how much of the backing store a present copies ---------------------
+//
+// A blit used to be the whole window however little had changed, so a repaint
+// of two tab headers copied a megapixel to move 4k of it. A drawing operation
+// reports the region it could have touched — its clip rectangle — and the
+// present copies the union of those instead.
+
+function backedWindow() {
+  const { app, fences, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  // the backing store is normally allocated by getContext('2d'); there is no
+  // real context here, so stand one in and drive _markDirty directly
+  wnd._backing = { id: 0xb000, width: 200, height: 100 };
+  wnd._presentGc = 0xc000;
+  return { wnd, fences, calls };
+}
+
+test('a present copies only the region the drawing reported', async () => {
+  const { wnd, calls } = backedWindow();
+  wnd._markDirty({ x: 10, y: 20, w: 30, h: 12 });
+  await tick();
+  assert.equal(calls.CopyArea, 1);
+  assert.deepEqual(calls.copies[0], { x: 10, y: 20, w: 30, h: 12 });
+});
+
+test('reported regions union, and the union is what gets copied', async () => {
+  const { wnd, calls } = backedWindow();
+  wnd._markDirty({ x: 10, y: 10, w: 10, h: 10 });
+  wnd._markDirty({ x: 50, y: 40, w: 20, h: 20 });
+  await tick();
+  assert.equal(calls.CopyArea, 1, 'still one blit');
+  assert.deepEqual(
+    calls.copies[0],
+    { x: 10, y: 10, w: 60, h: 50 },
+    'the bounding box of both'
+  );
+});
+
+test('drawing that reports no region copies the whole window', async () => {
+  const { wnd, calls } = backedWindow();
+  // an unclipped context cannot say where it drew
+  wnd._markDirty(undefined);
+  await tick();
+  assert.deepEqual(calls.copies[0], { x: 0, y: 0, w: 200, h: 100 });
+});
+
+test('one unreported operation gives up the bound for the whole frame', async () => {
+  const { wnd, calls } = backedWindow();
+  // This is the direction that has to be safe: a small clipped draw followed
+  // by an unclipped one must not blit only the small rect, or the unclipped
+  // drawing never reaches the screen. "Unbounded" absorbs.
+  wnd._markDirty({ x: 10, y: 10, w: 10, h: 10 });
+  wnd._markDirty(undefined);
+  wnd._markDirty({ x: 20, y: 20, w: 10, h: 10 });
+  await tick();
+  assert.deepEqual(calls.copies[0], { x: 0, y: 0, w: 200, h: 100 });
+});
+
+test('the region does not leak into the next frame', async () => {
+  const { wnd, fences, calls } = backedWindow();
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.deepEqual(calls.copies[0], { x: 0, y: 0, w: 10, h: 10 });
+  // release the fence the first present armed, so the second is not deferred
+  while (fences.length) fences.shift()();
+  wnd._markDirty({ x: 100, y: 50, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.CopyArea, 2);
+  assert.deepEqual(
+    calls.copies[1],
+    { x: 100, y: 50, w: 10, h: 10 },
+    'the second frame copies its own region, not the union with the first'
+  );
+});
+
+test('a reported region is clamped to the window', async () => {
+  const { wnd, calls } = backedWindow();
+  // a clip can extend past the surface; CopyArea sizes are unsigned
+  wnd._markDirty({ x: -20, y: -5, w: 400, h: 300 });
+  await tick();
+  assert.deepEqual(calls.copies[0], { x: 0, y: 0, w: 200, h: 100 });
 });


### PR DESCRIPTION

Every present was a full-window CopyArea however little had changed. A hover
repaint of two tab headers copied a megapixel to move about four thousand
pixels of it, and it did that on every frame of the 100ms transition.

A drawing operation already knows the region it could have touched: its clip
rectangle bounds it by definition. The 2d context now reports that with
_markDirty, the window accumulates the union, and the present copies the union
instead of the surface. No new API and no cooperation needed from the caller —
an operation that cannot say where it drew, because it was not clipped, reports
nothing and the frame falls back to copying everything.

That fallback is the load-bearing part, and it absorbs: once any operation in a
frame declines to name a region, the frame stays unbounded no matter what is
unioned in afterwards. The other way round would copy less than was drawn and
leave stale pixels on screen, so the safe state is the sticky one. There is a
test for exactly that ordering.

Measured through react-x11's stress app, twenty wheel notches and one hover
change, same harness, only this commit differing:

                            blits   Mpx copied
    hover two tab headers
      before                    6         4.20
      after                     7         0.03
    20 wheel notches
      before                   20        14.00
      after                    20        13.22

The hover case is the shape this helps: small damage, which is most
interaction. Scrolling barely moves because those frames legitimately repaint
most of the window, and the blit was never the expensive part of them.

Verified against under-copying rather than assumed: after the frames settle,
the window is compared pixel for pixel with the backing store it was copied
from. Nothing else would catch a CopyArea that copies too little — the
dirty-rect tests downstream read the backing store, so a bad blit is invisible
to them.

---

Second of the findings from profiling react-x11's stress app. The first was #107, where nested clipping turned out to dominate a frame; this is the blit at the end of it.

Worth noting what this does *not* do: presentation is still one CopyArea per frame, and the region is a bounding box rather than a list of rects, so two small changes at opposite corners still copy everything between them. That is the same single-rect limitation react-x11's damage tracking has, and it would want fixing in both places at once if it ever matters.