### PR TITLE
feat: publish frameInFlight, the gate for painting a discrete input now

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -141,6 +141,24 @@ delivered immediately — any buffered noisy events are flushed first so
 handlers observe them in the order they happened. Blits of an already-drawn
 backing store still respect the fence, but skip the timer for latency.
 
+A toolkit that schedules its own painting can go one better and draw a
+discrete input's response *inside* the handler, so the pixels leave with the
+handler's own requests rather than on the next paced frame — a click's
+`:active` flip is one paint of a few hundred microseconds, and waiting a
+frame interval for it buys nothing. `wnd.frameInFlight()` is the gate to
+make that decision with: `false` means the server is caught up and drawing
+now costs nothing extra, `true` means a frame is already on its way and the
+present would only be deferred and coalesced with it. Gating on it is what
+keeps a burst sane — the first wheel notch paints immediately, the rest fold
+into one catch-up frame.
+
+```js
+wnd.on('mousedown', (ev) => {
+  applyPressedState(ev);
+  if (!wnd.frameInFlight()) paint(); // else leave it to the frame clock
+});
+```
+
 Escape hatches, from mildest to rawest:
 
 - `frameInterval = 0` — fence-only pacing (fastest delivery that cannot
@@ -203,6 +221,10 @@ All return `this` unless noted.
 - `getContext(name)` — `'2d'`, `'opengl'` or `'x11'`; see the context docs
 - `requestAnimationFrame(cb)` — returns an id, does not return `this`;
   `cancelAnimationFrame(id)` (see above)
+- `frameInFlight()` — returns a boolean, not `this`: whether the last frame's
+  fence is still unanswered. The gate for painting a discrete input's
+  response from its own handler instead of on the next paced frame (see
+  [above](#frames-coalescing-and-slow-connections))
 - `createWindow(params)` — child window (`parent` preset to this window)
 - `createPixmap(params)` — pixmap defaulting to this window's size, depth 32
 - `setCursor(nameOrShapeId)` — mouse cursor shown over the window (see

--- a/lib/window.js
+++ b/lib/window.js
@@ -918,6 +918,30 @@ export default class Window extends Drawable {
     if (idx !== -1) f.rafCbs.splice(idx, 1);
   }
 
+  /**
+   * Whether the fence for the last frame is still unanswered — the server has
+   * not yet confirmed it consumed everything that frame drew.
+   *
+   * The one bit of frame-clock state worth publishing, because it is the
+   * difference between the two ways a toolkit can answer a discrete input.
+   * Drawing the response inside the event handler costs a frame less latency:
+   * the blit goes out with the handler's own requests (see the `_present()`
+   * at the end of the event dispatch) instead of waiting for the next paced
+   * frame. Drawing it while a frame is in flight costs a frame's *work* for
+   * nothing: the present is deferred until the ack and coalesces with the
+   * one already pending, so only the last paint is ever seen. So `false`
+   * means "draw it now", `true` means "leave it to the frame clock" — which
+   * is how a burst of discrete events (a spun wheel) paints its first notch
+   * immediately and folds the rest into one catch-up frame.
+   *
+   * Always `false` under `frameSync: false`: no fence is ever sent, so there
+   * is nothing to wait for, and a caller gating on this gets the unpaced
+   * behaviour that option asks for.
+   */
+  frameInFlight() {
+    return this._frame.inFlight;
+  }
+
   _present() {
     if (!this._backing) return;
     if (this._frame.inFlight) {

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -214,6 +214,57 @@ test('frameInterval paces flushes when the fence is disabled', async () => {
   wnd.destroy();
 });
 
+// frameInFlight() — the gate a toolkit paints a discrete input's response
+// through. What it has to get right is the *transitions*: false while the
+// server is caught up, true from the moment a frame's fence goes out until
+// its reply lands.
+test('frameInFlight tracks the fence across a frame', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  assert.equal(wnd.frameInFlight(), false, 'nothing drawn yet, nothing to wait for');
+
+  wnd.requestAnimationFrame(() => {});
+  await tick();
+  assert.equal(fences.length, 1);
+  assert.equal(wnd.frameInFlight(), true, 'the frame sent its fence');
+
+  fences.shift()(null);
+  assert.equal(wnd.frameInFlight(), false, 'the server caught up');
+  wnd.destroy();
+});
+
+test('a discrete handler that draws sees the gate open, then closed', async () => {
+  const { app, fences, calls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  wnd._enableBackingStore();
+  const gate = [];
+  wnd.on('mousedown', () => {
+    gate.push(wnd.frameInFlight());
+    wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 }); // as painting would
+  });
+
+  // three notches of a wheel arriving faster than the server can answer
+  wnd.emit('event', { type: 4, x: 1, y: 1, keycode: 4 });
+  wnd.emit('event', { type: 4, x: 1, y: 1, keycode: 4 });
+  wnd.emit('event', { type: 4, x: 1, y: 1, keycode: 4 });
+  assert.deepEqual(gate, [false, true, true], 'open for the first, shut behind it');
+  assert.equal(calls.CopyArea, 1, 'only the first press blitted');
+
+  fences.shift()(null);
+  assert.equal(calls.CopyArea, 2, 'the rest caught up in one blit');
+  wnd.destroy();
+});
+
+test('frameInFlight stays false when frameSync is off', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { frameSync: false, frameInterval: 0 });
+  wnd.requestAnimationFrame(() => {});
+  await tick();
+  assert.equal(fences.length, 0, 'no fence is ever sent');
+  assert.equal(wnd.frameInFlight(), false, 'so a caller gating on it never defers');
+  wnd.destroy();
+});
+
 test('interactive resize drives one paced draw per frame', async () => {
   const { app, fences, calls } = makeMockApp();
   const wnd = new Window(app, { frameInterval: 0, width: 100, height: 100 });


### PR DESCRIPTION
A toolkit that schedules its own painting wants to draw a click's response inside the event handler rather than on the next paced frame. The blit then leaves with the handler's own requests — ntk already presents a window's dirty backing rects when its event callback returns — instead of waiting up to a frame interval for a paint that takes a few hundred microseconds.

Doing it unconditionally is wrong, though. While a frame is in flight the present is deferred and coalesces with the pending one, so the extra paint is work nobody ever sees: spin a wheel and you would rasterize ten notches to display two.

The fence is the only state that tells those two cases apart, and it was private. `frameInFlight` returns it, so a `mousedown` handler can apply its pressed state and then paint immediately when the gate reads false, or leave it to the frame clock when it reads true. There is a worked example in the docs — no code fence here, because a callback's parentheses are what release-please cannot parse.

That gate is what makes a burst behave: the first notch paints immediately, the rest fold into one catch-up frame. Update instantly, then catch up, with the fence as the backpressure.

Always false under `frameSync: false`, where no fence is ever sent — a caller gating on this gets the unpaced behaviour that option asks for.

## What is here

- `lib/window.js` — the accessor, next to `requestAnimationFrame`.
- `docs/window.md` — the discrete-paint decision in the frame-clock section, with the example, plus the methods list.
- `test/frame-pacing.test.js` — three tests: the gate tracks the fence across a frame; a discrete handler that draws sees it open for the first press and shut behind it, with one blit for the burst and one more on the ack; and it stays open under `frameSync: false`.

Additive, and no behaviour change: nothing inside ntk reads it.

## Why

react-x11 needs it for sidorares/react-x11#141 — a click's `:active` flip and a click-placed caret currently wait a 16 ms tick plus a fence round trip behind a paint that measures about 70 microseconds. sidorares/react-x11#153 cannot ship without this one.

Full suite: 460 tests, all passing.
