### PR TITLE
perf: copy a region, not the box around it

### DIFF
--- a/lib/window.js
+++ b/lib/window.js
@@ -7,8 +7,94 @@ import Pixmap from './pixmap.js';
 import * as xevents from './events_map.js';
 
 /**
- * Union two dirty regions, where `undefined` is "nothing yet" and `null` is
- * "unbounded".
+ * How many rectangles a frame's dirty region is allowed to hold.
+ *
+ * Drawing reports one region per operation, so a repaint reports hundreds, and
+ * an uncapped list would turn every one of them into its own CopyArea. Past
+ * the cap the cheapest pair is merged (see addDirtyRect), which keeps
+ * genuinely separated clusters apart while adjacent ones coalesce.
+ */
+const MAX_DIRTY_RECTS = 8;
+
+/**
+ * How much of the surrounding box a split has to save to be worth making.
+ *
+ * Several rectangles are several CopyArea requests, and they only beat the one
+ * box around them when they are meaningfully smaller than it: two tab headers
+ * side by side describe nearly the same area either way, two corners of the
+ * window do not. Below this fraction the region is collapsed to its box.
+ */
+const SPLIT_SAVING = 0.75;
+
+function rectArea(r) {
+  return Math.max(0, r.w) * Math.max(0, r.h);
+}
+
+function coversRect(outer, inner) {
+  return (
+    inner.x >= outer.x &&
+    inner.y >= outer.y &&
+    inner.x + inner.w <= outer.x + outer.w &&
+    inner.y + inner.h <= outer.y + outer.h
+  );
+}
+
+function mergeRects(a, b) {
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  const right = Math.max(a.x + a.w, b.x + b.w);
+  const bottom = Math.max(a.y + a.h, b.y + b.h);
+  return { x, y, w: right - x, h: bottom - y };
+}
+
+/** The box around a non-empty list of rectangles. */
+function rectsBounds(rects) {
+  let out = rects[0];
+  for (let i = 1; i < rects.length; i++) out = mergeRects(out, rects[i]);
+  return out;
+}
+
+/**
+ * Add one rectangle to a capped list, returning a new list.
+ *
+ * A rectangle already covered by one in the list adds nothing, which is the
+ * common case by a wide margin: consecutive operations under the same clip all
+ * report the same region. Otherwise it goes on the end, and if that overflows
+ * the cap the pair whose merge wastes the least area is merged — waste being
+ * the area the merged rectangle covers that neither of the two did, so
+ * overlapping and adjacent pairs go first and far-apart ones last.
+ */
+function addDirtyRect(rects, add) {
+  for (const r of rects) {
+    if (coversRect(r, add)) return rects;
+  }
+  const out = rects.filter((r) => !coversRect(add, r));
+  out.push({ x: add.x, y: add.y, w: add.w, h: add.h });
+  if (out.length <= MAX_DIRTY_RECTS) return out;
+  let bestI = 0;
+  let bestJ = 1;
+  let bestMerged = null;
+  let bestWaste = Infinity;
+  for (let i = 0; i < out.length; i++) {
+    for (let j = i + 1; j < out.length; j++) {
+      const merged = mergeRects(out[i], out[j]);
+      const waste = rectArea(merged) - rectArea(out[i]) - rectArea(out[j]);
+      if (waste < bestWaste) {
+        bestWaste = waste;
+        bestI = i;
+        bestJ = j;
+        bestMerged = merged;
+      }
+    }
+  }
+  out[bestI] = bestMerged;
+  out.splice(bestJ, 1);
+  return out;
+}
+
+/**
+ * Union a reported region into a frame's dirty region, where `undefined` is
+ * "nothing yet" and `null` is "unbounded".
  *
  * The asymmetry is the whole point: once any operation declines to say where it
  * drew, the region cannot be trusted to bound the frame, and it has to stay
@@ -18,12 +104,8 @@ import * as xevents from './events_map.js';
  */
 function unionDirty(current, add) {
   if (current === null || add === null || add === undefined) return null;
-  if (current === undefined) return { x: add.x, y: add.y, w: add.w, h: add.h };
-  const x = Math.min(current.x, add.x);
-  const y = Math.min(current.y, add.y);
-  const right = Math.max(current.x + current.w, add.x + add.w);
-  const bottom = Math.max(current.y + current.h, add.y + add.h);
-  return { x, y, w: right - x, h: bottom - y };
+  if (current === undefined) return [{ x: add.x, y: add.y, w: add.w, h: add.h }];
+  return addDirtyRect(current, add);
 }
 
 // X window attributes forwarded verbatim from constructor args into the
@@ -422,17 +504,20 @@ export default class Window extends Drawable {
    *
    * `bounds` is the region that operation could have touched — a context
    * reports its clip rectangle, which by definition contains everything it
-   * drew. The regions accumulate, and the next blit copies just their union
-   * instead of the whole backing store: a repaint of two tab headers is a
-   * 125x31 CopyArea rather than a 1000x700 one. An operation that reports
-   * nothing, because it was not clipped, gives up the optimisation for this
-   * frame and the blit covers everything — the safe direction, and the reason
-   * this needs no cooperation from the caller to be correct.
+   * drew. The regions accumulate, and the next blit copies just those instead
+   * of the whole backing store: a repaint of two tab headers is a 125x31
+   * CopyArea rather than a 1000x700 one. They accumulate as a short list of
+   * rectangles rather than one box around them all, so two repaints at
+   * opposite corners of the window no longer drag everything between them
+   * along. An operation that reports nothing, because it was not clipped,
+   * gives up the optimisation for this frame and the blit covers everything —
+   * the safe direction, and the reason this needs no cooperation from the
+   * caller to be correct.
    */
   _markDirty(bounds) {
     if (!this._backing) return;
-    if (!this._dirty) this._dirtyRect = undefined;
-    this._dirtyRect = unionDirty(this._dirtyRect, bounds);
+    if (!this._dirty) this._dirtyRegion = undefined;
+    this._dirtyRegion = unionDirty(this._dirtyRegion, bounds);
     this._dirty = true;
     this._backingValid = true;
     if (this._presentScheduled) return;
@@ -624,22 +709,48 @@ export default class Window extends Drawable {
     this._presentPending = false;
     if (!this._backing) return;
     this._dirty = false;
-    const rect = this._dirtyRect;
-    this._dirtyRect = undefined;
+    const region = this._dirtyRegion;
+    this._dirtyRegion = undefined;
     const w = Math.min(this.width, this._backing.width);
     const h = Math.min(this.height, this._backing.height);
     // Clamped to both drawables: CopyArea outside either is a no-op region at
     // best, and the backing store is grow-only so it can be larger than the
-    // window after a shrink.
-    const x0 = rect ? Math.max(0, Math.floor(rect.x)) : 0;
-    const y0 = rect ? Math.max(0, Math.floor(rect.y)) : 0;
-    const x1 = rect ? Math.min(w, Math.ceil(rect.x + rect.w)) : w;
-    const y1 = rect ? Math.min(h, Math.ceil(rect.y + rect.h)) : h;
-    if (x1 <= x0 || y1 <= y0) return;
+    // window after a shrink. A rectangle that survives clamping with no area
+    // left is dropped; if that leaves nothing, nothing needs copying.
+    const clamped = [];
+    for (const rect of region ?? [{ x: 0, y: 0, w, h }]) {
+      const x0 = Math.max(0, Math.floor(rect.x));
+      const y0 = Math.max(0, Math.floor(rect.y));
+      const x1 = Math.min(w, Math.ceil(rect.x + rect.w));
+      const y1 = Math.min(h, Math.ceil(rect.y + rect.h));
+      if (x1 > x0 && y1 > y0) clamped.push({ x: x0, y: y0, w: x1 - x0, h: y1 - y0 });
+    }
+    if (!clamped.length) return;
+    const rects = this._blitList(clamped);
     // a paced frame can fire after the connection started closing
     safeRelease(this.X, () => {
-      this.X.CopyArea(this._backing.id, this.id, this._presentGc, x0, y0, x0, y0, x1 - x0, y1 - y0);
+      for (const r of rects) {
+        this.X.CopyArea(this._backing.id, this.id, this._presentGc, r.x, r.y, r.x, r.y, r.w, r.h);
+      }
     });
+  }
+
+  /**
+   * The rectangles a present actually copies, given the ones drawing reported.
+   *
+   * The list is not used as it stands: each rectangle is a request, and a
+   * region whose pieces nearly fill the box around them is better served by
+   * one copy of the box. So the split is kept only when it saves enough of
+   * that box to pay for the extra requests, and collapsed otherwise. Both
+   * directions cover every reported pixel, so this is a cost decision and
+   * never a correctness one.
+   */
+  _blitList(rects) {
+    if (rects.length < 2) return rects;
+    const box = rectsBounds(rects);
+    let sum = 0;
+    for (const r of rects) sum += rectArea(r);
+    return sum > rectArea(box) * SPLIT_SAVING ? [box] : rects;
   }
 
   map() {

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -252,7 +252,12 @@ test('interactive resize drives one paced draw per frame', async () => {
 // A blit used to be the whole window however little had changed, so a repaint
 // of two tab headers copied a megapixel to move 4k of it. A drawing operation
 // reports the region it could have touched — its clip rectangle — and the
-// present copies the union of those instead.
+// present copies those instead.
+//
+// They are kept as a list of rectangles, not one box around them all, so that
+// two repaints at opposite corners do not drag everything between them along.
+// The list is capped, and collapsed back to its box when splitting would not
+// save enough to pay for the extra requests.
 
 function backedWindow() {
   const { app, fences, calls } = makeMockApp();
@@ -274,17 +279,113 @@ test('a present copies only the region the drawing reported', async () => {
   assert.deepEqual(calls.copies[0], { x: 10, y: 20, w: 30, h: 12 });
 });
 
-test('reported regions union, and the union is what gets copied', async () => {
+test('regions far apart are copied separately, not as one box', async () => {
   const { wnd, calls } = backedWindow();
   wnd._markDirty({ x: 10, y: 10, w: 10, h: 10 });
   wnd._markDirty({ x: 50, y: 40, w: 20, h: 20 });
   await tick();
-  assert.equal(calls.CopyArea, 1, 'still one blit');
-  assert.deepEqual(
-    calls.copies[0],
-    { x: 10, y: 10, w: 60, h: 50 },
-    'the bounding box of both'
-  );
+  assert.equal(calls.CopyArea, 2, 'one blit each');
+  assert.deepEqual(calls.copies, [
+    { x: 10, y: 10, w: 10, h: 10 },
+    { x: 50, y: 40, w: 20, h: 20 }
+  ]);
+  // the point of the exercise: 500px copied where the box around both is 3000
+  const copied = calls.copies.reduce((sum, r) => sum + r.w * r.h, 0);
+  assert.equal(copied, 500);
+});
+
+test('regions that nearly fill their box are copied as the box', async () => {
+  const { wnd, calls } = backedWindow();
+  // side-by-side tab headers: two 20x10 rects with a 2px gap. Splitting saves
+  // 20 of 420 pixels, which is not worth a second request.
+  wnd._markDirty({ x: 10, y: 10, w: 20, h: 10 });
+  wnd._markDirty({ x: 32, y: 10, w: 20, h: 10 });
+  await tick();
+  assert.equal(calls.CopyArea, 1, 'collapsed to one blit');
+  assert.deepEqual(calls.copies[0], { x: 10, y: 10, w: 42, h: 10 });
+});
+
+// Nesting is checked on the list itself rather than through the copies,
+// because the collapse rule would hide a redundant entry: two rectangles that
+// nest are copied as their box either way, and their box is the outer one. The
+// list length is the property that matters — the cap is a budget, and spending
+// it on rectangles that cover each other is what forces the real ones to merge.
+test('a region already covered by another does not lengthen the list', async () => {
+  const { wnd, calls } = backedWindow();
+  // the overwhelmingly common case: consecutive operations under one clip all
+  // report the same rectangle, or one nested inside it
+  wnd._markDirty({ x: 10, y: 10, w: 40, h: 40 });
+  wnd._markDirty({ x: 20, y: 20, w: 10, h: 10 });
+  // checked here rather than at the end: re-reporting the outer rectangle
+  // would collapse the list again by covering both entries, so it would hide a
+  // nested entry that had been kept
+  assert.equal(wnd._dirtyRegion.length, 1, 'the nested rectangle was dropped');
+  wnd._markDirty({ x: 10, y: 10, w: 40, h: 40 });
+  assert.equal(wnd._dirtyRegion.length, 1);
+  await tick();
+  assert.equal(calls.CopyArea, 1);
+  assert.deepEqual(calls.copies[0], { x: 10, y: 10, w: 40, h: 40 });
+});
+
+test('a region covering an earlier one replaces it', async () => {
+  const { wnd, calls } = backedWindow();
+  wnd._markDirty({ x: 20, y: 20, w: 10, h: 10 });
+  wnd._markDirty({ x: 10, y: 10, w: 40, h: 40 });
+  assert.equal(wnd._dirtyRegion.length, 1);
+  await tick();
+  assert.equal(calls.CopyArea, 1, 'not two overlapping copies');
+  assert.deepEqual(calls.copies[0], { x: 10, y: 10, w: 40, h: 40 });
+});
+
+test('a far-apart region survives a flood of nested ones', async () => {
+  const { wnd, calls } = backedWindow();
+  // What the nesting checks buy: 30 operations under one clip, plus one small
+  // repaint in the far corner. Without them the cap fills with rectangles that
+  // cover each other and the corner gets merged into the rest.
+  wnd._markDirty({ x: 0, y: 0, w: 60, h: 60 });
+  for (let i = 0; i < 30; i++) {
+    wnd._markDirty({ x: 2 + (i % 20), y: 2 + (i % 20), w: 10, h: 10 });
+  }
+  wnd._markDirty({ x: 180, y: 90, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.CopyArea, 2, 'the corner is still its own copy');
+  assert.deepEqual(calls.copies, [
+    { x: 0, y: 0, w: 60, h: 60 },
+    { x: 180, y: 90, w: 10, h: 10 }
+  ]);
+});
+
+test('the number of copies stays capped however many regions are reported', async () => {
+  const { wnd, calls } = backedWindow();
+  // 40 scattered 2x2 rects, more than the cap. Whatever the merging does, it
+  // may not exceed the cap and may not lose a reported pixel.
+  const reported = [];
+  for (let i = 0; i < 40; i++) {
+    const rect = { x: (i * 7) % 190, y: (i * 11) % 90, w: 2, h: 2 };
+    reported.push(rect);
+    wnd._markDirty(rect);
+  }
+  await tick();
+  assert.ok(calls.CopyArea >= 1, 'something was copied');
+  assert.ok(calls.CopyArea <= 8, `at most the cap, got ${calls.CopyArea}`);
+  for (const r of reported) {
+    const inside = calls.copies.some(
+      (c) => r.x >= c.x && r.y >= c.y && r.x + r.w <= c.x + c.w && r.y + r.h <= c.y + c.h
+    );
+    assert.ok(inside, `${JSON.stringify(r)} is inside some copy`);
+  }
+});
+
+test('an unbounded region still absorbs a list of rectangles', async () => {
+  const { wnd, calls } = backedWindow();
+  // the same safety property as the single-rect version, now that "current"
+  // can be a list: an unreported operation has to discard the whole list
+  wnd._markDirty({ x: 10, y: 10, w: 10, h: 10 });
+  wnd._markDirty({ x: 150, y: 80, w: 10, h: 10 });
+  wnd._markDirty(undefined);
+  await tick();
+  assert.equal(calls.CopyArea, 1);
+  assert.deepEqual(calls.copies[0], { x: 0, y: 0, w: 200, h: 100 });
 });
 
 test('drawing that reports no region copies the whole window', async () => {


### PR DESCRIPTION
Follow-up to #110. That PR made a present copy the region drawing reported instead of the whole window; this one stops flattening that region into a single box.

Two repaints at opposite corners of a window used to be copied as the one rectangle containing both, so the pixels between them went along for the ride. The accumulator now keeps a short list of rectangles and the present issues a `CopyArea` per rectangle.

### How the list is kept

- A rectangle already covered by one in the list adds nothing. This is the common case by a wide margin — consecutive operations under the same clip all report the same region — and it matters because the cap below is a budget: spending it on rectangles that cover each other is what forces the real ones to merge.
- A rectangle that covers an existing entry replaces it.
- The list is capped at **8**. Drawing reports one region per operation, so a repaint reports hundreds and an uncapped list would turn every one into a request. Past the cap the pair whose merge wastes the least area is merged — waste being the area the merged rectangle covers that neither of the two did — so overlapping and adjacent pairs go first and far-apart clusters last.

### When the split is worth making

Several rectangles are several requests, and they only beat one copy of the box around them when they are meaningfully smaller than it. Two tab headers side by side describe nearly the same area either way; two corners of the window do not. So a region whose pieces fill more than three quarters of their box is collapsed back to the box before anything is copied. Both answers cover every reported pixel, which makes this a cost decision and never a correctness one.

### Safety

`undefined` (nothing reported yet) and `null` (unbounded) keep the asymmetry #110 introduced, and `null` still **absorbs**: an operation that declines to say where it drew discards the whole accumulated list for that frame, not just the rectangle it would have contributed. Copying less than was drawn leaves stale pixels on screen, so that is the direction that has to be safe. There is a test for it, and it fails if `undefined` is made non-absorbing.

### Measured

Driven through react-x11's stress app against the in-process pure-JS X server, with the renderer-side companion change (react-x11 paints a pass per damage rect). Damage panel, five commits each:

| scenario | before | after |
| --- | --- | --- |
| four cells at the grid's corners | 5 blits, 2508 kpx | 20 blits, **51 kpx** |
| every cell in the grid | 5 blits, 2508 kpx | 5 blits, 2508 kpx |
| hover two adjacent tab headers | 8 blits, 33 kpx | 8 blits, 33 kpx |

The second row is what makes the first mean something — damage that genuinely covers the grid still costs the grid. The third is the collapse rule declining to split a region that would not benefit.

Checked against copying *less* than was drawn by reading back the window and the backing store after each run and comparing: 0 pixels differ.

363 tests pass. Seven new ones in `test/frame-pacing.test.js`, each verified non-vacuous by planting the corresponding fault (cap removed, always collapse, never collapse, `undefined` non-absorbing, both containment checks removed) and confirming exactly the expected test fails.