### PR TITLE
feat: Window.scrollRegion — server-side scroll of the backing store

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -83,6 +83,29 @@ automatically (opt out with `createWindow({ backingStore: false })`):
 Foreign windows (`{ id }`) and windows drawing via the `'opengl'` or
 `'x11'` contexts are not double-buffered.
 
+### `wnd.scrollRegion(rect, dx, dy)` → boolean
+
+Scroll the pixels of `rect` (`{x, y, width, height}`, window coordinates)
+by `(dx, dy)` **within the backing store**, server-side — one `CopyArea` of
+the band that survives the shift, instead of the caller re-drawing content
+that merely moved. This is the fast half of a scrolling viewport: blit the
+surviving band, then draw only the strip the shift exposed (plus chrome
+that moved with the content, e.g. a scrollbar thumb). The whole `rect` is
+marked dirty, so the next present shows the scrolled band on the window
+through the normal fence-aware path.
+
+Returns `false` — having done nothing, so the caller just repaints `rect`
+as it would have anyway — when the window has no valid backing store, when
+`dx`/`dy` are fractional (a sub-pixel shift changes every pixel) or both
+zero, or when nothing of `rect` survives the shift after clamping to
+window ∩ backing.
+
+Overlap is safe (the server fetches the source region before storing), the
+copy cannot generate `GraphicsExpose` (pixmap contents are never occluded —
+the reason this operates on the backing store, not the window), and the
+copy is issued in-order with whatever the caller draws next on the same
+connection.
+
 ## Frames, coalescing and slow connections
 
 Some X events are noisy by nature: an interactive resize is a stream of

--- a/lib/window.js
+++ b/lib/window.js
@@ -693,6 +693,66 @@ export default class Window extends Drawable {
     });
   }
 
+  /**
+   * Scroll the pixels of `rect` (window coordinates, `{x, y, width, height}`)
+   * by (dx, dy) within the retained backing store, server-side: one CopyArea
+   * of the band that survives the shift, in place of the caller re-drawing
+   * everything that merely moved. Returns true when the blit was issued;
+   * false means "not possible here", and the caller repaints `rect` exactly
+   * as it would have without this method — every refusal is the status quo.
+   *
+   * Refused when there is no (valid) backing store, when the delta is
+   * fractional (a sub-pixel shift changes every pixel, so there is nothing
+   * to copy), when it is zero, or when nothing of `rect` survives the shift
+   * after clamping to window ∩ backing.
+   *
+   * Backing-store only, deliberately: pixmap contents cannot be occluded, so
+   * an overlapping self-copy is fully defined (the server fetches the source
+   * region before storing) and the GraphicsExpose handling a window-drawable
+   * scroll would need never exists. The copy goes out with the present GC —
+   * graphicsExposures: 0, where the 2d context's GC would emit a NoExposure
+   * packet per copy — and in-order with the caller's follow-up drawing of
+   * the exposed strip on the same connection.
+   *
+   * The whole of `rect` is marked dirty, so the next present shows the
+   * scrolled band through the normal fence-aware path; the caller only has
+   * to draw the strip the shift exposed, plus any chrome that moved with
+   * the content (a scrollbar thumb, say).
+   */
+  scrollRegion(rect, dx, dy) {
+    if (!this._backing || !this._backingValid) return false;
+    if (!Number.isInteger(dx) || !Number.isInteger(dy) || (dx === 0 && dy === 0)) return false;
+    // clamp like a present: the backing is grow-only, so it can be larger
+    // than the window after a shrink
+    const w = Math.min(this.width, this._backing.width);
+    const h = Math.min(this.height, this._backing.height);
+    const x0 = Math.max(0, Math.floor(rect.x));
+    const y0 = Math.max(0, Math.floor(rect.y));
+    const x1 = Math.min(w, Math.ceil(rect.x + rect.width));
+    const y1 = Math.min(h, Math.ceil(rect.y + rect.height));
+    // the band that survives: dest = clamped rect ∩ (clamped rect + delta)
+    const dstX0 = Math.max(x0, x0 + dx);
+    const dstY0 = Math.max(y0, y0 + dy);
+    const dstX1 = Math.min(x1, x1 + dx);
+    const dstY1 = Math.min(y1, y1 + dy);
+    if (dstX1 <= dstX0 || dstY1 <= dstY0) return false;
+    safeRelease(this.X, () => {
+      this.X.CopyArea(
+        this._backing.id,
+        this._backing.id,
+        this._presentGc,
+        dstX0 - dx,
+        dstY0 - dy,
+        dstX0,
+        dstY0,
+        dstX1 - dstX0,
+        dstY1 - dstY0
+      );
+    });
+    this._markDirty({ x: x0, y: y0, w: x1 - x0, h: y1 - y0 });
+    return true;
+  }
+
   /*
    * Frame clock. Noisy events (see events_map coalesce), synthetic redraws
    * and requestAnimationFrame callbacks are delivered in "frames", paced by

--- a/test/scroll-region.test.js
+++ b/test/scroll-region.test.js
@@ -1,0 +1,191 @@
+// Window.scrollRegion (sidorares/ntk#138): server-side scroll of the
+// backing store. Two halves: request arithmetic against a mock X client
+// (the frame-pacing pattern), and pixel truth against the in-process X
+// server — the blitted band moves exactly, the exposed strip is untouched.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import Window from '../lib/window.js';
+import { createClient } from '../lib/index.js';
+
+let nextId = 0xa000;
+
+function makeMockApp() {
+  const calls = { copies: [] };
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea(src, dst, gc, sx, sy, dx, dy, width, height) {
+      calls.copies.push({ src, dst, gc, sx, sy, dx, dy, width, height });
+    },
+    GetInputFocus() {}
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display }, calls };
+}
+
+function backedWindow() {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  // stand in for what getContext('2d') normally allocates
+  wnd._backing = { id: 0xb000, width: 200, height: 100 };
+  wnd._presentGc = 0xc000;
+  wnd._backingValid = true;
+  return { wnd, calls };
+}
+
+test('scrolling up copies the surviving band in place and presents the region', async () => {
+  const { wnd, calls } = backedWindow();
+  const ok = wnd.scrollRegion({ x: 10, y: 10, width: 100, height: 80 }, 0, -20);
+  assert.equal(ok, true);
+
+  // the self-copy: rows 30..90 land on rows 10..70, backing -> backing,
+  // with the graphicsExposures:0 present GC
+  assert.equal(calls.copies.length, 1);
+  assert.deepEqual(calls.copies[0], {
+    src: 0xb000,
+    dst: 0xb000,
+    gc: 0xc000,
+    sx: 10,
+    sy: 30,
+    dx: 10,
+    dy: 10,
+    width: 100,
+    height: 60
+  });
+
+  // the present that follows covers the whole scrolled region, so the shift
+  // reaches the window without the caller re-drawing the band
+  await tick();
+  assert.equal(calls.copies.length, 2);
+  assert.deepEqual(calls.copies[1], {
+    src: 0xb000,
+    dst: wnd.id,
+    gc: 0xc000,
+    sx: 10,
+    sy: 10,
+    dx: 10,
+    dy: 10,
+    width: 100,
+    height: 80
+  });
+});
+
+test('a two-axis shift copies one rectangle, shifted both ways', () => {
+  const { wnd, calls } = backedWindow();
+  assert.equal(wnd.scrollRegion({ x: 0, y: 0, width: 200, height: 100 }, 30, -20), true);
+  assert.deepEqual(calls.copies[0], {
+    src: 0xb000,
+    dst: 0xb000,
+    gc: 0xc000,
+    sx: 0,
+    sy: 20,
+    dx: 30,
+    dy: 0,
+    width: 170,
+    height: 80
+  });
+});
+
+test('the region is clamped to window ∩ backing before the shift', () => {
+  const { wnd, calls } = backedWindow();
+  // backing can be larger than the window after a shrink; the window wins
+  wnd._backing.width = 400;
+  wnd._backing.height = 300;
+  assert.equal(wnd.scrollRegion({ x: -50, y: -50, width: 1000, height: 1000 }, 0, -10), true);
+  assert.deepEqual(calls.copies[0], {
+    src: 0xb000,
+    dst: 0xb000,
+    gc: 0xc000,
+    sx: 0,
+    sy: 10,
+    dx: 0,
+    dy: 0,
+    width: 200,
+    height: 90
+  });
+});
+
+test('refusals: no backing, invalid backing, fractional, zero, nothing survives', () => {
+  const { app } = makeMockApp();
+  const bare = new Window(app, { width: 200, height: 100 });
+  assert.equal(bare.scrollRegion({ x: 0, y: 0, width: 100, height: 100 }, 0, -10), false);
+
+  const { wnd, calls } = backedWindow();
+  wnd._backingValid = false; // resized, nothing painted yet
+  assert.equal(wnd.scrollRegion({ x: 0, y: 0, width: 100, height: 100 }, 0, -10), false);
+  wnd._backingValid = true;
+  assert.equal(wnd.scrollRegion({ x: 0, y: 0, width: 100, height: 100 }, 0, -10.5), false);
+  assert.equal(wnd.scrollRegion({ x: 0, y: 0, width: 100, height: 100 }, 0, 0), false);
+  assert.equal(wnd.scrollRegion({ x: 0, y: 0, width: 100, height: 100 }, 0, -100), false);
+  assert.equal(wnd.scrollRegion({ x: 0, y: 0, width: 100, height: 100 }, 120, 0), false);
+  assert.equal(calls.copies.length, 0, 'every refusal is request-free');
+});
+
+// --- pixel truth against the in-process X server -------------------------
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) => (err ? reject(err) : resolve(data)))
+  );
+
+// BGRA readback -> [r, g, b]
+const px = (image, w, x, y) => {
+  const i = (y * w + x) * 4;
+  return [image.data[i + 2], image.data[i + 1], image.data[i]];
+};
+
+test('pixels: the band lands shifted exactly, the exposed strip is untouched', async () => {
+  const server = xserver.createServer({ width: 320, height: 240 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const app = await createClient({ stream: clientEnd });
+  try {
+    const wnd = app.createWindow({ width: 320, height: 240 });
+    wnd.map();
+    const ctx = wnd.getContext('2d');
+    // three 20px bands inside the region that will scroll
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, 320, 240);
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(0, 40, 320, 20);
+    ctx.fillStyle = '#00ff00';
+    ctx.fillRect(0, 60, 320, 20);
+    ctx.fillStyle = '#0000ff';
+    ctx.fillRect(0, 80, 320, 20);
+    await new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+    assert.equal(wnd.scrollRegion({ x: 0, y: 20, width: 320, height: 120 }, 0, -20), true);
+    await tick();
+    await new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+    const image = await readPixels(ctx, 320, 240);
+    // the bands moved up by 20
+    assert.deepEqual(px(image, 320, 160, 30), [255, 0, 0]);
+    assert.deepEqual(px(image, 320, 160, 50), [0, 255, 0]);
+    assert.deepEqual(px(image, 320, 160, 70), [0, 0, 255]);
+    // the exposed strip (bottom 20 rows of the region) still holds its old
+    // pixels — the blit does not invent content, the caller draws it
+    assert.deepEqual(px(image, 320, 160, 130), [255, 255, 255]);
+    // outside the region nothing moved
+    assert.deepEqual(px(image, 320, 160, 10), [255, 255, 255]);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Closes #138. The mechanism half of scroll-blitting; the policy half (deciding *when* a frame is a pure scroll) is sidorares/react-x11#138.

## What

```js
const ok = wnd.scrollRegion({ x, y, width, height }, dx, dy); // boolean
```

One self-`CopyArea` of the band of `rect` that survives the shift, inside the backing pixmap, then `_markDirty(rect)` so the next present shows the scrolled band on the window through the normal fence-aware path. The caller draws only the exposed strip (and chrome that moved, e.g. a scrollbar thumb).

Returns `false` — having issued nothing, so the caller just repaints as it would have anyway — when there is no valid backing store, the delta is fractional or zero, or nothing survives the clamp to window ∩ backing. Every refusal is the status quo.

## Why the backing store, not the window

Pixmap contents cannot be occluded: an overlapping self-copy is fully defined (the server fetches the source first) and the `GraphicsExpose` handling a window-drawable scroll would need never exists — node-x11 routes GraphicsExposure only to the global event stream (`xcore.js` keys per-window routing on `wid`, the event carries `drawable`) and `events_map.js` drops it anyway. Double buffering makes the classic hard part of scroll-blitting not exist here.

The copy uses `_presentGc` (`graphicsExposures: 0`); the 2d context's GC would emit a NoExposure packet per copy.

## Numbers motivating it

react-x11, 500-row list, 400×400 window, in-process server: **89 requests / 0.33 Mpx of Composite work per wheel notch** today — >2× the window's area re-composited per notch to move pixels the server already has. With the blit the content work is bounded by the 48px exposed strip (~12% of the viewport) plus one `CopyArea`.

## Tests

`test/scroll-region.test.js`:
- mock-client (frame-pacing pattern): exact src/dst arithmetic for one- and two-axis shifts, backing→backing with the present GC, the follow-up present covering the whole region, clamping to window ∩ backing, and all refusal cases request-free
- in-process X server, pixel readback: three colour bands scrolled up 20px land shifted exactly, the exposed strip keeps its old pixels (the blit invents nothing), content outside the region does not move

`npm test` 431/431. Docs: `docs/window.md` under Double buffering.
