### PR TITLE
fix: implement deleteProperty, which the docs already promised

### DIFF
--- a/lib/window.js
+++ b/lib/window.js
@@ -1956,6 +1956,27 @@ export default class Window extends Drawable {
   }
 
   /**
+   * Remove a property.
+   *
+   * Not the same as writing an empty value, and not at all the same as
+   * writing a zero: a deleted property reads back as type None — which is
+   * how "this client never declared that" is spelled — and a window manager
+   * watching gets a PropertyNotify with state Delete. `setTransientFor(null)`
+   * goes through here for exactly that reason; a `WM_TRANSIENT_FOR` of 0
+   * would name window None as the owner rather than saying there is none.
+   *
+   * @returns {Promise<Window>}
+   */
+  async deleteProperty(name) {
+    const atom = await this.atom(name);
+    if (this._destroyed) return this;
+    safeRelease(this.X, () => {
+      this.X.DeleteProperty(this.id, atom);
+    });
+    return this;
+  }
+
+  /**
    * Intern an atom by name. node-x11 caches them per connection, so asking
    * again for one already interned costs no round trip.
    * @returns {Promise<number>} the atom id

--- a/test/window-manager.test.js
+++ b/test/window-manager.test.js
@@ -227,6 +227,17 @@ test('setProperty round-trips through getProperty', async () => {
   assert.equal(raw.type, await window.atom('WINDOW'));
 });
 
+test('deleteProperty removes a property rather than emptying it', async () => {
+  const window = wm.createWindow({ width: 40, height: 30 });
+  await window.setProperty('_NET_WM_NAME', 'here');
+  assert.equal(await window.getProperty('_NET_WM_NAME', { as: 'string' }), 'here');
+
+  await window.deleteProperty('_NET_WM_NAME');
+  // type None, which is how "this client never declared that" is spelled —
+  // an empty write would leave the property present and readable
+  assert.equal(await window.getProperty('_NET_WM_NAME'), null);
+});
+
 test('close asks politely when the client opted in, kills it when it did not', async () => {
   const polite = client.createWindow({ width: 40, height: 30 });
   polite.setActions();


### PR DESCRIPTION
`docs/window.md` has listed `deleteProperty(name)` since #131 — in the methods table and again under the window-manager read/write section — and the method was never written. Following the docs gets you `TypeError: wnd.deleteProperty is not a function`.

Found while gathering evidence to close #19 and #31, both of which point at those docs as proof the API is there. Rather than delete the line, implement the four lines it describes.

Deleting a property is not the same as writing an empty value, and not at all the same as writing a zero: a deleted property reads back as **type None** — which is how "this client never declared that" is spelled — and a watching window manager gets a `PropertyNotify` with state Delete. `setTransientFor(null)` already went straight to `DeleteProperty` for exactly that reason, since a `WM_TRANSIENT_FOR` of 0 would name window None as the owner rather than saying there is no owner. This is the general form of something the file was already doing in one place.

One test, asserting the distinction that matters: after `deleteProperty`, `getProperty` resolves to `null` rather than to an empty value. 422 passing.