### PR TITLE
fix: follow the active keyboard layout, and stop CapsLock shifting digits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ lib/pixmap.js              offscreen drawable
 lib/drawable.js            EventEmitter base + getContext() registry
 lib/events_map.js          X event code <-> browser-ish event name tables
                            (incl. FocusIn/FocusOut as 'focus'/'blur')
+lib/keyboard.js            key event -> keysym/codepoint: XKB group from the
+                           event state, CapsLock only on cased keys
 lib/clipboard.js           app.clipboard: ICCCM selection/clipboard text
                            transfer (CLIPBOARD/PRIMARY, INCR-aware reads)
 lib/renderingcontext_2d.js canvas-like context (XRender); CanvasGradient

--- a/docs/window.md
+++ b/docs/window.md
@@ -674,9 +674,15 @@ Every event object gets `ev.window` and `ev.target` set to the `Window`.
 
 ## Keyboard input
 
-`keydown` carries the raw X `ev.keycode` plus `ev.codepoint`, the Unicode
-codepoint the key types, resolved against the keyboard mapping ntk fetches at
-connect and refreshes on `MappingNotify`.
+`keydown` and `keyup` carry the raw X `ev.keycode` plus:
+
+- `ev.codepoint` — the Unicode codepoint the key types
+- `ev.keysym` — the keysym it resolved to
+- `ev.baseKeysym` — the same key's group-1, level-1 keysym, for shortcuts
+- `ev.group` — the active XKB layout group, 0–3
+
+resolved against the keyboard mapping ntk fetches at connect and refreshes on
+`MappingNotify`.
 
 **`codepoint` is absent when the key types nothing** — arrows, function keys,
 modifiers, `Pause`, and dead keys (ntk has no compose support yet, and emitting
@@ -700,6 +706,35 @@ Both legacy keysyms and the direct-Unicode form modern non-Latin layouts emit
 keypress path reads the filesystem, so this works the same in an esbuild bundle,
 a single-executable build and the browser.
 
-> Selecting the keysym still ignores the active XKB group, so a second
-> (non-Latin) layout does not take effect and `AltGr` levels are unreachable.
-> Tracked in [#116](https://github.com/sidorares/ntk/issues/116).
+### Layout groups and shortcuts
+
+A layout switch on Linux does not change the keymap. Both layouts are loaded
+at once — the map holds `[g1l1, g1l2, g2l1, g2l2, …]` for each key — and
+switching moves the *active group*, which arrives in every key event's own
+state bits. No `MappingNotify` is sent, so there is nothing to refetch;
+reading those bits is the whole of it, and ntk does.
+
+Shortcuts should match `ev.baseKeysym`, not `ev.keysym`:
+
+```js
+wnd.on('keydown', (ev) => {
+  if (ev.buttons & 4 && ev.baseKeysym === 0x7a) undo(); // Ctrl+Z, any layout
+});
+```
+
+`baseKeysym` stays on group 1 whatever the user is typing, which is how GTK,
+Qt and browsers keep `Ctrl+Z` working while a Cyrillic layout is active. Match
+on `ev.keysym` instead and the shortcut disappears the moment the user
+switches layout.
+
+CapsLock applies only to keys that have a case, so it does not turn the number
+row into its shifted symbols — the rule XKB's key types encode, reproduced
+here from Unicode case mapping, which covers Cyrillic and Greek as well as
+Latin.
+
+> **Not yet: `AltGr` (level 3).** The core keyboard map is ambiguous about it —
+> four keysyms on a key are two groups of two levels under `us,ru` and one
+> group of four under `us(intl)`, and nothing in the core protocol tells them
+> apart. The request that resolves it, `XkbGetMap`, is not implemented in
+> node-x11, and guessing would break multi-layout users to half-serve AltGr
+> users. Tracked in [#116](https://github.com/sidorares/ntk/issues/116).

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ import App from './app.js';
 import Clipboard from './clipboard.js';
 import { CursorCache, cursorShapes, resolveCursorShape } from './cursor.js';
 import Window from './window.js';
+import { decodeKey, groupForState } from './keyboard.js';
 import Pixmap from './pixmap.js';
 import Picture from './picture.js';
 import { Image, decodeImage, loadImage } from './image.js';
@@ -138,7 +139,9 @@ export {
   cssColor,
   cssColorStraight,
   premultiply,
-  cssLength
+  cssLength,
+  decodeKey,
+  groupForState
 };
 // the yoga-layout instance ntk lays HtmlView out with — downstream layout
 // consumers (e.g. the react-x11 renderer) must share it to avoid loading a

--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -1,0 +1,114 @@
+import { keysymToUnicode } from './text/keysym-unicode.js';
+
+// Turning a key event into a character.
+//
+// X's core keyboard map is a flat list of keysyms per keycode, and XKB lays
+// its groups over that list in pairs: [g1l1, g1l2, g2l1, g2l2, ...]. A layout
+// switch moves the *active group*, which arrives in bits 13-14 of every key
+// event's state field — the keymap itself does not change, so no
+// MappingNotify is sent and nothing can be refetched in response. Reading
+// those two bits is the whole of layout support for the common case.
+//
+// What this cannot do is level 3, the AltGr row. The core map is ambiguous
+// there: four keysyms on a keycode are two groups of two levels under
+// `us,ru`, and one group of four levels under `us(intl)`, and nothing in the
+// core protocol distinguishes them. The request that resolves it is
+// XkbGetMap, which node-x11 does not implement — its xkb module says so in
+// as many words. Guessing would break multi-layout users to half-serve
+// AltGr users, so this reads groups only.
+
+const SHIFT_MASK = 1;
+const LOCK_MASK = 2;
+
+// XKB reports the effective group in bits 13-14 of the core state field
+const GROUP_SHIFT = 13;
+const GROUP_MASK = 3;
+
+// Pairs, because that is all the core keyboard map can express
+const LEVELS_PER_GROUP = 2;
+
+/** The active XKB layout group, 0-3, from a key event's state field. */
+export function groupForState(state) {
+  return (state >> GROUP_SHIFT) & GROUP_MASK;
+}
+
+/** NoSymbol is 0, and a short keysym list simply ends. */
+function present(sym) {
+  return sym !== undefined && sym !== 0;
+}
+
+/**
+ * The character a keysym types, or undefined for keys that type nothing —
+ * arrows, function keys, modifiers.
+ */
+function charOf(sym) {
+  const cp = present(sym) ? keysymToUnicode(sym) : undefined;
+  return cp === undefined ? undefined : String.fromCodePoint(cp);
+}
+
+/**
+ * Whether a key's two levels are the lower and upper case of one letter.
+ *
+ * This is what decides whether CapsLock applies. XKB asks the key's *type*:
+ * its ALPHABETIC type folds Lock into the level, and the two-level type used
+ * for the number row does not — which is why CapsLock does not turn `1` into
+ * `!` on any real desktop. Unicode case mapping answers the same question
+ * without the XKB map, and answers it for Cyrillic and Greek too.
+ */
+function isCasePair(lowerChar, upperChar) {
+  if (lowerChar === undefined || upperChar === undefined) return false;
+  return lowerChar !== upperChar && lowerChar.toUpperCase() === upperChar;
+}
+
+/**
+ * Decode a key event against the keyboard map.
+ *
+ * @param {number[]} syms the keycode's keysyms, as `GetKeyboardMapping`
+ *   returns them — `X.keycode2keysyms[ev.keycode]`
+ * @param {number} state the event's modifier/group state (`ev.buttons`)
+ * @returns {{ keysym: number, baseKeysym: number, group: number,
+ *   codepoint: number|undefined }|undefined} undefined when the keycode maps
+ *   to nothing at all
+ */
+export function decodeKey(syms, state) {
+  if (!syms || syms.length === 0) return undefined;
+
+  const group = groupForState(state);
+  let base = group * LEVELS_PER_GROUP;
+  // X core protocol: a group with no symbols on this key falls back to
+  // group 1. Layouts differ in which keys they define, so this is normal —
+  // a Cyrillic layout leaves the function row to the Latin one.
+  if (!present(syms[base]) && !present(syms[base + 1])) base = 0;
+
+  const first = syms[base];
+  if (!present(first)) return undefined;
+  const firstChar = charOf(first);
+
+  let second = syms[base + 1];
+  let secondChar = charOf(second);
+  if (!present(second)) {
+    // "if the second element is NoSymbol, the group is treated as the lower
+    // and upper case of the first when the first has a case, and as the first
+    // twice otherwise" — X core protocol, Keyboard and Pointer. There is no
+    // uppercase *keysym* to name in that case, only an uppercase character.
+    second = first;
+    const upper = firstChar === undefined ? undefined : firstChar.toUpperCase();
+    secondChar = upper !== undefined && upper.length === 1 ? upper : firstChar;
+  }
+
+  const shift = (state & SHIFT_MASK) !== 0;
+  const lock = (state & LOCK_MASK) !== 0 && isCasePair(firstChar, secondChar);
+  const upperLevel = shift !== lock;
+
+  const keysym = upperLevel ? second : first;
+  const char = upperLevel ? secondChar : firstChar;
+  return {
+    keysym,
+    // group 1, level 1 — what a keyboard shortcut should match against, so
+    // Ctrl+Z stays Ctrl+Z while the user is typing Cyrillic. GTK, Qt and
+    // browsers all resolve accelerators this way.
+    baseKeysym: present(syms[0]) ? syms[0] : keysym,
+    group,
+    codepoint: char === undefined ? undefined : char.codePointAt(0)
+  };
+}

--- a/lib/window.js
+++ b/lib/window.js
@@ -4,7 +4,7 @@ import { safeRelease } from './cleanup.js';
 import Drawable from './drawable.js';
 import Pixmap from './pixmap.js';
 import * as xevents from './events_map.js';
-import { keysymToUnicode } from './text/keysym-unicode.js';
+import { decodeKey } from './keyboard.js';
 
 /**
  * How many rectangles a frame's dirty region is allowed to hold.
@@ -475,17 +475,16 @@ export default class Window extends Drawable {
         this._handleExpose(ev);
         return;
       }
-      if (eventName === 'keydown') {
-        const evKeysym = X.keycode2keysyms[ev.keycode];
-        const shift = ev.buttons & 1;
-        const capsLock = ev.buttons & 2;
-        const capital = (capsLock && !shift) || (shift && !capsLock);
-        const symInd = capital ? 1 : 0; // TODO: AltGr & other modifiers to use syms 2, 3, 4 etc
-        // keys that type nothing (arrows, F-keys, modifiers) leave `codepoint`
-        // absent rather than reporting a codepoint of 0
-        const cp = evKeysym ? keysymToUnicode(evKeysym[symInd]) : undefined;
-        if (cp !== undefined) {
-          ev.codepoint = cp;
+      if (eventName === 'keydown' || eventName === 'keyup') {
+        // the active layout arrives in the event's own state bits, not in the
+        // keymap — see lib/keyboard.js. Keys that type nothing (arrows,
+        // F-keys, modifiers) leave `codepoint` absent rather than reporting 0.
+        const key = decodeKey(X.keycode2keysyms[ev.keycode], ev.buttons);
+        if (key) {
+          ev.keysym = key.keysym;
+          ev.baseKeysym = key.baseKeysym;
+          ev.group = key.group;
+          if (key.codepoint !== undefined) ev.codepoint = key.codepoint;
         }
       }
       if (this._coalesce && xevents.coalesce[eventName]) {

--- a/test/keyboard.test.js
+++ b/test/keyboard.test.js
@@ -1,0 +1,113 @@
+// Which character a key event types. Pure unit tests against the keyboard
+// map — no X server, because the whole bug is that the answer depends on
+// state bits ntk was not reading, not on anything the server does.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { decodeKey, groupForState } from '../lib/keyboard.js';
+
+const SHIFT = 1;
+const LOCK = 2;
+const group = (n) => n << 13;
+
+// keysyms, as GetKeyboardMapping reports them
+const a = 0x0061;
+const A = 0x0041;
+const one = 0x0031;
+const exclam = 0x0021;
+const cyrillicEf = 0x06c6; // Cyrillic_ef, the 'a' key under the ru layout
+const cyrillicEF = 0x06e6; // Cyrillic_EF
+const F1 = 0xffbe;
+const NoSymbol = 0;
+
+const ch = (result) =>
+  result && result.codepoint !== undefined ? String.fromCodePoint(result.codepoint) : undefined;
+
+test('group bits are the top of the state field, not a modifier', () => {
+  assert.equal(groupForState(0), 0);
+  assert.equal(groupForState(group(1)), 1);
+  assert.equal(groupForState(group(3) | SHIFT | LOCK), 3);
+  // the modifier bits below them must not leak in
+  assert.equal(groupForState(0x1fff), 0);
+});
+
+test('group 1 types unshifted and shifted as before', () => {
+  assert.equal(ch(decodeKey([a, A], 0)), 'a');
+  assert.equal(ch(decodeKey([a, A], SHIFT)), 'A');
+});
+
+test('the active group selects the second pair of keysyms', () => {
+  // this is the bug: with us,ru loaded the keymap holds all four symbols and
+  // a layout switch moves only the group bits, so ntk typed Latin forever
+  const syms = [a, A, cyrillicEf, cyrillicEF];
+  assert.equal(ch(decodeKey(syms, group(1))), 'ф');
+  assert.equal(ch(decodeKey(syms, group(1) | SHIFT)), 'Ф');
+  assert.equal(ch(decodeKey(syms, 0)), 'a', 'and group 1 is unaffected');
+});
+
+test('a group with nothing on this key falls back to group 1', () => {
+  // layouts differ in which keys they define — a Cyrillic layout leaves the
+  // function row to the Latin one, and X core protocol says so explicitly
+  assert.equal(decodeKey([F1, NoSymbol, NoSymbol, NoSymbol], group(1)).keysym, F1);
+  assert.equal(decodeKey([F1], group(1)).keysym, F1, 'a short list is the same case');
+});
+
+test('CapsLock applies to letters', () => {
+  assert.equal(ch(decodeKey([a, A], LOCK)), 'A');
+  // XKB folds Lock into the level for alphabetic keys, so caps + shift is
+  // lowercase again — what every real desktop does
+  assert.equal(ch(decodeKey([a, A], LOCK | SHIFT)), 'a');
+});
+
+test('CapsLock does not apply to the number row', () => {
+  // the old shift-xor-lock rule turned 1 into ! with CapsLock on, because it
+  // never asked whether the key had a case at all
+  assert.equal(ch(decodeKey([one, exclam], LOCK)), '1');
+  assert.equal(ch(decodeKey([one, exclam], SHIFT)), '!');
+  assert.equal(ch(decodeKey([one, exclam], LOCK | SHIFT)), '!');
+});
+
+test('CapsLock applies to Cyrillic too, not just Latin', () => {
+  assert.equal(ch(decodeKey([a, A, cyrillicEf, cyrillicEF], group(1) | LOCK)), 'Ф');
+});
+
+test('a missing second level is the upper case of the first', () => {
+  assert.equal(ch(decodeKey([a], 0)), 'a');
+  assert.equal(ch(decodeKey([a], SHIFT)), 'A');
+  assert.equal(ch(decodeKey([a], LOCK)), 'A');
+  // and a key with no case repeats rather than inventing one
+  assert.equal(ch(decodeKey([one], SHIFT)), '1');
+});
+
+test('keys that type nothing report no codepoint', () => {
+  const key = decodeKey([F1, NoSymbol], 0);
+  assert.equal(key.keysym, F1);
+  assert.equal(key.codepoint, undefined, 'F1 is a keysym, not a character');
+});
+
+test('an unmapped keycode decodes to nothing at all', () => {
+  assert.equal(decodeKey(undefined, 0), undefined);
+  assert.equal(decodeKey([], 0), undefined);
+  assert.equal(decodeKey([NoSymbol, NoSymbol], 0), undefined);
+});
+
+test('baseKeysym stays on group 1 so shortcuts survive a layout switch', () => {
+  // Ctrl+Z has to keep being Ctrl+Z while the user types Cyrillic. GTK, Qt
+  // and browsers all resolve accelerators against the group-1 keysym.
+  const z = 0x007a;
+  const Z = 0x005a;
+  const cyrillicYa = 0x06d1;
+  const syms = [z, Z, cyrillicYa, cyrillicYa];
+
+  const typed = decodeKey(syms, group(1));
+  assert.equal(typed.keysym, cyrillicYa, 'types Cyrillic');
+  assert.equal(typed.baseKeysym, z, 'but the shortcut is still z');
+  assert.equal(typed.group, 1);
+});
+
+test('direct-Unicode keysyms decode to their codepoint', () => {
+  // 0x01000000 | codepoint — how layouts spell characters keysymdef.h has no
+  // name for, and the shape a non-Latin layout most often emits
+  const snowman = 0x01002603;
+  assert.equal(ch(decodeKey([snowman], 0)), '☃');
+});

--- a/test/window-keyboard.test.js
+++ b/test/window-keyboard.test.js
@@ -1,0 +1,135 @@
+// The keydown path end to end: a real key event over the wire, decoded
+// against the connection's keyboard map. Hermetic — node-x11's in-process
+// pure-JS X server delivers the events, and SendEvent supplies the state bits
+// a layout switch would set, which no server-side action can produce here.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+let server = null;
+let app = null;
+
+const KEYCODE = 38; // 'a' on an evdev keymap
+const a = 0x0061;
+const A = 0x0041;
+const cyrillicEf = 0x06c6;
+const cyrillicEF = 0x06e6;
+
+const SHIFT = 1;
+const LOCK = 2;
+const group = (n) => n << 13;
+
+before(async () => {
+  server = createServer({ width: 320, height: 240 });
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+  // createClient issues GetKeyboardMapping and fills keycode2keysyms from the
+  // reply, so wait for that to land before replacing a row — otherwise the
+  // server's two-symbol default arrives afterwards and quietly wins
+  await new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+  // stand in for a `us,ru` keymap: four keysyms on the key, which is what
+  // GetKeyboardMapping reports once a second layout is loaded
+  app.X.keycode2keysyms[KEYCODE] = [a, A, cyrillicEf, cyrillicEF];
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+/** Deliver a KeyPress to `wnd` carrying `state`, and resolve with the event. */
+const press = (wnd, state) =>
+  new Promise((resolve) => {
+    wnd.once('keydown', resolve);
+    app.X.SendEvent(wnd.id, 0, 0, {
+      name: 'KeyPress',
+      keycode: KEYCODE,
+      time: 0,
+      root: app.display.screen[0].root,
+      wid: wnd.id,
+      child: 0,
+      rootx: 0,
+      rooty: 0,
+      x: 0,
+      y: 0,
+      buttons: state,
+      sameScreen: 1
+    });
+  });
+
+test('a key event types the character of the active layout group', async () => {
+  const wnd = app.createWindow({ width: 40, height: 40 });
+
+  assert.equal(String.fromCodePoint((await press(wnd, 0)).codepoint), 'a');
+  assert.equal(String.fromCodePoint((await press(wnd, SHIFT)).codepoint), 'A');
+
+  // the layout switch: no keysym changed and no MappingNotify was sent, only
+  // these two bits moved
+  assert.equal(String.fromCodePoint((await press(wnd, group(1))).codepoint), 'ф');
+  assert.equal(String.fromCodePoint((await press(wnd, group(1) | SHIFT)).codepoint), 'Ф');
+  assert.equal(String.fromCodePoint((await press(wnd, group(1) | LOCK)).codepoint), 'Ф');
+});
+
+test('the event carries the keysym, the group and the shortcut keysym', async () => {
+  const wnd = app.createWindow({ width: 40, height: 40 });
+
+  const ev = await press(wnd, group(1));
+  assert.equal(ev.keysym, cyrillicEf, 'what was typed');
+  assert.equal(ev.baseKeysym, a, 'what a Ctrl+A accelerator should match');
+  assert.equal(ev.group, 1);
+});
+
+test('an unmapped keycode leaves the event without a codepoint', async () => {
+  const wnd = app.createWindow({ width: 40, height: 40 });
+
+  const ev = await new Promise((resolve) => {
+    wnd.once('keydown', resolve);
+    app.X.SendEvent(wnd.id, 0, 0, {
+      name: 'KeyPress',
+      keycode: 250, // nothing on this keycode
+      time: 0,
+      root: app.display.screen[0].root,
+      wid: wnd.id,
+      child: 0,
+      rootx: 0,
+      rooty: 0,
+      x: 0,
+      y: 0,
+      buttons: 0,
+      sameScreen: 1
+    });
+  });
+  assert.equal(ev.codepoint, undefined);
+  assert.equal(ev.keysym, undefined);
+});
+
+test('keyup decodes the same way keydown does', async () => {
+  // a text field that acts on keyup, or any code comparing the two, saw a
+  // keysym on one and nothing on the other
+  const wnd = app.createWindow({ width: 40, height: 40 });
+
+  const ev = await new Promise((resolve) => {
+    wnd.once('keyup', resolve);
+    app.X.SendEvent(wnd.id, 0, 0, {
+      name: 'KeyRelease',
+      keycode: KEYCODE,
+      time: 0,
+      root: app.display.screen[0].root,
+      wid: wnd.id,
+      child: 0,
+      rootx: 0,
+      rooty: 0,
+      x: 0,
+      y: 0,
+      buttons: group(1),
+      sameScreen: 1
+    });
+  });
+  assert.equal(String.fromCodePoint(ev.codepoint), 'ф');
+  assert.equal(ev.baseKeysym, a);
+});


### PR DESCRIPTION
Partially addresses #116 — the layout-group half. AltGr stays open, for a reason worth reading below.

## The bug

`symInd = capital ? 1 : 0` reaches only levels 1–2 of group 1. So on Linux a second layout never took effect: switch to Cyrillic, Greek, Hebrew or Arabic and ntk keeps typing Latin, forever. Every user with a non-Latin layout in their list cannot type their own language in any ntk app.

What made it look like nothing was wrong: **a layout switch changes no keysym.** Both layouts are loaded at once — the map holds `[g1l1, g1l2, g2l1, g2l2]` per key — and switching moves only the *active group*, which arrives in bits 13–14 of every key event's state field. No `MappingNotify` is sent, so the existing refresh had nothing to react to and could never have helped.

Decoding moves to `lib/keyboard.js` as a pure function. That is what makes it testable without a display: the whole bug is about state bits, not about anything a server does.

## Two things that fell out of doing it properly

**CapsLock no longer shifts the number row.** Shift-xor-lock on every key is what made CapsLock turn `1` into `!`. XKB encodes the real rule in the key's *type* — the alphabetic type folds Lock into the level, the two-level type used for digits does not. Unicode case mapping answers the same question without the XKB map, and answers it for Cyrillic and Greek as well as Latin. This is a behaviour change, so it has its own test.

**`keyup` decodes like `keydown`.** It carried no keysym at all before, so code comparing the two saw a character on one and nothing on the other.

## New event fields

```js
wnd.on('keydown', onKey);

function onKey(ev) {
  // Ctrl+Z, whatever layout is active
  if (ev.buttons & 4 && ev.baseKeysym === 0x7a) undo();
}
```

`ev.keysym`, `ev.group` and `ev.baseKeysym` join `ev.codepoint`. `baseKeysym` is the key's group-1 level-1 keysym and is what a shortcut should match — it keeps `Ctrl+Z` working while the user types Cyrillic, the way GTK, Qt and browsers resolve accelerators. Match on `ev.keysym` instead and every shortcut vanishes on a layout switch. `decodeKey` is exported for downstream renderers.

## Why AltGr is still not here

The issue lists level 3 as a follow-on in the same pass. It cannot be done from the core keyboard map, and this is worth stating so nobody tries.

Four keysyms on a key are **two groups of two levels** under `us,ru` and **one group of four levels** under `us(intl)`. `xmodmap -pke` prints them identically, and nothing in the core protocol distinguishes the two. The request that resolves it is `XkbGetMap`, and node-x11's xkb module says in its header comment that it is not implemented — *"The notoriously complex GetMap:8 (and Set\* siblings) are NOT implemented."*

So the choice was: read groups correctly, or guess. Guessing on `syms.length >= 4` would make every `us,ru` user type Cyrillic whenever they held AltGr — breaking the population this issue is about, to half-serve a different one. #116 stays open for the XKB half.

## Verification caveat

Written on macOS. XQuartz takes the other path entirely: it rewrites the keymap on a layout switch and fires `MappingNotify`, rather than using groups. So the payoff cannot be observed on this machine.

What the 16 tests do cover: the selection logic directly, and the wire path end to end with the group bits supplied by `SendEvent`, which is the only way to produce them here. What has **not** been observed is a real layout switch under Mutter or KWin. If you have a Linux box, `setxkbmap -layout us,ru -option grp:alt_shift_toggle` and typing into any example is the check.

Mutation-checked:

| mutation | caught by |
| --- | --- |
| ignore the group bits — the original bug | 6 tests |
| CapsLock applies to everything again | the number-row test |
| drop the empty-group fallback | the fallback test |
| `baseKeysym` follows the active group | 3 tests |

421 passing.
