### PR TITLE
feat!: load the layout engine without top-level await

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,5 +34,7 @@ matching file here (see AGENTS.md).
 - [OpenGL rendering context](context-opengl.md) — indirect GLX / OpenGL 1.4 API
 - [Raw X11 rendering context](context-x11.md) — core X drawing requests
 - [Resource management](resource-management.md) — `using` / `Symbol.dispose`, GC-based cleanup
+- [Packaging](packaging.md) — bundling to one file, and shipping a single
+  executable (what has to stay out of the module graph for that to work)
 - [Headless X server](xserver.md) — run ntk against node-x11's pure-JS X
   server (XRender built in since x11 3.1.0) — no DISPLAY needed

--- a/docs/html.md
+++ b/docs/html.md
@@ -36,10 +36,31 @@ parsing [postcss](https://www.npmjs.com/package/postcss). PNG/JPEG images
 render through the [image pipeline](images.md); SVG — inline or as an
 `<img>` source — through the [SVG widget](svg.md).
 
-The yoga-layout instance ntk uses is re-exported as `Yoga`
-(`import { Yoga } from 'ntk'`) so downstream layout consumers — e.g. the
-react-x11 renderer — share the same WASM module and enum values instead of
-loading a second, possibly version-mismatched copy.
+The layout engine ntk uses is exported as `Yoga` (`import { Yoga } from
+'ntk'`) so downstream layout consumers — e.g. the react-x11 renderer — share
+the same WASM instance and enum values instead of loading a second, possibly
+version-mismatched copy. Import it from `ntk`, not from `yoga-layout`: the
+package's default entry builds its own instance, and nodes from two
+instances cannot be mixed.
+
+Its enum constants (`Yoga.FLEX_DIRECTION_ROW`, …) are readable as soon as
+ntk is imported, so a module-level lookup table works. `Yoga.Node` and
+`Yoga.Config` need the WebAssembly, which `createClient()` loads — a widget
+used **without** an App must load it first:
+
+```js
+import { HtmlView, loadLayout } from 'ntk';
+
+await loadLayout();                       // createClient() does this for you
+const view = new HtmlView(null, { fonts });
+view.setHtml('<p>headless layout</p>');
+view.layout(400);
+```
+
+Using `Yoga.Node` before that throws a message saying so. `layoutLoaded()`
+reports whether it is in place. This split is what keeps ntk out of
+top-level await, which is what makes a CommonJS bundle — and therefore a
+single-file executable — possible; see [packaging.md](packaging.md).
 
 The value parsers the CSS layer is built on are exported for the same
 reason: `cssColor(value)` → **premultiplied** `[r, g, b, a]` floats 0..1,

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,69 @@
+# Packaging an ntk app
+
+ntk is pure JavaScript and WebAssembly — no node-gyp, no prebuild matrix — so
+`npm install` on a fresh box just works. This page is about the other two
+ways to ship: one bundled file, and one executable file.
+
+## A single `.mjs`
+
+```sh
+esbuild app.js --bundle --platform=node --format=esm --outfile=app.mjs \
+  --banner:js="import{createRequire as __cjsRequire}from'node:module';const require=__cjsRequire(import.meta.url);"
+
+node app.mjs
+```
+
+The banner is needed because node-x11 is CommonJS and calls `require()` from
+inside functions; esbuild turns those into a shim that needs a real `require`
+to exist. Alias the import — `createRequire` collides with the same import in
+some consumers, react-x11 among them.
+
+## A single executable
+
+Node's [single executable applications](https://nodejs.org/api/single-executable-applications.html)
+embed a script in a copy of the node binary. The embedded main is evaluated
+as **CommonJS**, so the bundle must be CommonJS too:
+
+```sh
+esbuild app.js --bundle --platform=node --format=cjs --outfile=app.cjs
+node --build-sea=sea-config.json          # { "main": "app.cjs", "output": "app" }
+./app
+```
+
+Two rules follow from "the main is CommonJS":
+
+- **No top-level `await` anywhere in the graph.** esbuild refuses to emit
+  CommonJS for a graph that has one, and the diagnostic names the file. Put
+  your own startup in an `async function main()` rather than awaiting at
+  module scope — `await createClient()` at the top level of your entry is
+  enough to block the build.
+- **`import.meta.url` is `undefined`** in a CommonJS bundle, so anything
+  resolving paths through it (a `createRequire(import.meta.url)` of your own,
+  for instance) has to use `process.execPath` or a literal path instead.
+
+Inside a SEA, `require()` and `import()` resolve **built-in modules only** —
+a `data:` or `file:` URL import fails with `ERR_UNKNOWN_BUILTIN_MODULE`. That
+is fine for a bundle, which has nothing left to resolve, but it rules out
+loading anything at runtime.
+
+ntk itself is built for this: nothing in `lib/` uses top-level await, and
+`test/packaging.test.js` keeps it that way. The one thing that would take it
+away is importing `yoga-layout`'s default entry — it is
+`const Yoga = wrapAssembly(await loadYoga())` — which is why ntk loads the
+layout engine through `yoga-layout/load` and exposes it as
+[`Yoga`/`loadLayout()`](html.md). Verified end to end: a bundle with ntk,
+node-x11's client *and* its pure-JS X server runs as one file, drawing
+through XRender and laying out an `HtmlView`.
+
+The binary is large (~140 MB): most of it is node itself.
+
+## What to ship beside it
+
+- A **`.desktop`** file whose `StartupWMClass` matches the window's
+  `wmClass`, or the desktop groups your windows under the wrong icon
+  ([window.md](window.md#application-identity--setclassinstance-class--wmclass)).
+- **Icons** under `usr/share/icons/hicolor/<size>/apps/`.
+- **Fonts**, if the target may not have fontconfig: `StaticFontSource` takes
+  font bytes directly and needs no `fc-match`
+  ([fonts.md](fonts.md#pluggable-font-sources)). Bundling the faces you draw
+  with also makes rendering identical across machines.

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ import App from './app.js';
 import Clipboard from './clipboard.js';
 import { BLANK_CURSOR, CursorCache, cursorNames, cursorShapes, resolveCursorShape } from './cursor.js';
 import Window from './window.js';
+import { loadLayout } from './yoga.js';
 import { decodeKey, groupForState } from './keyboard.js';
 import Pixmap from './pixmap.js';
 import Picture from './picture.js';
@@ -71,7 +72,11 @@ export function createClient(options, callback) {
   const x11Options = { ...(options || {}) };
   if (x11Options.bufferRequests === undefined) x11Options.bufferRequests = DEFAULT_BUFFER_REQUESTS;
 
-  const promise = new Promise((resolve, reject) => {
+  // the layout engine's WASM loads alongside the connection, so widgets are
+  // usable synchronously by the time the App exists (see lib/yoga.js)
+  const layout = loadLayout();
+
+  const connecting = new Promise((resolve, reject) => {
     x11.createClient(x11Options, (error, display) => {
       if (error) return reject(error);
 
@@ -112,6 +117,8 @@ export function createClient(options, callback) {
       });
     });
   });
+
+  const promise = Promise.all([connecting, layout]).then(([app]) => app);
 
   if (callback) {
     promise.then(
@@ -160,8 +167,11 @@ export {
   decodeKey,
   groupForState
 };
-// the yoga-layout instance ntk lays HtmlView out with — downstream layout
-// consumers (e.g. the react-x11 renderer) must share it to avoid loading a
-// second WASM copy with potentially mismatched enums
-export { default as Yoga } from 'yoga-layout';
+// The layout engine ntk lays HtmlView out with — downstream layout consumers
+// (e.g. the react-x11 renderer) must import it from here rather than from
+// `yoga-layout`, or they get a second WASM instance whose Nodes cannot be
+// mixed with ntk's. Its enum constants are readable as soon as ntk is
+// imported; `Node`/`Config` need the WASM, which `createClient()` loads —
+// `loadLayout()` is there for widgets used without an App.
+export { default as Yoga, loadLayout, layoutLoaded } from './yoga.js';
 export default { createClient };

--- a/lib/widgets/htmlview.js
+++ b/lib/widgets/htmlview.js
@@ -1,7 +1,7 @@
 import { selectAll } from 'css-select';
 import { textContent } from 'domutils';
 import { parseDocument } from 'htmlparser2';
-import Yoga from 'yoga-layout';
+import Yoga from '../yoga.js';
 
 import { decodeImage, Image } from '../image.js';
 import { TextLayout } from '../text/layout.js';

--- a/lib/yoga.js
+++ b/lib/yoga.js
@@ -1,0 +1,119 @@
+// The layout engine, without a top-level await.
+//
+// `yoga-layout`'s default entry is `const Yoga = wrapAssembly(await
+// loadYoga())`. That one `await` is contagious: every bundle containing ntk
+// inherits it, esbuild then refuses to emit CommonJS ("Top-level await is
+// currently not supported with the cjs output format"), and Node's single
+// executable format runs its embedded main as CommonJS — so an ntk app could
+// not be shipped as one binary at all.
+//
+// So ntk imports the half of the package that has no WASM in it —
+// `yoga-layout/load` exports the enums as plain JavaScript and the assembly
+// behind an async function — and loads the assembly during `createClient()`,
+// which is already asynchronous.
+//
+// The object exported here keeps yoga's own shape, and that is the point:
+// the flat SCREAMING_CASE constants are present from the first tick, so a
+// consumer that builds a lookup table at module scope (ntk's own HtmlView,
+// react-x11's styles.js) still reads them at import time. `Node`, `Config`
+// and the rest of the assembly appear when `loadLayout()` resolves.
+
+import {
+  loadYoga,
+  Align,
+  BoxSizing,
+  Dimension,
+  Direction,
+  Display,
+  Edge,
+  Errata,
+  ExperimentalFeature,
+  FlexDirection,
+  Gutter,
+  Justify,
+  LogLevel,
+  MeasureMode,
+  NodeType,
+  Overflow,
+  PositionType,
+  Unit,
+  Wrap
+} from 'yoga-layout/load';
+
+const ENUMS = {
+  Align,
+  BoxSizing,
+  Dimension,
+  Direction,
+  Display,
+  Edge,
+  Errata,
+  ExperimentalFeature,
+  FlexDirection,
+  Gutter,
+  Justify,
+  LogLevel,
+  MeasureMode,
+  NodeType,
+  Overflow,
+  PositionType,
+  Unit,
+  Wrap
+};
+
+// yoga's generator names each constant <ENUM>_<MEMBER>, both snake-cased from
+// PascalCase: FlexDirection.ColumnReverse -> FLEX_DIRECTION_COLUMN_REVERSE.
+// yoga-export.test.js pins every name against the real assembly, so a rename
+// upstream fails loudly instead of yielding an undefined constant.
+const screamingSnake = (name) => name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toUpperCase();
+
+/** The layout engine: enums now, assembly after `loadLayout()`. */
+const Yoga = {};
+for (const [enumName, members] of Object.entries(ENUMS)) {
+  // a bundler may stub yoga out entirely — the browser playground does,
+  // since no demo uses HtmlView — and importing ntk must still work
+  if (!members || typeof members !== 'object') continue;
+  const prefix = screamingSnake(enumName);
+  for (const [member, value] of Object.entries(members)) {
+    if (typeof value === 'number') Yoga[`${prefix}_${screamingSnake(member)}`] = value;
+  }
+}
+
+const notLoaded = (what) => () => {
+  throw new Error(
+    `ntk: the layout engine is not loaded, so Yoga.${what} is not available yet. ` +
+      'createClient() loads it; widgets used without an App need `await loadLayout()` first.'
+  );
+};
+
+// A useful message instead of "Cannot read properties of undefined"
+for (const name of ['Node', 'Config']) {
+  Object.defineProperty(Yoga, name, { configurable: true, get: notLoaded(name) });
+}
+
+let loading = null;
+
+/**
+ * Load the layout engine's WebAssembly. Idempotent, and resolves with the
+ * same `Yoga` object this module exports — `createClient()` awaits it, so
+ * applications rarely call it themselves. Widgets used without an App
+ * (`new HtmlView(null, …)`) need it.
+ */
+export function loadLayout() {
+  if (!loading) {
+    loading = loadYoga().then((assembly) => {
+      for (const name of ['Node', 'Config']) delete Yoga[name]; // drop the throwing getters
+      Object.assign(Yoga, assembly);
+      return Yoga;
+    });
+  }
+  return loading;
+}
+
+/** Whether the assembly is in place — layout will not throw. */
+export function layoutLoaded() {
+  return Object.getOwnPropertyDescriptor(Yoga, 'Node')?.value !== undefined;
+}
+
+export { Yoga };
+export default Yoga;

--- a/test/htmlview.test.js
+++ b/test/htmlview.test.js
@@ -2,11 +2,16 @@
 // server; needs fontconfig for text measurement).
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { test } from 'node:test';
+import { before, test } from 'node:test';
 
 import FontManager from '../lib/text/fontmanager.js';
 import HtmlView from '../lib/widgets/htmlview.js';
+import { loadLayout } from '../lib/yoga.js';
 import { invalidation } from './helpers/async.js';
+
+// HtmlView lays out with yoga's WebAssembly. createClient() loads it for an
+// application; these tests have no App, so they load it themselves.
+before(() => loadLayout());
 
 let hasFontconfig = true;
 try {

--- a/test/packaging.test.js
+++ b/test/packaging.test.js
@@ -1,0 +1,44 @@
+// ntk must stay bundleable as CommonJS.
+//
+// Node's single-executable format runs its embedded main as CommonJS, and
+// esbuild refuses to emit CommonJS for a module graph containing top-level
+// await ("Top-level await is currently not supported with the cjs output
+// format"). One import can take that away from every ntk app: `yoga-layout`'s
+// default entry is `const Yoga = wrapAssembly(await loadYoga())`. lib/yoga.js
+// exists to keep it out of the graph — see docs/packaging.md.
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const libDir = join(dirname(dirname(fileURLToPath(import.meta.url))), 'lib');
+
+function sources(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) out.push(...sources(path));
+    else if (name.endsWith('.js')) out.push(path);
+  }
+  return out;
+}
+
+test('nothing in lib/ imports the top-level-await yoga entry', () => {
+  const offenders = sources(libDir)
+    .filter((path) => /from\s+['"]yoga-layout['"]|import\(['"]yoga-layout['"]\)/.test(readFileSync(path, 'utf8')))
+    .map((path) => path.slice(libDir.length + 1));
+  assert.deepEqual(
+    offenders,
+    [],
+    `import from 'yoga-layout/load' instead — the default entry is a top-level await, ` +
+      `which makes every bundle containing ntk ESM-only`
+  );
+});
+
+test('importing ntk does not load the layout WebAssembly', async () => {
+  // startup cost aside, this is what keeps the graph free of top-level await:
+  // the assembly is fetched by createClient(), not by module evaluation
+  const { layoutLoaded } = await import('../lib/index.js');
+  assert.equal(layoutLoaded(), false);
+});

--- a/test/yoga-export.test.js
+++ b/test/yoga-export.test.js
@@ -1,14 +1,44 @@
-// ntk re-exports its yoga-layout instance so downstream layout consumers
-// (e.g. the react-x11 renderer) share one WASM module and one set of enums.
+// ntk exports its layout engine so downstream layout consumers (e.g. the
+// react-x11 renderer) share one WASM instance and one set of enums.
+//
+// The engine is not the `yoga-layout` default entry: that entry is a
+// top-level await, which makes every bundle containing ntk ESM-only and so
+// rules out Node's single-executable format. ntk builds the same object from
+// `yoga-layout/load` instead — enums synchronously, assembly on demand — so
+// these tests check both halves of that shape.
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import YogaDirect from 'yoga-layout';
+import { loadYoga } from 'yoga-layout/load';
 
-import { Yoga } from '../lib/index.js';
+import { Yoga, loadLayout, layoutLoaded } from '../lib/index.js';
+import YogaFromModule from '../lib/yoga.js';
 
-test('Yoga is re-exported and functional', () => {
-  assert.ok(Yoga, 'Yoga export present');
+test('enum constants are readable without loading anything', () => {
+  // module-scope lookup tables (ntk's HtmlView, react-x11's styles.js) are
+  // built at import time and must not have to await first
+  assert.equal(typeof Yoga.FLEX_DIRECTION_ROW, 'number');
+  assert.equal(typeof Yoga.JUSTIFY_SPACE_EVENLY, 'number');
+  assert.equal(typeof Yoga.ALIGN_BASELINE, 'number');
+  assert.equal(typeof Yoga.EDGE_TOP, 'number');
+  assert.equal(typeof Yoga.DIRECTION_LTR, 'number');
+  assert.equal(typeof Yoga.MEASURE_MODE_UNDEFINED, 'number');
+  assert.equal(typeof Yoga.WRAP_NO_WRAP, 'number');
+});
+
+test('using the assembly before it is loaded says so', async () => {
+  // a fresh module instance, because the rest of this file loads the engine
+  const fresh = await import('../lib/yoga.js?before-load');
+  assert.equal(fresh.layoutLoaded(), false);
+  assert.throws(() => fresh.default.Node.create(), /layout engine is not loaded/);
+});
+
+test('loadLayout() makes it functional, and is idempotent', async () => {
+  const loaded = await loadLayout();
+  assert.equal(loaded, Yoga, 'resolves with the object it filled in');
+  assert.equal(await loadLayout(), Yoga, 'a second call is the same instance');
+  assert.equal(layoutLoaded(), true);
+
   const node = Yoga.Node.create();
   node.setWidth(100);
   node.calculateLayout(100, 100, Yoga.DIRECTION_LTR);
@@ -16,9 +46,17 @@ test('Yoga is re-exported and functional', () => {
   node.free();
 });
 
-test('Yoga is the same instance htmlview uses', () => {
-  // htmlview.js does `import Yoga from 'yoga-layout'` — module resolution
-  // guarantees identity as long as both import the same specifier from the
-  // same package instance
-  assert.equal(Yoga, YogaDirect, 'single shared yoga-layout module');
+test('the exported engine is the one the widgets lay out with', () => {
+  assert.equal(Yoga, YogaFromModule, 'one instance for ntk and its consumers');
+});
+
+test('every constant ntk generates matches the assembly', async () => {
+  // ntk derives the flat SCREAMING_CASE names from yoga's typed enums; this
+  // pins them against yoga's own, so a rename upstream fails here rather
+  // than silently yielding `undefined` in a layout lookup table
+  await loadLayout();
+  const real = await loadYoga();
+  const names = Object.keys(real).filter((k) => /^[A-Z][A-Z0-9_]*$/.test(k));
+  assert.ok(names.length > 50, `expected yoga's constants, found ${names.length}`);
+  for (const name of names) assert.equal(Yoga[name], real[name], `constant ${name}`);
 });

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -93,7 +93,9 @@ await esbuild.build({
     util: path.join(shimsDir, 'util.js'),
     'node:util': path.join(shimsDir, 'util.js'),
     // heavy optional deps no playground demo needs
+    // both entries: ntk imports the WASM-free 'yoga-layout/load'
     'yoga-layout': path.join(stubsDir, 'yoga-layout.js'),
+    'yoga-layout/load': path.join(stubsDir, 'yoga-layout.js'),
     pngjs: path.join(stubsDir, 'pngjs.js'),
   },
 });

--- a/website/scripts/stubs/yoga-layout.js
+++ b/website/scripts/stubs/yoga-layout.js
@@ -1,3 +1,3 @@
-// Inert stub: HtmlView (yoga-layout flexbox) is not available in the
-// playground bundle. See scripts/stubs/unavailable.js.
+// Inert stub for both yoga-layout entries: HtmlView (yoga-layout flexbox)
+// is not available in the playground bundle. See scripts/stubs/unavailable.js.
 module.exports = require('./unavailable.js')('yoga-layout');


### PR DESCRIPTION
Unblocks tier 3 of react-x11's [packaging guide](https://github.com/sidorares/react-x11/blob/master/docs/packaging.md) — shipping an app as a single executable — which that page measured as impossible and traced to two requirements in direct conflict.

## The conflict, and which half was ours

Node's single executable format evaluates its embedded main as **CommonJS**. esbuild refuses to emit CommonJS for a module graph containing top-level await. So the question was where the top-level await came from, and the answer turned out to be one line in a dependency:

```js
// node_modules/yoga-layout/dist/src/index.js
const Yoga = wrapAssembly(await loadYoga());
```

`lib/widgets/htmlview.js` imported that entry, and `lib/index.js` re-exported it, so **every** ntk app inherited the await — including apps that never touch HtmlView. esbuild names exactly one library file when asked for a CommonJS build, and that was it.

## What changed

ntk now imports `yoga-layout/load`, the half of the package with no WASM in it: the enums are plain JavaScript, and the assembly comes back from an async function. `lib/yoga.js` rebuilds yoga's own object shape from those enums and fills in the assembly when it arrives; `createClient()` starts that load alongside the connection, so by the time an App exists the engine is in place and every widget stays synchronous.

The flat `Yoga.FLEX_DIRECTION_ROW`-style constants are readable **as soon as ntk is imported**. That is deliberate and load-bearing: ntk's own HtmlView and react-x11's `src/styles.js` both build lookup tables at module scope, and those keep working untouched.

## Effect

An ntk app bundles to CommonJS and runs as one file. Verified end to end on Node 26 — a single 140 MB executable containing ntk, node-x11's client *and* its pure-JS X server, which starts the server, connects, draws through XRender, syncs, and lays out an `HtmlView`:

```
$ esbuild app.mjs --bundle --platform=node --format=cjs --outfile=app.cjs
$ node --build-sea=sea.json && ./app
OK: single executable — X server, client, drawing and yoga layout
```

Two other things measured while establishing this, both now in `docs/packaging.md`: inside a SEA, `require()` and `import()` resolve **built-in modules only** (a `data:` or `file:` URL import fails with `ERR_UNKNOWN_BUILTIN_MODULE`, so "embed the ESM as an asset and import it" is not a way around the CommonJS rule), and `import.meta.url` is `undefined` in a CommonJS bundle.

## Breaking

- **Widgets used without an App** must `await loadLayout()` first. `createClient()` does it for applications, so a normal app changes nothing. Until then `Yoga.Node` throws a message that says exactly this, and `layoutLoaded()` reports the state.
- **`Yoga` is no longer the same object as `yoga-layout`'s default export.** Import it from ntk; importing `yoga-layout` directly creates a second WASM instance whose nodes cannot be mixed with ntk's. That hazard is why the export exists, and `docs/html.md` now says so.

**react-x11 is unaffected at runtime** — its renderer creates yoga nodes only after `createClient()`. Its headless tests build trees against a mock app that never connects, so they need one line (`await loadLayout()` in `src/testing/mock-app.js`); with that, all 322 of its tests pass against this branch, and one of its examples runs clean against a real server.

## Testing

- `test/packaging.test.js` (new) pins the invariant that made this necessary: nothing under `lib/` may import the top-level-await yoga entry, and importing ntk must not load the WASM.
- `test/yoga-export.test.js` (rewritten) covers the new shape: constants without loading, a clear error before load, idempotent `loadLayout()`, one shared instance — and compares **every** constant ntk generates against the real assembly, so a rename upstream fails loudly instead of leaving `undefined` in a layout table.
- `test/htmlview.test.js` loads the engine in a `before` hook, being the one suite that lays out without an App.
- Full suite green: 439 tests. Browser playground rebuilt and all 7 demos pixel-check green (its yoga stub covers both entries now).
