### PR TITLE
feat: setCursor('none'), a genuinely blank cursor

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -171,7 +171,8 @@ All return `this` unless noted.
 - `createWindow(params)` — child window (`parent` preset to this window)
 - `createPixmap(params)` — pixmap defaulting to this window's size, depth 32
 - `setCursor(nameOrShapeId)` — mouse cursor shown over the window (see
-  [Cursor](#cursor) below); `setCursor(null)` restores the parent's cursor
+  [Cursor](#cursor) below); `setCursor('none')` hides the pointer, while
+  `setCursor(null)` restores the parent's cursor — not the same thing
 - `focus(revertTo = 2)` — take the keyboard focus (X `SetInputFocus`);
   `revertTo` is 0 None / 1 PointerRoot / 2 Parent. A window manager may take
   focus back, so the authority is the `focus`/`blur` events, not the request
@@ -617,6 +618,7 @@ the window:
 ```js
 input.setCursor('text'); // I-beam over a text input
 button.setCursor('pointer'); // hand over a button or link
+kiosk.setCursor('none'); // pointer invisible over this window
 wnd.setCursor(null); // back to inheriting the parent's cursor
 ```
 
@@ -625,6 +627,17 @@ resolve to cursorfont.h glyph indices; a raw glyph index (any `XC_*`
 constant) is accepted too. Unknown names throw synchronously, listing the
 valid names. Created cursors are server-side resources, cached per
 connection on `app.cursors` and freed on `app.close()`.
+
+**`'none'` and `null` are not the same thing**, and the difference is the
+one people get wrong. `setCursor('none')` hides the pointer.
+`setCursor(null)` sets X cursor `None`, which means *inherit the parent's
+cursor* — for a top-level window that is the root window's, so the pointer
+stays on screen and merely stops being whatever this window asked for.
+
+`'none'` is the only name that is not a glyph: the cursor font has no glyph
+meaning "no cursor", so it is built from a 1×1 bitmap used as both source
+and mask. Mask bits that are 0 are not drawn, so an empty mask draws
+nothing. It is created once per connection and freed with the rest.
 
 | name | cursor font glyph |
 |---|---|
@@ -641,6 +654,7 @@ connection on `app.cursors` and freed on `app.close()`.
 | `grab` | `XC_hand1` (58) |
 | `help` | `XC_question_arrow` (92) |
 | `not-allowed` | `XC_X_cursor` (0) |
+| `none` | *no glyph* — an empty 1×1 mask, see above |
 
 `createWindow({ cursor })` still accepts a raw X cursor id at creation time;
 `app.cursors.get(name)` supplies one if you need it there:

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -24,9 +24,23 @@ export const cursorShapes = {
 };
 
 /**
+ * The invisible cursor, spelled as CSS spells it. It is a name but not a
+ * shape: the 'cursor' font has no glyph meaning "no cursor", so this one is
+ * built from an empty bitmap instead of looked up. Kept out of
+ * `cursorShapes` for exactly that reason — every value in there is a glyph
+ * index, and this has none.
+ */
+export const BLANK_CURSOR = 'none';
+
+/** Every name `setCursor` accepts, for the error message and for docs. */
+export const cursorNames = [...Object.keys(cursorShapes), BLANK_CURSOR];
+
+/**
  * Resolve a friendly cursor name (see `cursorShapes`) or a raw cursor-font
  * glyph index to the glyph index. Throws on unknown names so typos surface
- * immediately instead of silently keeping the old cursor.
+ * immediately instead of silently keeping the old cursor. `'none'` is a
+ * valid cursor name but not a glyph, so it never reaches here — see
+ * `CursorCache.get`.
  */
 export function resolveCursorShape(nameOrShape) {
   if (typeof nameOrShape === 'number') {
@@ -38,7 +52,7 @@ export function resolveCursorShape(nameOrShape) {
   const shape = cursorShapes[nameOrShape];
   if (shape === undefined) {
     throw new Error(
-      `unknown cursor name '${nameOrShape}' — valid names: ${Object.keys(cursorShapes).join(', ')}`
+      `unknown cursor name '${nameOrShape}' — valid names: ${cursorNames.join(', ')}`
     );
   }
   return shape;
@@ -56,10 +70,12 @@ export class CursorCache {
     this.X = app.X;
     this._font = 0; // the 'cursor' font, opened on first use
     this._byShape = new Map(); // glyph index -> cursor xid
+    this._blank = 0; // the invisible cursor, built on first use
   }
 
   /** cursor xid for a friendly name or raw glyph index, creating it on first use */
   get(nameOrShape) {
+    if (nameOrShape === BLANK_CURSOR) return this.blank();
     const shape = resolveCursorShape(nameOrShape);
     const cached = this._byShape.get(shape);
     if (cached) return cached;
@@ -79,6 +95,41 @@ export class CursorCache {
     return cid;
   }
 
+  /**
+   * The invisible cursor, created once per connection. Hiding the pointer is
+   * not the same thing as X's cursor None, which means *inherit the parent's*
+   * — for a top-level window that is the root's cursor, so the pointer stays
+   * on screen. A cursor whose mask is empty is the way to hide it: mask bits
+   * that are 0 are not drawn, so a 1x1 all-zero mask draws nothing at all.
+   */
+  blank() {
+    if (this._blank) return this._blank;
+    const X = this.X;
+    const pid = X.AllocID();
+    // depth 1 — CreateCursor takes bitmaps, not pixmaps of the window depth
+    X.CreatePixmap(pid, X.display.screen[0].root, 1, 1, 1);
+    // a freshly created pixmap's contents are *undefined* per the protocol,
+    // so it has to be cleared. Skipping this is how the recipe ends up
+    // hiding the cursor on one server and drawing a stray pixel on another
+    const gc = X.AllocID();
+    X.CreateGC(gc, pid, { foreground: 0 });
+    X.PolyFillRectangle(pid, gc, [0, 0, 1, 1]);
+    X.FreeGC(gc);
+    X.ReleaseID(gc);
+
+    const cid = X.AllocID();
+    const black = { R: 0, G: 0, B: 0 };
+    // source and mask are the same empty bitmap; the colours are immaterial
+    // when nothing is drawn, but the request needs them
+    X.CreateCursor(cid, pid, pid, black, black, 0, 0);
+    // the cursor keeps its own copy of the bitmaps, so the pixmap goes now
+    // rather than living as long as the connection
+    X.FreePixmap(pid);
+    X.ReleaseID(pid);
+    this._blank = cid;
+    return cid;
+  }
+
   /** free the server-side cursors (and the font); safe to call repeatedly */
   dispose() {
     const X = this.X;
@@ -89,6 +140,14 @@ export class CursorCache {
       });
     }
     this._byShape.clear();
+    if (this._blank) {
+      const cid = this._blank;
+      this._blank = 0;
+      safeRelease(X, () => {
+        X.FreeCursor(cid);
+        X.ReleaseID(cid);
+      });
+    }
     if (this._font) {
       const fid = this._font;
       this._font = 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ import x11 from 'x11';
 
 import App from './app.js';
 import Clipboard from './clipboard.js';
-import { CursorCache, cursorShapes, resolveCursorShape } from './cursor.js';
+import { BLANK_CURSOR, CursorCache, cursorNames, cursorShapes, resolveCursorShape } from './cursor.js';
 import Window from './window.js';
 import { decodeKey, groupForState } from './keyboard.js';
 import Pixmap from './pixmap.js';
@@ -111,7 +111,9 @@ export {
   App,
   Clipboard,
   Window,
+  BLANK_CURSOR,
   CursorCache,
+  cursorNames,
   cursorShapes,
   resolveCursorShape,
   Pixmap,

--- a/lib/window.js
+++ b/lib/window.js
@@ -1763,9 +1763,15 @@ export default class Window extends Drawable {
    * Set the mouse cursor shown over this window. Accepts a friendly name
    * ('text', 'pointer', 'wait', ... — see cursorShapes in lib/cursor.js and
    * docs/window.md) or a raw X11 cursor-font glyph index. Cursors are
-   * created once per connection and cached on the app. `setCursor(null)`
-   * restores the parent window's cursor (X cursor = None). Throws
-   * synchronously on unknown names.
+   * created once per connection and cached on the app. Throws synchronously
+   * on unknown names.
+   *
+   * Two things that sound alike and are not:
+   *
+   *   setCursor('none')  the pointer is invisible over this window
+   *   setCursor(null)    X cursor None — *inherit* the parent's cursor,
+   *                      which for a top-level window is the root's, so the
+   *                      pointer stays visible
    */
   setCursor(nameOrShape) {
     const cursor = nameOrShape == null ? 0 : this.app.cursors.get(nameOrShape);

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -86,11 +86,59 @@ test('setCursor(null) restores the parent cursor (None)', async () => {
   wnd.destroy();
 });
 
+// 'none' is the pointer being invisible; setCursor(null) is X cursor None,
+// which *inherits* the parent's cursor and leaves the pointer on screen.
+// The two get conflated because CSS spells the first one `cursor: none`.
+
+test("setCursor('none') hides the pointer with an empty-mask cursor", async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.setCursor('none');
+  const cid = app.cursors.get('none');
+  await roundtrip(app);
+
+  assert.equal(server.resources.get(wnd.id).cursor, cid, 'set on the window');
+  const cursor = server.resources.get(cid);
+  assert.equal(cursor.type, 'cursor');
+  assert.equal(cursor.sourceFont, undefined, 'not a cursor-font glyph cursor');
+  assert.equal(cursor.source, cursor.mask, 'one empty bitmap serves as both');
+  assert.deepEqual(cursor.fore, [0, 0, 0]);
+  assert.deepEqual(cursor.back, [0, 0, 0]);
+  wnd.destroy();
+});
+
+test("the bitmap behind 'none' is freed, not held for the connection", async () => {
+  const cid = app.cursors.get('none');
+  await roundtrip(app);
+  const { source } = server.resources.get(cid);
+  assert.equal(
+    server.resources.get(source),
+    undefined,
+    'the cursor keeps its own copy, so the pixmap goes straight back'
+  );
+});
+
+test("'none' is cached like any other cursor", async () => {
+  assert.equal(app.cursors.get('none'), app.cursors.get('none'), 'built once');
+  assert.notEqual(app.cursors.get('none'), app.cursors.get('default'));
+  await roundtrip(app);
+});
+
+test("setCursor(null) after 'none' brings the pointer back", async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.setCursor('none');
+  await roundtrip(app);
+  assert.notEqual(server.resources.get(wnd.id).cursor, 0, 'hidden');
+  wnd.setCursor(null);
+  await roundtrip(app);
+  assert.equal(server.resources.get(wnd.id).cursor, 0, 'inheriting again');
+  wnd.destroy();
+});
+
 test('unknown cursor names throw synchronously and list the valid names', () => {
   const wnd = app.createWindow({ width: 40, height: 30 });
   assert.throws(() => wnd.setCursor('sideways'), (err) => {
     assert.match(err.message, /unknown cursor name 'sideways'/);
-    for (const name of Object.keys(cursorShapes)) {
+    for (const name of [...Object.keys(cursorShapes), 'none']) {
       assert.ok(err.message.includes(name), `error lists '${name}'`);
     }
     return true;
@@ -101,6 +149,7 @@ test('unknown cursor names throw synchronously and list the valid names', () => 
 test('app.close() frees the cached cursors and the cursor font', async () => {
   const app2 = await connect();
   const cid = app2.cursors.get('move');
+  const blank = app2.cursors.get('none');
   await roundtrip(app2);
   const fontId = server.resources.get(cid).sourceFont;
   assert.ok(server.resources.get(fontId), 'font resource exists while cached');
@@ -110,6 +159,7 @@ test('app.close() frees the cached cursors and the cursor font', async () => {
   app2.cursors.dispose();
   await roundtrip(app2);
   assert.equal(server.resources.get(cid), undefined, 'cursor freed');
+  assert.equal(server.resources.get(blank), undefined, 'blank cursor freed too');
   assert.equal(server.resources.get(fontId), undefined, 'font closed');
   await app2.close();
 });


### PR DESCRIPTION
Closes #135.

## What was wrong

There was no way to hide the pointer. `setCursor(null)` sets X cursor `None`, which means **inherit the parent's cursor** — for a top-level window that is the root window's, so the pointer stays on screen and merely stops being whatever this window asked for. Asking for the spelling everyone reaches for first, `setCursor('none')`, threw `unknown cursor name 'none'`.

`CursorCache` only knew how to make glyph cursors out of the standard `cursor` font, and that font has no glyph meaning "no cursor".

## What it does now

```js
kiosk.setCursor('none'); // the pointer is invisible over this window
wnd.setCursor(null);     // unchanged: inherit the parent's cursor
```

`'none'` is the one name that is not a shape, so it is built rather than looked up: a 1×1 depth-1 bitmap used as both source and mask. Mask bits that are 0 are not drawn, so an empty mask draws nothing.

Two details that are easy to get wrong and are the reason this is more than three lines:

- **The bitmap is cleared before use.** A freshly created pixmap's contents are *undefined* per the protocol. Skipping the clear is how this recipe hides the cursor on the server you tested against and draws a stray pixel on the next one.
- **The pixmap is freed immediately.** `CreateCursor` keeps its own copy, so holding it for the life of the connection is a leak with no purpose.

The cursor is cached per connection beside the glyph cursors and freed with them in `dispose()`.

`cursorNames` joins the exports because the valid-names list is no longer just the keys of `cursorShapes` — the error message for a typo now has to include a name that has no shape.

## No screenshot

The change is visible by definition, and by definition not capturable: X does not composite the pointer into window contents, so `GetImage` readback — the recipe AGENTS.md prescribes — cannot show a cursor whether it is there or not. The server-side assertions below are the substitute: they check the exact resource the window points at.

## Test plan

`npm test` — 426 pass, 4 new in `test/cursor.test.js`, all hermetic against node-x11's in-process X server and asserted through its resource table:

- `setCursor('none')` puts a cursor on the window that has **no** `sourceFont` — i.e. not a glyph cursor — and whose source and mask are the same bitmap.
- the pixmap behind it is gone by the time the cursor exists, so nothing leaks.
- `'none'` is cached like any other cursor and is distinct from `default`.
- `setCursor(null)` after `'none'` puts the attribute back to `0`, which is the distinction this PR is about.

Two existing tests were extended: the valid-names error now has to list `none`, and `dispose()` has to free the blank cursor along with the glyph ones.
