### PR TITLE
feat: _NET_WM_STATE beyond always-on-top, and both ways of changing it

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -194,6 +194,9 @@ All return `this` unless noted.
   `setTransientFor(owner)`, `setClass(instance, class)`,
   `setWindowType(type)`, `setAlwaysOnTop(on)`, `setPid(pid, hostname)` — see
   [Window manager hints](#window-manager-hints) below
+- `setWmState(names, action)` / `addWmState(names)` /
+  `removeWmState(names)` / `getWmStates()` — EWMH `_NET_WM_STATE`:
+  fullscreen, maximized, skip-taskbar and the rest. Promises
 - `addProtocol(name)` / `removeProtocol(name)` / `setProtocols(names)` /
   `getProtocols()` — WM_PROTOCOLS, returning promises; `setActions()` is the
   older spelling of `addProtocol('WM_DELETE_WINDOW')`
@@ -394,10 +397,49 @@ This is the window-manager-cooperative alternative to override-redirect: a
 menu marked `dropdown_menu` still gets shadows and correct stacking, while
 an override-redirect window bypasses the window manager entirely.
 
+### Window states — `setWmState(names, action)`
+
+Writes EWMH `_NET_WM_STATE`: fullscreen, maximized, sticky, shaded, modal,
+skip-taskbar, skip-pager, demands-attention, above, below.
+
+```js
+await wnd.setWmState('fullscreen');           // 'add' is the default
+await wnd.setWmState('maximized');            // both axes in one message
+await wnd.setWmState(['skip_taskbar', 'skip_pager'], 'add');
+await wnd.setWmState('fullscreen', 'toggle');
+await wnd.removeWmState('above');
+
+await wnd.getWmStates();   // ['fullscreen', 'focused'] — what the WM did
+wnd.on('statechange', (states) => { ... });
+```
+
+Names are the EWMH atoms without their `_NET_WM_STATE_` prefix, in lower
+case; full atom names work too. `'maximized'` expands to the
+`MAXIMIZED_VERT` + `MAXIMIZED_HORZ` pair, which is what the message's two
+state slots are for. More than two at once throws rather than being
+truncated — send several messages.
+
+**Mapped and unmapped windows change state differently, and the two are not
+interchangeable** (EWMH 7.7). A mapped window *asks* the window manager with
+a ClientMessage to the root; an unmapped one *declares* its initial state by
+writing the property, which is how you open a window fullscreen. ntk asks
+the server which the window is rather than trusting the last `map`/`unmap`
+event, so this is right even on the line after `map()`.
+
+The promise resolves to whether the window manager advertises every state
+asked for in `_NET_SUPPORTED`. The request is made either way — an unmapped
+window may legitimately declare a state before any window manager is
+running — so `false` means "nothing is listening", not "nothing happened".
+
+`getWmStates()` is what the window manager actually put on the window, so it
+is the answer to *am I fullscreen*, where `setWmState` is only the request.
+`statechange` fires when that property changes: the user hitting a maximize
+button or a fullscreen hotkey changes the state behind the application's
+back, and an app mirroring it in its own UI goes stale without this.
+
 ### Always on top — `setAlwaysOnTop(on)` / `alwaysOnTop`
 
-Prefers the EWMH `_NET_WM_STATE_ABOVE` state, sent as a ClientMessage to
-the root window as the spec requires for mapped windows.
+A wrapper for `setWmState('above')`, kept because it carries a fallback.
 
 quartz-wm (XQuartz) does not advertise `_NET_WM_STATE_ABOVE`, so on macOS
 this falls back to the Apple-WM extension's window levels, which are the
@@ -405,7 +447,9 @@ only always-on-top mechanism there. The fallback addresses the frame the
 window manager created rather than our own window id — Apple-WM answers
 `BadWindow` for a reparented client.
 
-Where neither is available the call is a no-op.
+The EWMH request is made either way, so where neither mechanism exists the
+window is left declaring a state nothing acts on — harmless, and what a
+window manager starting later would read.
 
 ## Being the window manager
 
@@ -623,6 +667,7 @@ constructor arg) automatically extends the window's X event mask.
 | `map` / `unmap` | Map/UnmapNotify | |
 | `destroy` | DestroyNotify | wrapper is removed from the cache |
 | `map_request`, `configure_request` | SubstructureRedirect | for window managers |
+| `statechange` | PropertyNotify | derived, not an X event: the window manager changed `_NET_WM_STATE`. The handler gets the state names, not an event object — see [Window states](#window-states--setwmstatenames-action) |
 | `property`, `reparent`, `message`, `selection*` | | |
 
 Every event object gets `ev.window` and `ev.target` set to the `Window`.

--- a/lib/events_map.js
+++ b/lib/events_map.js
@@ -64,6 +64,9 @@ export const mask = {
   destroy: x11.eventMask.StructureNotify,
   keyup: x11.eventMask.KeyRelease,
   property: x11.eventMask.PropertyChange,
+  // not an X event of its own: Window derives it from the PropertyNotify for
+  // _NET_WM_STATE, so it needs the same mask a 'property' listener does
+  statechange: x11.eventMask.PropertyChange,
   selection: 0,
   selection_request: 0,
   message: 0

--- a/lib/window.js
+++ b/lib/window.js
@@ -190,6 +190,50 @@ const CREATION_HINT_KEYS = [
   'protocols'
 ];
 
+// EWMH 5.7 _NET_WM_STATE, in spec order. FOCUSED and HIDDEN are set by the
+// window manager rather than asked for, but a client still reads them.
+const EWMH_STATES = [
+  'modal',
+  'sticky',
+  'maximized_vert',
+  'maximized_horz',
+  'shaded',
+  'skip_taskbar',
+  'skip_pager',
+  'hidden',
+  'fullscreen',
+  'above',
+  'below',
+  'demands_attention',
+  'focused'
+];
+
+/** 'fullscreen' -> '_NET_WM_STATE_FULLSCREEN'; a full atom name passes through. */
+function stateAtomName(name) {
+  return name.startsWith('_NET_WM_STATE_') ? name : `_NET_WM_STATE_${name.toUpperCase()}`;
+}
+
+/** The inverse, for reporting what the window manager put on the window. */
+function stateShortName(atomName) {
+  return atomName.startsWith('_NET_WM_STATE_')
+    ? atomName.slice('_NET_WM_STATE_'.length).toLowerCase()
+    : atomName;
+}
+
+/**
+ * Normalize the argument of setWmState.
+ *
+ * 'maximized' is the one name that is not an atom: EWMH maximizes an axis at
+ * a time, and giving the message both atoms at once is exactly what its two
+ * state slots are for.
+ */
+function expandStateNames(names) {
+  const list = Array.isArray(names) ? names : [names];
+  return list.flatMap((n) =>
+    n === 'maximized' ? ['maximized_vert', 'maximized_horz'] : [n]
+  );
+}
+
 /**
  * Warn once per process about a hint that will do nothing.
  *
@@ -270,6 +314,9 @@ export default class Window extends Drawable {
     // WM_PROTOCOLS is a set: read-modify-write, serialized (see addProtocol)
     this._protocols = null;
     this._protocolQueue = Promise.resolve();
+    // so is _NET_WM_STATE, on the unmapped path (see setWmState)
+    this._wmStateQueue = Promise.resolve();
+    this._netWmStateAtom = 0; // resolved when a 'statechange' listener appears
     // what setHints has accumulated per struct, so a later call can rewrite
     // the whole property without dropping what an earlier one set
     this._sizeHints = null;
@@ -445,6 +492,16 @@ export default class Window extends Drawable {
         this._enqueueCoalesced(eventName, ntkev);
         return;
       }
+      // the window manager reporting what it did with the window: a user who
+      // hit maximize or a fullscreen hotkey changes the state behind the
+      // app's back, and this is the only way an app that mirrors it in its
+      // own UI stays honest
+      if (eventName === 'property' && ev.atom === this._netWmStateAtom) {
+        this.getWmStates().then(
+          (states) => this.emit('statechange', states),
+          () => {}
+        );
+      }
       // deliver buffered state events before a discrete one so handlers see
       // them in the order they happened (a drag sees the move, then the up)
       this._flushCoalesced();
@@ -471,6 +528,16 @@ export default class Window extends Drawable {
     });
 
     this.on('newListener', (name) => {
+      // 'statechange' is derived from a PropertyNotify, so it needs the atom
+      // to compare against as well as the mask the table below selects
+      if (name === 'statechange' && !this._netWmStateAtom) {
+        this.atom('_NET_WM_STATE').then(
+          (atom) => {
+            this._netWmStateAtom = atom;
+          },
+          () => {}
+        );
+      }
       // extend the server-side event mask if this event needs it
       const eventMask = xevents.mask[name];
       if (!eventMask) return;
@@ -1490,6 +1557,171 @@ export default class Window extends Drawable {
   }
 
   /**
+   * EWMH `_NET_WM_STATE` — fullscreen, maximized, sticky, skip-taskbar and
+   * the rest of the states a window can be in.
+   *
+   *   await wnd.setWmState('fullscreen');            // add, the default
+   *   await wnd.setWmState('maximized', 'add');      // both axes at once
+   *   await wnd.setWmState(['skip_taskbar', 'skip_pager'], 'add');
+   *   await wnd.setWmState('fullscreen', 'toggle');
+   *
+   * Names are the EWMH atoms without their `_NET_WM_STATE_` prefix, in
+   * lower case; full atom names work too. `'maximized'` expands to the
+   * `MAXIMIZED_VERT` + `MAXIMIZED_HORZ` pair, which is why the spec allows
+   * two states per message.
+   *
+   * How the change is made depends on whether the window is mapped, and the
+   * two are not interchangeable (EWMH 7.7): a mapped window *asks* the
+   * window manager with a ClientMessage to the root, an unmapped one
+   * *declares* its initial state by writing the property. This asks the
+   * server which it is rather than trusting the last map/unmap event, so it
+   * is right even on the line after `map()`.
+   *
+   * @param {string|string[]} names
+   * @param {'add'|'remove'|'toggle'} [action]
+   * @returns {Promise<boolean>} whether the window manager advertises every
+   *   state asked for in `_NET_SUPPORTED`. The request is made either way —
+   *   an unmapped window may legitimately declare a state before any window
+   *   manager is running — but `false` means nothing is listening for it.
+   */
+  async setWmState(names, action = 'add') {
+    const list = expandStateNames(names);
+    if (!list.length) return false;
+    if (list.length > 2) {
+      // EWMH gives the message two atom slots and no more; splitting into
+      // several messages is fine, but silently sending the first two is not
+      throw new RangeError(
+        `setWmState: a _NET_WM_STATE message carries at most 2 states, got ${list.length}`
+      );
+    }
+    const mode = { remove: 0, add: 1, toggle: 2 }[action];
+    if (mode === undefined) {
+      throw new TypeError(`setWmState: action must be add, remove or toggle, got ${action}`);
+    }
+
+    const [atoms, supported, attrs] = await Promise.all([
+      this._stateAtoms(list),
+      this._netSupported(),
+      this.getAttributes().catch(() => null)
+    ]);
+    if (this._destroyed) return false;
+    const ids = list.map((n) => atoms.get(n));
+    // mapState: 0 Unmapped, 1 Unviewable, 2 Viewable. Unviewable is mapped
+    // under an unmapped ancestor, which is still mapped as far as EWMH cares
+    const mapped = attrs ? attrs.mapState !== 0 : this._mapped;
+
+    if (mapped) {
+      const root = this.app.display.screen[0].root;
+      const messageType = await this.atom('_NET_WM_STATE');
+      if (this._destroyed) return false;
+      safeRelease(this.X, () => {
+        this.X.SendClientMessage(root, this.id, messageType, 32, [
+          mode,
+          ids[0],
+          ids[1] ?? 0,
+          1 // source indication: a normal application, not a pager
+        ]);
+      });
+    } else {
+      await this._writeWmState(ids, mode);
+    }
+    return ids.every((id) => supported.has(id));
+  }
+
+  /** `setWmState(names, 'add')`. @returns {Promise<boolean>} */
+  addWmState(names) {
+    return this.setWmState(names, 'add');
+  }
+
+  /** `setWmState(names, 'remove')`. @returns {Promise<boolean>} */
+  removeWmState(names) {
+    return this.setWmState(names, 'remove');
+  }
+
+  /**
+   * The states currently in `_NET_WM_STATE`, as short lower-case names.
+   * `[]` when the window has none.
+   *
+   * This is what the window manager put there, so it is the answer to "am I
+   * actually fullscreen", where `setWmState` is only the request.
+   *
+   * @returns {Promise<string[]>}
+   */
+  async getWmStates() {
+    const ids = await this.getProperty('_NET_WM_STATE', { as: 'numbers' }).catch(() => null);
+    if (!ids || !ids.length) return [];
+    const known = await this._stateAtoms(EWMH_STATES);
+    const byAtom = new Map([...known].map(([name, atom]) => [atom, name]));
+    return Promise.all(
+      ids.map(async (id) => {
+        const name = byAtom.get(id);
+        if (name) return name;
+        // a state this build does not know about, or a vendor one
+        const full = await new Promise((resolve) =>
+          this.X.GetAtomName(id, (err, n) => resolve(err ? null : n))
+        );
+        return full ? stateShortName(full) : null;
+      })
+    ).then((names) => names.filter(Boolean));
+  }
+
+  /**
+   * Read-modify-write on the atom list an unmapped window declares.
+   *
+   * `_NET_WM_STATE` is a list, so a plain Replace with one atom drops the
+   * rest — the same trap WM_PROTOCOLS had. Serialized for the same reason:
+   * two changes in a tick would each read the list before the other wrote.
+   */
+  _writeWmState(ids, mode) {
+    const run = async () => {
+      const current = new Set(
+        (await this.getProperty('_NET_WM_STATE', { as: 'numbers' }).catch(() => null)) || []
+      );
+      for (const id of ids) {
+        const add = mode === 2 ? !current.has(id) : mode === 1;
+        if (add) current.add(id);
+        else current.delete(id);
+      }
+      const property = await this.atom('_NET_WM_STATE');
+      if (this._destroyed) return this;
+      safeRelease(this.X, () => {
+        this.X.ChangeProperty(0, this.id, property, this.X.atoms.ATOM, 32, [...current]);
+      });
+      return this;
+    };
+    this._wmStateQueue = this._wmStateQueue.then(run, run);
+    return this._wmStateQueue;
+  }
+
+  /** Intern the atoms for a list of short state names. @returns {Promise<Map>} */
+  async _stateAtoms(names) {
+    const ids = await Promise.all(names.map((n) => this.atom(stateAtomName(n))));
+    return new Map(names.map((n, i) => [n, ids[i]]));
+  }
+
+  /**
+   * The atoms in the root window's `_NET_SUPPORTED`, read once per
+   * connection.
+   *
+   * It is one property on one window describing one window manager, so
+   * re-reading it per window per call is pure round trips. A window manager
+   * that restarts and advertises differently is the cost, and the same one
+   * every toolkit accepts.
+   *
+   * @returns {Promise<Set<number>>}
+   */
+  _netSupported() {
+    if (!this.app._netSupportedPromise) {
+      this.app._netSupportedPromise = this.app
+        .rootWindow()
+        .getProperty('_NET_SUPPORTED', { as: 'numbers' })
+        .then((ids) => new Set(ids || []))
+        .catch(() => new Set());
+    }
+    return this.app._netSupportedPromise;
+  }
+
+  /**
    * Keep this window above normal windows.
    *
    * Prefers EWMH `_NET_WM_STATE_ABOVE`. quartz-wm (XQuartz) does not
@@ -1500,42 +1732,12 @@ export default class Window extends Drawable {
    * parent is root — not our own id.
    */
   setAlwaysOnTop(on = true) {
-    const X = this.X;
-    const _NET_WM_STATE_ADD = 1;
-    const _NET_WM_STATE_REMOVE = 0;
-
-    this._withAtoms(['_NET_WM_STATE', '_NET_WM_STATE_ABOVE', '_NET_SUPPORTED'], (atoms) => {
-      const root = this.app.display.screen[0].root;
-      safeRelease(X, () => {
-        X.GetProperty(0, root, atoms._NET_SUPPORTED, X.atoms.ATOM, 0, 1024, (err, prop) => {
-          if (err || this._destroyed) return;
-          let supported = false;
-          const data = prop?.data;
-          for (let i = 0; data && i + 4 <= data.length; i += 4) {
-            if (data.readUInt32LE(i) === atoms._NET_WM_STATE_ABOVE) {
-              supported = true;
-              break;
-            }
-          }
-          if (supported) {
-            // a mapped window changes state by asking the WM, not by
-            // writing the property (EWMH 7.7). The message goes to the root
-            // with the default SubstructureRedirect|SubstructureNotify mask,
-            // which is where the window manager is listening.
-            safeRelease(X, () => {
-              X.SendClientMessage(root, this.id, atoms._NET_WM_STATE, 32, [
-                on ? _NET_WM_STATE_ADD : _NET_WM_STATE_REMOVE,
-                atoms._NET_WM_STATE_ABOVE,
-                0, // second property: none
-                1 // source indication: application
-              ]);
-            });
-          } else {
-            this._appleWMSetLevel(on);
-          }
-        });
-      });
-    });
+    this.setWmState('above', on ? 'add' : 'remove').then(
+      (supported) => {
+        if (!supported && !this._destroyed) this._appleWMSetLevel(on);
+      },
+      (err) => this.app.options.onXError?.(err)
+    );
     return this;
   }
 

--- a/test/event-send.test.js
+++ b/test/event-send.test.js
@@ -100,11 +100,18 @@ test('setAlwaysOnTop asks the window manager with a five-word EWMH message', asy
   // the WM advertises the state, so the EWMH path is taken rather than the
   // Apple-WM fallback
   await root.setProperty('_NET_SUPPORTED', [above], { type: 'ATOM' });
-  await root.selectInput(REDIRECT);
+  // SubstructureNotify alone: enough to receive a message sent with the
+  // substructure mask, and without the redirect bit the client's own map()
+  // proceeds instead of turning into a map_request for us to answer
+  await root.selectInput(x11.eventMask.SubstructureNotify);
   await settleBoth();
 
   const app = client.createWindow({ width: 40, height: 30 });
+  const mapped = nextEvent(app, 'map');
+  app.map();
+  await mapped;
   await settleBoth();
+
   // the message travels via the root's substructure mask but names the
   // client window in its own window field, and ntk routes events by that
   // field — so a window manager sees it on its wrapper for the client

--- a/test/events-map.test.js
+++ b/test/events-map.test.js
@@ -10,11 +10,20 @@ test('every camelCase handler name maps to a snake event with a mask entry', () 
   }
 });
 
-test('every maskable event name is emitted by some X event type', () => {
+// names in the mask table that are not X event types. `statechange` is
+// derived from the PropertyNotify for _NET_WM_STATE and is in the table
+// because a listener for it still has to select PropertyChange.
+const DERIVED = new Set(['statechange']);
+
+test('every maskable event name is emitted by some X event type, or derived from one', () => {
   const emitted = new Set(eventName.filter(Boolean));
   for (const name of Object.keys(mask)) {
-    if (name === 'selection_clear') continue;
+    if (name === 'selection_clear' || DERIVED.has(name)) continue;
     assert.ok(emitted.has(name), `${name} never emitted`);
+  }
+  for (const name of DERIVED) {
+    assert.ok(mask[name], `${name} is derived but selects no mask`);
+    assert.ok(!emitted.has(name), `${name} is an X event after all — drop it from DERIVED`);
   }
 });
 

--- a/test/window-state.test.js
+++ b/test/window-state.test.js
@@ -1,0 +1,225 @@
+// EWMH _NET_WM_STATE: fullscreen, maximize, skip-taskbar and the rest.
+// The interesting part is that there are two ways to change it and they are
+// not interchangeable — a mapped window asks the window manager, an unmapped
+// one declares its initial state by writing the property (EWMH 7.7) — so
+// these tests run both paths against node-x11's in-process pure-JS X server
+// and watch what actually goes on the wire.
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import x11 from 'x11';
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+let server = null;
+let wm = null; // stands in for the window manager: watches the root
+let client = null;
+
+const connect = async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+};
+
+beforeEach(async () => {
+  server = createServer({ width: 400, height: 300 });
+  wm = await connect();
+  client = await connect();
+});
+
+afterEach(() => {
+  wm?.X.terminate();
+  client?.X.terminate();
+  server = wm = client = null;
+});
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+const settleBoth = async () => {
+  await settle(client);
+  await settle(wm);
+};
+
+const nextEvent = (window, name) => new Promise((resolve) => window.once(name, resolve));
+
+const atom = (app, name) =>
+  new Promise((resolve, reject) =>
+    app.X.InternAtom(false, name, (err, id) => (err ? reject(err) : resolve(id)))
+  );
+
+/** Advertise `names` in the root's _NET_SUPPORTED, as a window manager would. */
+const advertise = async (names) => {
+  const ids = await Promise.all(names.map((n) => atom(wm, `_NET_WM_STATE_${n.toUpperCase()}`)));
+  await wm.rootWindow().setProperty('_NET_SUPPORTED', ids, { type: 'ATOM' });
+  await settleBoth();
+  return ids;
+};
+
+/** Create a window and wait until the server really has it mapped. */
+const mappedWindow = async (args = {}) => {
+  const wnd = client.createWindow({ width: 60, height: 40, ...args });
+  const up = nextEvent(wnd, 'map');
+  wnd.map();
+  await up;
+  await settleBoth();
+  return wnd;
+};
+
+// ---------------------------------------------------------------------
+// The unmapped path: declare the state by writing the property
+// ---------------------------------------------------------------------
+
+test('an unmapped window declares its state by writing the property', async () => {
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  await wnd.setWmState('fullscreen');
+
+  assert.deepEqual(await wnd.getWmStates(), ['fullscreen']);
+});
+
+test('the unmapped path accumulates instead of replacing', async () => {
+  // _NET_WM_STATE is a list, so a plain Replace with one atom drops the rest
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  await wnd.addWmState('fullscreen');
+  await wnd.addWmState('skip_taskbar');
+
+  assert.deepEqual((await wnd.getWmStates()).sort(), ['fullscreen', 'skip_taskbar']);
+
+  await wnd.removeWmState('fullscreen');
+  assert.deepEqual(await wnd.getWmStates(), ['skip_taskbar']);
+});
+
+test('two unmapped changes in the same tick both land', async () => {
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  await Promise.all([wnd.addWmState('above'), wnd.addWmState('sticky')]);
+
+  assert.deepEqual((await wnd.getWmStates()).sort(), ['above', 'sticky']);
+});
+
+test("toggle flips each state on the unmapped path", async () => {
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  await wnd.setWmState('fullscreen', 'toggle');
+  assert.deepEqual(await wnd.getWmStates(), ['fullscreen']);
+
+  await wnd.setWmState('fullscreen', 'toggle');
+  assert.deepEqual(await wnd.getWmStates(), []);
+});
+
+test("'maximized' expands to the vertical and horizontal pair", async () => {
+  // EWMH maximizes one axis at a time, which is why its message has room
+  // for two states rather than one
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  await wnd.setWmState('maximized');
+
+  assert.deepEqual((await wnd.getWmStates()).sort(), ['maximized_horz', 'maximized_vert']);
+});
+
+// ---------------------------------------------------------------------
+// The mapped path: ask the window manager
+// ---------------------------------------------------------------------
+
+test('a mapped window asks the window manager instead of writing the property', async () => {
+  await wm.rootWindow().selectInput(x11.eventMask.SubstructureNotify);
+  const [fullscreen] = await advertise(['fullscreen']);
+  const netWmState = await atom(wm, '_NET_WM_STATE');
+
+  const wnd = await mappedWindow();
+  const seen = wm.createWindow({ id: wnd.id });
+  const pending = nextEvent(seen, 'message');
+
+  assert.equal(await wnd.setWmState('fullscreen'), true, 'the WM advertises it');
+  const ev = await pending;
+
+  assert.equal(ev.message_type, netWmState);
+  assert.deepEqual(ev.data, [1 /* add */, fullscreen, 0, 1 /* application */, 0]);
+  // and it did NOT write the property: the window manager owns it on a
+  // mapped window, and a client writing it there is ignored at best
+  await settleBoth();
+  assert.deepEqual(await wnd.getWmStates(), [], 'nothing written behind the WM back');
+});
+
+test('both maximize atoms travel in one message', async () => {
+  await wm.rootWindow().selectInput(x11.eventMask.SubstructureNotify);
+  const [vert, horz] = await advertise(['maximized_vert', 'maximized_horz']);
+
+  const wnd = await mappedWindow();
+  const pending = nextEvent(wm.createWindow({ id: wnd.id }), 'message');
+  await wnd.setWmState('maximized', 'add');
+
+  const ev = await pending;
+  assert.deepEqual(ev.data.slice(0, 3), [1, vert, horz], 'both slots used');
+});
+
+test('more than two states at once is refused, not silently truncated', async () => {
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  await assert.rejects(
+    () => wnd.setWmState(['fullscreen', 'above', 'sticky']),
+    /at most 2 states/
+  );
+  await assert.rejects(() => wnd.setWmState('fullscreen', 'maybe'), /add, remove or toggle/);
+});
+
+// ---------------------------------------------------------------------
+// _NET_SUPPORTED
+// ---------------------------------------------------------------------
+
+test('a state the window manager does not advertise reports false', async () => {
+  await advertise(['above']);
+  const wnd = await mappedWindow();
+
+  assert.equal(await wnd.setWmState('above'), true);
+  assert.equal(await wnd.setWmState('fullscreen'), false, 'nothing is listening for it');
+});
+
+test('an unmapped window still declares a state no window manager advertises', async () => {
+  // there may be no window manager running yet; the property is how a
+  // client says what it wants before one arrives to read it
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  assert.equal(await wnd.setWmState('fullscreen'), false, 'reported honestly');
+  assert.deepEqual(await wnd.getWmStates(), ['fullscreen'], 'and written anyway');
+});
+
+// ---------------------------------------------------------------------
+// Reading back, and hearing about changes
+// ---------------------------------------------------------------------
+
+test('getWmStates names states this build has never heard of', async () => {
+  const wnd = client.createWindow({ width: 60, height: 40 });
+  const vendor = await atom(client, '_NET_WM_STATE_SOMETHING_NEW');
+  await wnd.setProperty('_NET_WM_STATE', [vendor], { type: 'ATOM' });
+
+  assert.deepEqual(await wnd.getWmStates(), ['something_new']);
+});
+
+test("statechange fires when the window manager changes the window's state", async () => {
+  // the user hits the maximize button or a fullscreen hotkey: the state
+  // changes behind the application's back, and this is the only way an app
+  // that mirrors it in its own UI stays honest
+  const wnd = await mappedWindow();
+  const heard = nextEvent(wnd, 'statechange');
+  await settleBoth();
+
+  // the window manager owns the property on a mapped window
+  await wm.createWindow({ id: wnd.id }).setProperty('_NET_WM_STATE', [
+    await atom(wm, '_NET_WM_STATE_FULLSCREEN'),
+    await atom(wm, '_NET_WM_STATE_FOCUSED')
+  ], { type: 'ATOM' });
+
+  const states = await heard;
+  assert.deepEqual(states.slice().sort(), ['focused', 'fullscreen']);
+});
+
+test('setAlwaysOnTop still works, and now takes the mapped path', async () => {
+  await wm.rootWindow().selectInput(x11.eventMask.SubstructureNotify);
+  const [above] = await advertise(['above']);
+
+  const wnd = await mappedWindow();
+  const pending = nextEvent(wm.createWindow({ id: wnd.id }), 'message');
+  wnd.setAlwaysOnTop(true);
+
+  const ev = await pending;
+  assert.deepEqual(ev.data.slice(0, 2), [1, above]);
+});


### PR DESCRIPTION
Third of three, after #130 and #131. Rebased onto master now that both have merged, so this diff is only the `_NET_WM_STATE` work.

Closes #117.

## What was there

`setAlwaysOnTop` was the entire `_NET_WM_STATE` surface: one of the thirteen states EWMH defines, hard-wired. Everything in it — the `_NET_SUPPORTED` probe, the ClientMessage, the XQuartz fallback — was state-agnostic and only needed the atom as a parameter.

```js
await wnd.setWmState('fullscreen');          // 'add' is the default
await wnd.setWmState('maximized');           // both axes, one message
await wnd.setWmState(['skip_taskbar', 'skip_pager'], 'add');
await wnd.setWmState('fullscreen', 'toggle');

await wnd.getWmStates();                     // ['fullscreen', 'focused']
wnd.on('statechange', onStates);
```

`'maximized'` expands to the `MAXIMIZED_VERT` + `MAXIMIZED_HORZ` pair, which is what the message's two state slots are for. More than two at once throws rather than being truncated.

## The half that was missing, not just narrow

EWMH 7.7 gives mapped and unmapped windows **different mechanisms, and they are not interchangeable**: a mapped window *asks* the window manager with a ClientMessage to the root; an unmapped one *declares* its initial state by writing the property. `setAlwaysOnTop` always sent the message, so an ntk window could not open fullscreen at all — only ask to become fullscreen after it was already on screen.

Which path applies is decided by asking the server for the window's map state, not by trusting the last `map`/`unmap` event. That matters on the line right after `map()`, where the event has not arrived and `this._mapped` is still `false` — the obvious implementation would take the wrong branch exactly when a caller is most likely to write that code.

The property is a list, so the unmapped path is read-modify-write and serialized: the same trap `WM_PROTOCOLS` had in #131, and the same fix.

## Reporting instead of no-op

`setWmState` resolves to whether the window manager advertises every state asked for, so an unsupported state reports `false` rather than silently doing nothing.

The request is made either way, which is the one judgement call here worth flagging. An unmapped window may legitimately declare a state before any window manager is running — that is precisely how "open fullscreen" works — so gating the write on `_NET_SUPPORTED` would break the case the unmapped path exists for. `false` therefore means *nothing is listening*, not *nothing happened*, and the docs say so.

`_NET_SUPPORTED` is now read once per connection instead of once per call: it is one property on one window describing one window manager. A window manager that restarts and advertises differently is the cost, and it is the one every toolkit accepts.

## Reading back

`getWmStates()` returns what the window manager actually put on the window, which is the answer to *am I fullscreen* where `setWmState` is only the request. It names states this build has never heard of — vendor atoms, anything added to EWMH later — rather than dropping them.

`statechange` fires on the `PropertyNotify` behind it. This is the piece a controlled `fullscreen` prop needs downstream: the user hitting a maximize button or a global fullscreen hotkey changes the state behind the application's back, and an app that mirrors it in its own UI goes stale on the first one. It is the first derived event in ntk — not an X event type of its own — so `lib/events_map.js` grew a note and `test/events-map.test.js`'s invariant now says "emitted by an X event type, **or** derived from one" and checks that derived names still select a mask.

`setAlwaysOnTop` keeps its name, its signature and its Apple-WM fallback, and is now four lines.

## Behaviour change worth reviewing

One test from #130 had to change: `setAlwaysOnTop` on an unmapped window no longer sends a ClientMessage, because that is now the property-write path. The test maps the window first. That is the fix for #117's headline gap showing up in a test that had encoded the old behaviour, not a regression — but it is the one place where this PR changes what an existing call does, so it is worth a look.

## Test

405 passing; 13 new in `test/window-state.test.js`, covering both paths. Mutation-checked:

| mutation | caught by |
| --- | --- |
| always take the mapped path | 6 unmapped tests |
| always take the unmapped path | 3 mapped tests |
| unmapped write replaces instead of accumulating | 3 tests |
| `_NET_SUPPORTED` never consulted | 2 tests |
