### PR TITLE
feat!: getImageData and putImageData speak straight RGBA, as canvas does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,8 +191,9 @@ README.md holds only the pitch and short samples — details belong in docs/.
   on the PR branch and reference them with
   `https://raw.githubusercontent.com/sidorares/ntk/<commit-sha>/docs/img/…`
   URLs (SHA-pinned links survive squash-merge branch deletion). Headless
-  recipe: draw into a pixmap, read back with `getImageData` (BGRA order) and
-  save with `pngjs` — same pattern as `test/smoke-canvas.test.js`.
+  recipe: draw into a pixmap, read back with `getImageData` (straight RGBA,
+  ready to hand to `pngjs`) and save — same pattern as
+  `test/smoke-canvas.test.js`.
 
 ## Releases
 
@@ -244,7 +245,11 @@ release and publishes to npm via OIDC trusted publishing (no token secrets).
   fragment. For min-content, measure each whitespace-delimited token
   unconstrained; an unconstrained token cannot be broken. Pinned by a test, so
   the probe does not come back as an obvious simplification.
-- `getImageData` returns BGRA byte order.
+- `getImageData`/`putImageData` speak straight (non-premultiplied) RGBA, as
+  the canvas spec does; `lib/imagedata.js` owns the conversion to and from
+  the drawable's layout. `readPixels` is the raw escape hatch. Never assume
+  BGRA — that is only what an LSBFirst server with the standard visual masks
+  happens to want.
 - Colors in XRender are premultiplied `[r, g, b, a]` floats 0..1.
 - A `Window` constructed with an existing `{ id }` returns a cached instance
   if one exists; geometry arrives async (`_readyPromise`).

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -124,9 +124,40 @@ to the anchor point, but glyphs are not rotated/scaled — size text via
   be another ntk 2d context (server-side composite of the whole drawable) or
   a node-canvas-like object exposing `image.context.getImageData()` (pixels
   are uploaded)
-- `createImageData(w, h)`, `putImageData(data, x, y)`
-- `getImageData(x, y, w, h, cb)` — async, `cb(err, image)`; `image.data` is
-  BGRA byte order
+### Pixels
+
+Pixel access follows the canvas API: `ImageData` is straight
+(non-premultiplied) RGBA in a `Uint8ClampedArray`, rows top to bottom, and
+ntk converts to and from the drawable's own layout at the boundary.
+
+- `getImageData(x, y, w, h)` — resolves to an `ImageData`. A trailing
+  `cb(err, imageData)` is still accepted. Reads the backing pixmap on
+  double-buffered windows, so it is valid even where the window is occluded
+- `putImageData(data, x, y[, dirtyX, dirtyY, dirtyWidth, dirtyHeight])` —
+  writes straight RGBA back, optionally only part of the source
+- `createImageData(w, h)` / `createImageData(imagedata)` — a blank
+  `ImageData`; the second form copies the size, not the pixels
+
+```js
+const img = await ctx.getImageData(0, 0, 64, 64);
+img.data[0] = 255; // red channel of the top-left pixel
+ctx.putImageData(img, 0, 0);
+```
+
+What the drawable actually holds is none of those things — `GetImage`
+returns words in the *server's* `image_byte_order` (a different handshake
+field from the one the connection speaks), the channel positions come from
+the visual's masks, anything XRender composited into is premultiplied, and a
+depth-24 drawable's fourth byte is undefined padding rather than opacity.
+Converting costs a pass over the pixels: roughly 0.04 ms for a 128×128 read,
+0.7 ms at 640×480, 4.6 ms at 1920×1080.
+
+- `readPixels(x, y, w, h)` — the way out when you want the server's own
+  bytes, for handing straight back to `PutImage` or into a codec. Resolves to
+  `{ width, height, data, depth, bitsPerPixel, byteOrder, masks,
+  premultiplied }`, so unlike a bare `GetImage` the bytes say what they mean.
+  `byteOrder` is `'lsb'` or `'msb'`; `masks.alpha` is 0 when the drawable has
+  no alpha channel
 
 ## Paths
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -27,6 +27,10 @@ wnd.map();
   `URL`, or a `Buffer`/`Uint8Array` of encoded PNG/JPEG bytes
 - `decodeImage(buffer)` → `Image` — synchronous decode of in-memory bytes;
   the format is sniffed from magic bytes
+- `new Image(imagedata)` — an `ImageData` from
+  [`ctx.getImageData()`](context-2d.md) is already the right shape, so
+  reading pixels back and turning them into a reusable server-side image
+  needs no conversion
 - `new Image({ width, height, data })` — wrap raw non-premultiplied RGBA
   pixels (`width * height * 4` bytes)
 

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,6 +1,7 @@
 import jpeg from 'jpeg-js';
 import { PNG } from 'pngjs';
 
+import { fromStraightRgba, pixelLayout } from './imagedata.js';
 import Picture from './picture.js';
 
 /**
@@ -40,23 +41,15 @@ export class Image {
     const Render = app.display.Render;
     const pixmap = app.createPixmap({ depth: 32, width: this.width, height: this.height });
 
-    // XRender composites premultiplied alpha; PutImage on a 32-bit ZPixmap
-    // wants BGRA byte order (see AGENTS.md gotchas)
-    const bgra = Buffer.allocUnsafe(this.width * this.height * 4);
-    const src = this.data;
-    for (let i = 0; i < bgra.length; i += 4) {
-      const a = src[i + 3];
-      if (a === 255) {
-        bgra[i] = src[i + 2];
-        bgra[i + 1] = src[i + 1];
-        bgra[i + 2] = src[i];
-      } else {
-        bgra[i] = (src[i + 2] * a + 127) / 255;
-        bgra[i + 1] = (src[i + 1] * a + 127) / 255;
-        bgra[i + 2] = (src[i] * a + 127) / 255;
-      }
-      bgra[i + 3] = a;
-    }
+    // straight RGBA in, the server's own premultiplied layout out. This used
+    // to assume BGRA, which is only what a little-endian server with the
+    // standard visual masks happens to want.
+    const bgra = fromStraightRgba(
+      this.data,
+      pixelLayout(app.display, 32),
+      this.width,
+      this.height
+    );
 
     // node-x11 has no FreeGC — share one upload GC per app (valid for any
     // depth-32 drawable on the screen)

--- a/lib/imagedata.js
+++ b/lib/imagedata.js
@@ -1,0 +1,286 @@
+/**
+ * The canvas pixel contract, and the conversions between it and what an X
+ * server actually hands over.
+ *
+ * Canvas `ImageData` is straight (non-premultiplied) RGBA bytes, one byte per
+ * channel, rows top to bottom. An X drawable is none of those things by
+ * default:
+ *
+ *   - `GetImage` returns the drawable's raw words in the *server's*
+ *     `image_byte_order`, which is a different field from the byte order this
+ *     connection speaks;
+ *   - which bits inside a word hold which channel comes from the visual's
+ *     masks, not from a convention;
+ *   - anything XRender composited into is premultiplied, and a drawable
+ *     without an alpha channel has a fourth byte that is undefined padding
+ *     rather than opaque.
+ *
+ * Everything crossing that boundary goes through here, so callers see RGBA
+ * and only this file knows about the rest. `readPixels()` is the way out for
+ * code that genuinely wants the server's own bytes — it reports the layout
+ * alongside them instead of leaving the caller to assume one.
+ */
+
+/** shift of the lowest set bit, i.e. where a channel starts inside a word */
+function shiftOf(mask) {
+  let s = 0;
+  while (s < 32 && !((mask >>> s) & 1)) s++;
+  return s;
+}
+
+/** width of a contiguous mask, so 5- and 6-bit channels can be scaled to 8 */
+function widthOf(mask, shift) {
+  let w = 0;
+  while (shift + w < 32 && (mask >>> (shift + w)) & 1) w++;
+  return w;
+}
+
+/**
+ * How pixels of `depth` are laid out on this display: which bits hold which
+ * channel, whether there is an alpha channel at all, and which end of a word
+ * the server writes first.
+ *
+ * Channel positions come from a TrueColor visual of that depth when the
+ * screen has one. Depth 32 has no visual on most servers (XQuartz has none at
+ * all) but every depth-32 drawable ntk makes is paired with a `Render.rgba32`
+ * picture, whose PictStandardARGB32 format pins A=24 R=16 G=8 B=0 — so that
+ * is the fallback, and it is a specification rather than a guess.
+ */
+export function pixelLayout(display, depth) {
+  const screen = display.screen[0];
+  let masks = null;
+  for (const visual of Object.values(screen.depths?.[depth] ?? {})) {
+    if (visual.class === 4 || visual.class === 5) {
+      // TrueColor / DirectColor
+      masks = { red: visual.red_mask, green: visual.green_mask, blue: visual.blue_mask };
+      break;
+    }
+  }
+  if (!masks) masks = { red: 0xff0000, green: 0x00ff00, blue: 0x0000ff };
+
+  const bitsPerPixel = display.format?.[depth]?.bits_per_pixel ?? (depth > 16 ? 32 : depth);
+  if (bitsPerPixel !== 32) {
+    throw new Error(
+      `ntk works in 32-bit pixels; depth ${depth} on this server is ` +
+        `${bitsPerPixel} bits per pixel. Use readPixels() and unpack it yourself.`
+    );
+  }
+
+  const hasAlpha = depth === 32;
+  // whatever the colour masks leave over, which for ARGB32 is the top byte
+  const alpha = hasAlpha ? (~(masks.red | masks.green | masks.blue) & 0xffffffff) >>> 0 : 0;
+
+  return {
+    depth,
+    bitsPerPixel,
+    masks: { ...masks, alpha },
+    // 0 LSBFirst, 1 MSBFirst — the server's pixel order, NOT display.byte_order
+    byteOrder: display.image_byte_order ? 'msb' : 'lsb',
+    // XRender composites premultiplied, so anything with an alpha channel
+    // that ntk has drawn into holds premultiplied colour
+    premultiplied: hasAlpha
+  };
+}
+
+/** the common case: LSBFirst words with 8-bit channels at ARGB32 positions */
+function isStandardLsb(layout) {
+  return (
+    layout.byteOrder === 'lsb' &&
+    layout.masks.red === 0xff0000 &&
+    layout.masks.green === 0x00ff00 &&
+    layout.masks.blue === 0x0000ff
+  );
+}
+
+/**
+ * Server pixels -> straight RGBA. `raw` is a `GetImage` reply body.
+ *
+ * @param {Buffer} raw
+ * @param {object} layout from `pixelLayout()`
+ * @param {number} width
+ * @param {number} height
+ * @returns {Uint8ClampedArray}
+ */
+export function toStraightRgba(raw, layout, width, height) {
+  const n = width * height;
+  const out = new Uint8ClampedArray(n * 4);
+  const { premultiplied } = layout;
+
+  if (isStandardLsb(layout)) {
+    // bytes arrive B, G, R, A — a straight index shuffle, which measures
+    // faster than reading 32-bit words back out of the Buffer
+    for (let i = 0; i < n * 4; i += 4) {
+      const a = layout.depth === 32 ? raw[i + 3] : 255;
+      if (a === 255) {
+        out[i] = raw[i + 2];
+        out[i + 1] = raw[i + 1];
+        out[i + 2] = raw[i];
+      } else if (a === 0 || !premultiplied) {
+        out[i] = raw[i + 2];
+        out[i + 1] = raw[i + 1];
+        out[i + 2] = raw[i];
+      } else {
+        out[i] = (raw[i + 2] * 255) / a;
+        out[i + 1] = (raw[i + 1] * 255) / a;
+        out[i + 2] = (raw[i] * 255) / a;
+      }
+      out[i + 3] = a;
+    }
+    return out;
+  }
+
+  const { masks } = layout;
+  const rs = shiftOf(masks.red);
+  const gs = shiftOf(masks.green);
+  const bs = shiftOf(masks.blue);
+  const as = masks.alpha ? shiftOf(masks.alpha) : 0;
+  const rw = widthOf(masks.red, rs);
+  const gw = widthOf(masks.green, gs);
+  const bw = widthOf(masks.blue, bs);
+  // scale a channel of `w` bits up to 8, so 0b11111 becomes 255 not 248
+  const up = (v, w) => (w === 8 ? v : Math.round((v * 255) / ((1 << w) - 1)));
+  const readWord = layout.byteOrder === 'msb'
+    ? (o) => raw.readUInt32BE(o)
+    : (o) => raw.readUInt32LE(o);
+
+  for (let i = 0; i < n; i++) {
+    const px = readWord(i * 4);
+    const a = masks.alpha ? (px & masks.alpha) >>> as : 255;
+    let r = up((px & masks.red) >>> rs, rw);
+    let g = up((px & masks.green) >>> gs, gw);
+    let b = up((px & masks.blue) >>> bs, bw);
+    if (premultiplied && a !== 0 && a !== 255) {
+      r = (r * 255) / a;
+      g = (g * 255) / a;
+      b = (b * 255) / a;
+    }
+    out[i * 4] = r;
+    out[i * 4 + 1] = g;
+    out[i * 4 + 2] = b;
+    out[i * 4 + 3] = a;
+  }
+  return out;
+}
+
+/**
+ * Straight RGBA -> server pixels, ready for `PutImage`.
+ *
+ * @param {Uint8Array} rgba straight RGBA, 4 bytes per pixel
+ * @param {object} layout from `pixelLayout()`
+ * @param {number} width
+ * @param {number} height
+ * @returns {Buffer}
+ */
+export function fromStraightRgba(rgba, layout, width, height) {
+  const n = width * height;
+  const out = Buffer.allocUnsafe(n * 4);
+  const { premultiplied } = layout;
+
+  if (isStandardLsb(layout)) {
+    for (let i = 0; i < n * 4; i += 4) {
+      const a = rgba[i + 3];
+      if (!premultiplied || a === 255) {
+        out[i] = rgba[i + 2];
+        out[i + 1] = rgba[i + 1];
+        out[i + 2] = rgba[i];
+      } else {
+        // +127 rounds to nearest rather than truncating, which otherwise
+        // drifts a translucent fill visibly darker over repeated round trips
+        out[i] = (rgba[i + 2] * a + 127) / 255;
+        out[i + 1] = (rgba[i + 1] * a + 127) / 255;
+        out[i + 2] = (rgba[i] * a + 127) / 255;
+      }
+      out[i + 3] = layout.depth === 32 ? a : 0;
+    }
+    return out;
+  }
+
+  const { masks } = layout;
+  const rs = shiftOf(masks.red);
+  const gs = shiftOf(masks.green);
+  const bs = shiftOf(masks.blue);
+  const as = masks.alpha ? shiftOf(masks.alpha) : 0;
+  const rw = widthOf(masks.red, rs);
+  const gw = widthOf(masks.green, gs);
+  const bw = widthOf(masks.blue, bs);
+  const down = (v, w) => (w === 8 ? v : Math.round((v * ((1 << w) - 1)) / 255));
+  const writeWord = layout.byteOrder === 'msb'
+    ? (v, o) => out.writeUInt32BE(v, o)
+    : (v, o) => out.writeUInt32LE(v, o);
+
+  for (let i = 0; i < n; i++) {
+    const a = rgba[i * 4 + 3];
+    let r = rgba[i * 4];
+    let g = rgba[i * 4 + 1];
+    let b = rgba[i * 4 + 2];
+    if (premultiplied && a !== 255) {
+      r = (r * a + 127) / 255;
+      g = (g * a + 127) / 255;
+      b = (b * a + 127) / 255;
+    }
+    const word =
+      ((down(r | 0, rw) << rs) |
+        (down(g | 0, gw) << gs) |
+        (down(b | 0, bw) << bs) |
+        (masks.alpha ? (a << as) & masks.alpha : 0)) >>>
+      0;
+    writeWord(word, i * 4);
+  }
+  return out;
+}
+
+/**
+ * Canvas `ImageData`: straight RGBA in a `Uint8ClampedArray`, rows top to
+ * bottom. Both spec constructor forms work:
+ *
+ *   new ImageData(width, height)
+ *   new ImageData(data, width[, height])
+ *
+ * `data` may be any `Uint8Array` — a node `Buffer` included — and is adopted
+ * as-is when it is already a `Uint8ClampedArray`, copied otherwise.
+ */
+export class ImageData {
+  constructor(a, b, c) {
+    if (typeof a === 'number') {
+      const width = a;
+      const height = b;
+      if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+        throw new Error('ImageData: width and height must be positive integers');
+      }
+      this.width = width;
+      this.height = height;
+      this.data = new Uint8ClampedArray(width * height * 4);
+      return;
+    }
+    if (!ArrayBuffer.isView(a)) {
+      throw new TypeError('ImageData: first argument must be a width or a typed array');
+    }
+    const width = b;
+    if (!Number.isInteger(width) || width <= 0) {
+      throw new Error('ImageData: width must be a positive integer');
+    }
+    if (a.length % 4 !== 0) {
+      throw new Error(`ImageData: data length ${a.length} is not a whole number of RGBA pixels`);
+    }
+    const height = c ?? a.length / 4 / width;
+    if (!Number.isInteger(height) || height <= 0) {
+      throw new Error(`ImageData: ${a.length} bytes is not a whole number of ${width}px rows`);
+    }
+    if (a.length !== width * height * 4) {
+      throw new Error(
+        `ImageData: data must be ${width * height * 4} bytes for ${width}x${height}, got ${a.length}`
+      );
+    }
+    this.width = width;
+    this.height = height;
+    this.data =
+      a instanceof Uint8ClampedArray
+        ? a
+        : new Uint8ClampedArray(a.buffer, a.byteOffset, a.byteLength).slice();
+  }
+
+  /** the sRGB colour space, for parity with the browser's property */
+  get colorSpace() {
+    return 'srgb';
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ import { decodeKey, groupForState } from './keyboard.js';
 import Pixmap from './pixmap.js';
 import Picture from './picture.js';
 import { Image, decodeImage, loadImage } from './image.js';
+import { ImageData, fromStraightRgba, pixelLayout, toStraightRgba } from './imagedata.js';
 import { Path2D, parseSvgPath } from './path.js';
 import Font from './text/font.js';
 import FontManager from './text/fontmanager.js';
@@ -150,6 +151,10 @@ export {
   Pixmap,
   Picture,
   Image,
+  ImageData,
+  pixelLayout,
+  toStraightRgba,
+  fromStraightRgba,
   decodeImage,
   loadImage,
   Path2D,

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -4,6 +4,7 @@ import extrudePolyline from 'extrude-polyline';
 import { cssColor } from './color.js';
 import Drawable from './drawable.js';
 import { Image } from './image.js';
+import { ImageData, fromStraightRgba, pixelLayout, toStraightRgba } from './imagedata.js';
 import {
   Path2D,
   flattenPath,
@@ -148,7 +149,9 @@ class RenderingContext2d {
     this.X = X;
 
     this.window = window;
-    this.Render = window.app.display.Render;
+    this.display = window.app.display;
+    this.Render = this.display.Render;
+    this._layoutCache = null;
 
     // draw into the window's backing pixmap when it has one (double
     // buffering); re-bind when the backing pixmap is reallocated on resize
@@ -200,6 +203,7 @@ class RenderingContext2d {
     const target = this.window._backing || this.window;
     if (this._target === target) return;
     this._target = target;
+    this._layoutCache = null; // the new target may be a different depth
 
     if (!this._gc) {
       // one GC is enough: it stays valid for any drawable of the same
@@ -1320,25 +1324,137 @@ class RenderingContext2d {
     return new CanvasGradient('conical', this, x0, y0, angle);
   }
 
-  createImageData(w, h) {
-    return {
-      width: w,
-      height: h,
-      data: Buffer.alloc(w * h * 4)
-    };
+  /** the pixel layout of whatever this context currently draws into */
+  get _layout() {
+    const depth = this._target.depth ?? this.window.depth ?? this.display.screen[0].root_depth;
+    if (!this._layoutCache || this._layoutCache.depth !== depth) {
+      this._layoutCache = pixelLayout(this.display, depth);
+    }
+    return this._layoutCache;
   }
 
-  // TODO: remove, add drawImage
-  putImageData(data, x, y) {
-    // todo: use constants
-    this.X.PutImage(2, this._target.id, this._gc, data.width, data.height, x, y, 0, 24, data.data);
+  /**
+   * A blank `ImageData`, or a copy of one — both canvas forms:
+   *
+   *   createImageData(width, height)
+   *   createImageData(imagedata)
+   */
+  createImageData(a, b) {
+    if (typeof a === 'number') return new ImageData(a, b);
+    if (a && typeof a.width === 'number' && a.data) return new ImageData(a.width, a.height);
+    throw new TypeError('createImageData: pass (width, height) or an ImageData');
+  }
+
+  /**
+   * Write straight RGBA pixels into the drawable at `(x, y)`.
+   *
+   * `data` is an `ImageData` or anything shaped like one; its bytes are
+   * non-premultiplied RGBA, and they are converted to the drawable's own
+   * pixel layout on the way out. The optional `dirty*` rectangle limits the
+   * write to part of the source, as in the canvas spec.
+   */
+  putImageData(data, x, y, dirtyX = 0, dirtyY = 0, dirtyWidth, dirtyHeight) {
+    const { width, height } = data;
+    const src = data.data;
+    if (!src || src.length !== width * height * 4) {
+      throw new Error(
+        `putImageData: data must be ${width * height * 4} RGBA bytes for ${width}x${height}`
+      );
+    }
+    dirtyWidth ??= width;
+    dirtyHeight ??= height;
+    // the spec normalises negative extents by moving the origin
+    if (dirtyWidth < 0) { dirtyX += dirtyWidth; dirtyWidth = -dirtyWidth; }
+    if (dirtyHeight < 0) { dirtyY += dirtyHeight; dirtyHeight = -dirtyHeight; }
+    const sx = Math.max(0, dirtyX);
+    const sy = Math.max(0, dirtyY);
+    const sw = Math.min(width, dirtyX + dirtyWidth) - sx;
+    const sh = Math.min(height, dirtyY + dirtyHeight) - sy;
+    if (!(sw > 0) || !(sh > 0)) return;
+
+    let rgba = src;
+    if (sx !== 0 || sy !== 0 || sw !== width || sh !== height) {
+      const cropped = new Uint8ClampedArray(sw * sh * 4);
+      for (let row = 0; row < sh; row++) {
+        cropped.set(
+          src.subarray((sy + row) * width * 4 + sx * 4, (sy + row) * width * 4 + (sx + sw) * 4),
+          row * sw * 4
+        );
+      }
+      rgba = cropped;
+    }
+
+    const layout = this._layout;
+    const bytes = fromStraightRgba(rgba, layout, sw, sh);
+    // stay under the server's maximum request size by uploading row bands
+    const stride = sw * 4;
+    const maxBytes = ((this.display.max_request_length ?? 65535) - 8) * 4;
+    const rowsPerBand = Math.max(1, Math.floor(maxBytes / stride));
+    for (let row = 0; row < sh; row += rowsPerBand) {
+      const rows = Math.min(rowsPerBand, sh - row);
+      this.X.PutImage(
+        2, // ZPixmap
+        this._target.id,
+        this._gc,
+        sw, rows,
+        x + sx, y + sy + row,
+        0,
+        layout.depth,
+        bytes.subarray(row * stride, (row + rows) * stride)
+      );
+    }
     this._markDirty();
   }
 
+  /**
+   * Read pixels back as canvas `ImageData` — straight (non-premultiplied)
+   * RGBA in a `Uint8ClampedArray`, exactly like the browser's.
+   *
+   * Reads the backing pixmap on double-buffered windows, so it is valid even
+   * where the window is occluded. Returns a promise; a trailing
+   * `cb(err, imageData)` is still accepted.
+   *
+   * The drawable's own bytes are none of those things — see
+   * `lib/imagedata.js` — so this costs a pass over the pixels. `readPixels()`
+   * is the way to skip that when you want the server's layout.
+   */
   getImageData(x, y, w, h, cb) {
-    // reads the backing pixmap on double-buffered windows: always valid,
-    // even where the window is occluded on screen
-    this.X.GetImage(2, this._target.id, x, y, w, h, 0xffffffff, cb);
+    const promise = this.readPixels(x, y, w, h).then(
+      (raw) => new ImageData(toStraightRgba(raw.data, raw.layout, w, h), w, h)
+    );
+    if (typeof cb === 'function') {
+      promise.then((data) => cb(null, data), cb);
+      return undefined;
+    }
+    return promise;
+  }
+
+  /**
+   * Read pixels in the server's own layout, with no conversion.
+   *
+   * The escape hatch under `getImageData` for code that wants to hand the
+   * bytes straight back to `PutImage`, feed a codec, or do its own unpacking.
+   * Unlike a bare `GetImage` it says what the bytes mean:
+   *
+   *   { width, height, data, depth, bitsPerPixel, byteOrder, masks,
+   *     premultiplied }
+   *
+   * `byteOrder` is `'lsb'` or `'msb'` and is the *server's* pixel order,
+   * which is a different handshake field from the one this connection
+   * speaks. `masks` gives the bit position of each channel inside a pixel
+   * word, `alpha` being 0 when the drawable has no alpha channel — in which
+   * case the spare byte is undefined padding, not opacity.
+   *
+   * @returns {Promise<object>}
+   */
+  readPixels(x, y, w, h) {
+    const layout = this._layout;
+    return new Promise((resolve, reject) => {
+      this.X.GetImage(2, this._target.id, x, y, w, h, 0xffffffff, (err, img) => {
+        if (err) return reject(err);
+        resolve({ width: w, height: h, data: img.data, layout, ...layout });
+      });
+    });
   }
 
   /**
@@ -1441,20 +1557,23 @@ class RenderingContext2d {
     } else if (image && image.context && typeof image.context.getImageData === 'function') {
       // node-canvas Canvas ( or any ctx with ctx.canvas.getImageData returning pixels)
       const imageData = image.context.getImageData(sx, sy, sWidth, sHeight);
-      // rgba -> bgra
-      const data = Buffer.alloc(imageData.data.length);
-      for (let i = 0; i < data.length; i += 4) {
-        data[i + 2] = imageData.data[i];
-        data[i + 1] = imageData.data[i + 1];
-        data[i] = imageData.data[i + 2];
-        data[i + 3] = imageData.data[i + 3]; // multiply source alpha by context globalAlpha?
-      }
+      // node-canvas hands over straight RGBA, and the rgba32 picture below is
+      // premultiplied — this used to swap the channels and stop there, which
+      // composited translucent images at full brightness
+      const data = fromStraightRgba(
+        imageData.data,
+        pixelLayout(this.display, 32),
+        sWidth,
+        sHeight
+      );
 
       const pixmap = new Pixmap(this.window.app, { depth: 32, width: sWidth, height: sHeight });
       const picture = new Picture(this.window.app, { drawable: pixmap, format: this.Render.rgba32 });
       pixmap._gc = this.X.AllocID();
       this.X.CreateGC(pixmap._gc, pixmap.id);
-      this.X.PutImage(2, pixmap.id, pixmap._gc, sWidth, sHeight, sx, sy, 0, 32, data);
+      // the crop already happened in getImageData, so it lands at the pixmap's
+      // origin — sx/sy here wrote it off the edge
+      this.X.PutImage(2, pixmap.id, pixmap._gc, sWidth, sHeight, 0, 0, 0, 32, data);
 
       this.Render.Composite(
         this.Render.PictOp.Over,

--- a/test/color.test.js
+++ b/test/color.test.js
@@ -31,15 +31,10 @@ after(async () => {
   if (app) await app.close();
 });
 
-// getImageData returns BGRA, so red is index 2
 const centre = async (ctx) => {
-  const d = await new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, W, H, (err, data) =>
-      err ? reject(err) : resolve(data)
-    )
-  );
+  const d = await ctx.getImageData(0, 0, W, H);
   const i = (10 * W + 10) * 4;
-  return [d.data[i + 2], d.data[i + 1], d.data[i]];
+  return [d.data[i], d.data[i + 1], d.data[i + 2]];
 };
 
 // fill `under`, then apply a style and fill again over the top

--- a/test/fill-bbox.test.js
+++ b/test/fill-bbox.test.js
@@ -39,15 +39,11 @@ function freshCtx() {
   return ctx;
 }
 
-const read = (ctx) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d))),
-  );
+const read = (ctx) => ctx.getImageData(0, 0, W, H);
 
-// BGRA -> [r, g, b]
 const at = (img, x, y) => {
   const i = (y * W + x) * 4;
-  return [img.data[i + 2], img.data[i + 1], img.data[i]];
+  return [img.data[i], img.data[i + 1], img.data[i + 2]];
 };
 const isWhite = (p) => p[0] > 240 && p[1] > 240 && p[2] > 240;
 

--- a/test/glyph-clip.test.js
+++ b/test/glyph-clip.test.js
@@ -38,10 +38,7 @@ after(async () => {
 const W = 160;
 const H = 80;
 
-const readPixels = (ctx) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, W, H, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+const readPixels = (ctx) => ctx.getImageData(0, 0, W, H);
 
 /** Count pixels darker than white in a band of rows. */
 function inkInRows(image, y0, y1) {
@@ -49,7 +46,7 @@ function inkInRows(image, y0, y1) {
   for (let y = y0; y < y1; y++) {
     for (let x = 0; x < W; x++) {
       const i = (y * W + x) * 4;
-      // BGRA; anything appreciably darker than the white background is ink
+      // anything appreciably darker than the white background is ink
       if (image.data[i] < 200 || image.data[i + 1] < 200 || image.data[i + 2] < 200) n++;
     }
   }

--- a/test/glyph-positions.test.js
+++ b/test/glyph-positions.test.js
@@ -72,10 +72,7 @@ function expectedImage(positions) {
   return img;
 }
 
-const readPixels = (ctx) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, W, H, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+const readPixels = (ctx) => ctx.getImageData(0, 0, W, H);
 
 function diffStats(actual, expected) {
   let bad = 0;

--- a/test/imagedata.test.js
+++ b/test/imagedata.test.js
@@ -1,0 +1,361 @@
+// The canvas pixel contract: getImageData/putImageData speak straight
+// (non-premultiplied) RGBA, whatever the server underneath is doing.
+//
+// Split in two. The conversions are pure functions, so the byte-order and
+// premultiply cases are tested directly — no X server can cover them here,
+// because every server available to CI is LSBFirst. The rest runs against
+// node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from 'node:assert/strict';
+import { after, before, describe, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+import {
+  ImageData,
+  fromStraightRgba,
+  pixelLayout,
+  toStraightRgba
+} from '../lib/imagedata.js';
+
+// --- pure conversions ------------------------------------------------------
+
+const TRUECOLOR = {
+  class: 4,
+  red_mask: 0xff0000,
+  green_mask: 0x00ff00,
+  blue_mask: 0x0000ff
+};
+
+const fakeDisplay = (imageByteOrder) => ({
+  image_byte_order: imageByteOrder,
+  format: { 24: { bits_per_pixel: 32 }, 32: { bits_per_pixel: 32 } },
+  screen: [{ root_depth: 24, depths: { 24: { 1: TRUECOLOR } } }]
+});
+
+describe('pixelLayout', () => {
+  test('depth 24 has no alpha channel and is not premultiplied', () => {
+    const l = pixelLayout(fakeDisplay(0), 24);
+    assert.equal(l.masks.alpha, 0, 'the spare byte is padding, not opacity');
+    assert.equal(l.premultiplied, false);
+    assert.equal(l.byteOrder, 'lsb');
+  });
+
+  test('depth 32 gets ARGB32 positions even with no depth-32 visual', () => {
+    // XQuartz exposes none at all, and this is the case that matters
+    const l = pixelLayout(fakeDisplay(0), 32);
+    assert.equal(l.masks.alpha >>> 0, 0xff000000);
+    assert.equal(l.masks.red, 0xff0000);
+    assert.equal(l.premultiplied, true, 'XRender composites premultiplied');
+  });
+
+  test('byteOrder follows image_byte_order, not the connection', () => {
+    assert.equal(pixelLayout(fakeDisplay(1), 24).byteOrder, 'msb');
+  });
+});
+
+describe('toStraightRgba', () => {
+  test('LSBFirst depth 24 arrives B,G,R and comes out opaque RGBA', () => {
+    const layout = pixelLayout(fakeDisplay(0), 24);
+    // one pixel, and a fourth byte of junk that must not become the alpha
+    const raw = Buffer.from([0x33, 0x22, 0x11, 0x00]);
+    assert.deepEqual([...toStraightRgba(raw, layout, 1, 1)], [0x11, 0x22, 0x33, 255]);
+  });
+
+  test('MSBFirst reads the same pixel from the other end of the word', () => {
+    const layout = pixelLayout(fakeDisplay(1), 24);
+    const raw = Buffer.from([0x00, 0x11, 0x22, 0x33]);
+    assert.deepEqual([...toStraightRgba(raw, layout, 1, 1)], [0x11, 0x22, 0x33, 255]);
+  });
+
+  test('depth 32 un-premultiplies', () => {
+    const layout = pixelLayout(fakeDisplay(0), 32);
+    // premultiplied half-alpha red: B=0 G=0 R=128 A=128
+    const raw = Buffer.from([0x00, 0x00, 0x80, 0x80]);
+    const [r, g, b, a] = toStraightRgba(raw, layout, 1, 1);
+    assert.equal(a, 128);
+    assert.ok(Math.abs(r - 255) <= 1, `red back to full, got ${r}`);
+    assert.equal(g, 0);
+    assert.equal(b, 0);
+  });
+
+  test('a fully transparent pixel does not divide by zero', () => {
+    const layout = pixelLayout(fakeDisplay(0), 32);
+    const out = toStraightRgba(Buffer.alloc(4), layout, 1, 1);
+    assert.deepEqual([...out], [0, 0, 0, 0]);
+  });
+
+  test('the result is a Uint8ClampedArray, as the canvas spec says', () => {
+    const layout = pixelLayout(fakeDisplay(0), 24);
+    assert.ok(toStraightRgba(Buffer.alloc(4), layout, 1, 1) instanceof Uint8ClampedArray);
+  });
+});
+
+describe('fromStraightRgba', () => {
+  for (const order of [0, 1]) {
+    const name = order ? 'MSBFirst' : 'LSBFirst';
+    test(`${name}: depth 24 round-trips exactly`, () => {
+      const layout = pixelLayout(fakeDisplay(order), 24);
+      const rgba = new Uint8ClampedArray([0x11, 0x22, 0x33, 255, 0xaa, 0xbb, 0xcc, 255]);
+      const packed = fromStraightRgba(rgba, layout, 2, 1);
+      assert.deepEqual([...toStraightRgba(packed, layout, 2, 1)], [...rgba]);
+    });
+
+    test(`${name}: depth 32 round-trips through premultiplication`, () => {
+      const layout = pixelLayout(fakeDisplay(order), 32);
+      // alphas chosen so the premultiplied value divides back cleanly
+      const rgba = new Uint8ClampedArray([255, 128, 0, 255, 255, 0, 0, 128]);
+      const back = toStraightRgba(fromStraightRgba(rgba, layout, 2, 1), layout, 2, 1);
+      assert.deepEqual([...back.slice(0, 4)], [255, 128, 0, 255]);
+      const [r, g, b, a] = back.slice(4);
+      assert.equal(a, 128);
+      assert.ok(Math.abs(r - 255) <= 2, `red survives the round trip, got ${r}`);
+      assert.equal(g, 0);
+      assert.equal(b, 0);
+    });
+  }
+
+  test('the two orders really do produce different bytes', () => {
+    const rgba = new Uint8ClampedArray([0x11, 0x22, 0x33, 255]);
+    const lsb = fromStraightRgba(rgba, pixelLayout(fakeDisplay(0), 24), 1, 1);
+    const msb = fromStraightRgba(rgba, pixelLayout(fakeDisplay(1), 24), 1, 1);
+    assert.notDeepEqual([...lsb], [...msb], 'otherwise the byte order is being ignored');
+    assert.deepEqual([...lsb], [0x33, 0x22, 0x11, 0]);
+    assert.deepEqual([...msb], [0, 0x11, 0x22, 0x33]);
+  });
+});
+
+describe('ImageData', () => {
+  test('(width, height) allocates transparent black', () => {
+    const d = new ImageData(2, 3);
+    assert.equal(d.width, 2);
+    assert.equal(d.height, 3);
+    assert.equal(d.data.length, 24);
+    assert.ok(d.data.every((b) => b === 0));
+    assert.equal(d.colorSpace, 'srgb');
+  });
+
+  test('(data, width) infers the height', () => {
+    const d = new ImageData(new Uint8ClampedArray(24), 2);
+    assert.equal(d.height, 3);
+  });
+
+  test('a Buffer is accepted and converted', () => {
+    const d = new ImageData(Buffer.alloc(16), 2, 2);
+    assert.ok(d.data instanceof Uint8ClampedArray);
+  });
+
+  test('a length that is not whole rows throws', () => {
+    assert.throws(() => new ImageData(new Uint8ClampedArray(20), 3), /rows|pixels/);
+  });
+
+  test('a length that disagrees with an explicit height throws', () => {
+    assert.throws(() => new ImageData(new Uint8ClampedArray(16), 2, 3), /must be 24 bytes/);
+  });
+});
+
+// --- against the in-process X server ---------------------------------------
+
+let app = null;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+const W = 16;
+const H = 16;
+
+function freshCtx(depth = 24) {
+  const pixmap = app.createPixmap({ width: W, height: H, depth });
+  return pixmap.getContext('2d');
+}
+
+describe('getImageData', () => {
+  test('returns canvas ImageData in RGBA order', async () => {
+    const ctx = freshCtx();
+    ctx.fillStyle = 'rgb(17, 34, 51)';
+    ctx.fillRect(0, 0, W, H);
+
+    const img = await ctx.getImageData(0, 0, W, H);
+    assert.ok(img instanceof ImageData);
+    assert.ok(img.data instanceof Uint8ClampedArray);
+    assert.equal(img.width, W);
+    assert.equal(img.data.length, W * H * 4);
+    assert.deepEqual([...img.data.slice(0, 4)], [17, 34, 51, 255]);
+  });
+
+  test('a depth-24 read is opaque, not transparent', async () => {
+    // the drawable's fourth byte is padding; reporting it as alpha made the
+    // whole image transparent
+    const ctx = freshCtx();
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, W, H);
+    const img = await ctx.getImageData(0, 0, W, H);
+    assert.ok([...img.data].filter((_, i) => i % 4 === 3).every((a) => a === 255));
+  });
+
+  test('the callback form still works and agrees with the promise', async () => {
+    const ctx = freshCtx();
+    ctx.fillStyle = 'rgb(10, 20, 30)';
+    ctx.fillRect(0, 0, W, H);
+
+    const viaCallback = await new Promise((resolve, reject) =>
+      ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d)))
+    );
+    const viaPromise = await ctx.getImageData(0, 0, W, H);
+    assert.deepEqual([...viaCallback.data], [...viaPromise.data]);
+  });
+
+  test('errors reach the callback rather than becoming an unhandled rejection', async () => {
+    const ctx = freshCtx();
+    ctx.canvas.destroy(); // reading a freed drawable is a BadDrawable
+    const err = await new Promise((resolve) =>
+      ctx.getImageData(0, 0, W, H, (e) => resolve(e))
+    );
+    assert.ok(err, 'expected an X error');
+  });
+
+  test('errors reject the promise when no callback is given', async () => {
+    const ctx = freshCtx();
+    ctx.canvas.destroy();
+    await assert.rejects(() => ctx.getImageData(0, 0, W, H));
+  });
+
+  test('a translucent fill on a depth-32 target reads back straight', async () => {
+    const ctx = freshCtx(32);
+    ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
+    ctx.fillRect(0, 0, W, H);
+
+    const img = await ctx.getImageData(0, 0, W, H);
+    const [r, g, b, a] = img.data.slice(0, 4);
+    assert.ok(Math.abs(a - 128) <= 2, `half alpha, got ${a}`);
+    assert.ok(r > 245, `red is straight, not premultiplied down to ~128 (got ${r})`);
+    assert.equal(g, 0);
+    assert.equal(b, 0);
+  });
+});
+
+describe('putImageData', () => {
+  test('createImageData -> fill RGBA -> putImageData round-trips', async () => {
+    // the path that used to swap red and blue: the canvas idiom, where the
+    // caller never sees a server byte
+    const ctx = freshCtx();
+    const data = ctx.createImageData(W, H);
+    for (let i = 0; i < data.data.length; i += 4) {
+      data.data[i] = 200; // r
+      data.data[i + 1] = 100; // g
+      data.data[i + 2] = 50; // b
+      data.data[i + 3] = 255;
+    }
+    ctx.putImageData(data, 0, 0);
+
+    const back = await ctx.getImageData(0, 0, W, H);
+    assert.deepEqual([...back.data.slice(0, 4)], [200, 100, 50, 255]);
+  });
+
+  test('what getImageData read can be written straight back', async () => {
+    const ctx = freshCtx();
+    ctx.fillStyle = 'rgb(1, 2, 3)';
+    ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = 'rgb(250, 240, 230)';
+    ctx.fillRect(0, 0, 4, 4);
+
+    const first = await ctx.getImageData(0, 0, W, H);
+    const other = freshCtx();
+    other.putImageData(first, 0, 0);
+    const second = await other.getImageData(0, 0, W, H);
+    assert.deepEqual([...second.data], [...first.data]);
+  });
+
+  test('the dirty rectangle limits the write to part of the source', async () => {
+    const ctx = freshCtx();
+    ctx.fillStyle = 'black';
+    ctx.fillRect(0, 0, W, H);
+
+    const data = ctx.createImageData(W, H);
+    data.data.fill(255); // opaque white everywhere
+
+    ctx.putImageData(data, 0, 0, 2, 2, 4, 4);
+    const back = await ctx.getImageData(0, 0, W, H);
+    const at = (x, y) => [...back.data.slice((y * W + x) * 4, (y * W + x) * 4 + 3)];
+    assert.deepEqual(at(3, 3), [255, 255, 255], 'inside the dirty rect');
+    assert.deepEqual(at(1, 1), [0, 0, 0], 'above-left of it, untouched');
+    assert.deepEqual(at(7, 7), [0, 0, 0], 'below-right of it, untouched');
+  });
+
+  test('data of the wrong length is rejected rather than sent', () => {
+    const ctx = freshCtx();
+    assert.throws(
+      () => ctx.putImageData({ width: 4, height: 4, data: new Uint8ClampedArray(16) }, 0, 0),
+      /must be 64 RGBA bytes/
+    );
+  });
+});
+
+describe('createImageData', () => {
+  test('the copy form takes the size and leaves the pixels blank', () => {
+    const ctx = freshCtx();
+    const src = ctx.createImageData(3, 5);
+    src.data.fill(9);
+    const copy = ctx.createImageData(src);
+    assert.equal(copy.width, 3);
+    assert.equal(copy.height, 5);
+    assert.ok(copy.data.every((b) => b === 0), 'spec says blank, not a clone');
+  });
+});
+
+describe('composition with Image', () => {
+  test('an ImageData can be handed straight to new Image()', async () => {
+    // both sides are straight RGBA now, so no conversion in user code
+    const { Image } = await import('../lib/image.js');
+    const ctx = freshCtx();
+    ctx.fillStyle = 'rgb(12, 34, 56)';
+    ctx.fillRect(0, 0, W, H);
+
+    const img = new Image(await ctx.getImageData(0, 0, W, H));
+    assert.equal(img.width, W);
+
+    const target = freshCtx();
+    target.fillStyle = 'black';
+    target.fillRect(0, 0, W, H);
+    target.drawImage(img, 0, 0);
+
+    const back = await target.getImageData(0, 0, W, H);
+    assert.deepEqual([...back.data.slice(0, 4)], [12, 34, 56, 255]);
+  });
+});
+
+describe('readPixels', () => {
+  test('reports the layout alongside the server bytes', async () => {
+    const ctx = freshCtx();
+    ctx.fillStyle = 'rgb(17, 34, 51)';
+    ctx.fillRect(0, 0, W, H);
+
+    const raw = await ctx.readPixels(0, 0, W, H);
+    assert.equal(raw.depth, 24);
+    assert.equal(raw.byteOrder, 'lsb');
+    assert.equal(raw.premultiplied, false);
+    assert.equal(raw.masks.red, 0xff0000);
+    assert.equal(raw.masks.alpha, 0);
+    // unconverted, so on this LSBFirst server the bytes are B, G, R
+    assert.deepEqual([...raw.data.subarray(0, 3)], [51, 34, 17]);
+  });
+
+  test('its bytes are what getImageData converts', async () => {
+    const ctx = freshCtx();
+    ctx.fillStyle = 'rgb(9, 99, 199)';
+    ctx.fillRect(0, 0, W, H);
+
+    const raw = await ctx.readPixels(0, 0, W, H);
+    const converted = toStraightRgba(raw.data, raw.layout, W, H);
+    const img = await ctx.getImageData(0, 0, W, H);
+    assert.deepEqual([...converted], [...img.data]);
+  });
+});

--- a/test/raster-route.test.js
+++ b/test/raster-route.test.js
@@ -42,15 +42,11 @@ function freshCtx() {
   return ctx;
 }
 
-const read = (ctx) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d)))
-  );
+const read = (ctx) => ctx.getImageData(0, 0, W, H);
 
-// BGRA -> [r, g, b]
 const at = (img, x, y) => {
   const i = (y * W + x) * 4;
-  return [img.data[i + 2], img.data[i + 1], img.data[i]];
+  return [img.data[i], img.data[i + 1], img.data[i + 2]];
 };
 const isWhite = (p) => p[0] > 240 && p[1] > 240 && p[2] > 240;
 

--- a/test/scroll-region.test.js
+++ b/test/scroll-region.test.js
@@ -140,15 +140,11 @@ test('refusals: no backing, invalid backing, fractional, zero, nothing survives'
 
 // --- pixel truth against the in-process X server -------------------------
 
-const readPixels = (ctx, w, h) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, w, h, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+const readPixels = (ctx, w, h) => ctx.getImageData(0, 0, w, h);
 
-// BGRA readback -> [r, g, b]
 const px = (image, w, x, y) => {
   const i = (y * w + x) * 4;
-  return [image.data[i + 2], image.data[i + 1], image.data[i]];
+  return [image.data[i], image.data[i + 1], image.data[i + 2]];
 };
 
 test('pixels: the band lands shifted exactly, the exposed strip is untouched', async () => {

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -26,15 +26,11 @@ after(async () => {
   if (app) await app.close();
 });
 
-const readPixels = (ctx, w, h) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, w, h, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+const readPixels = (ctx, w, h) => ctx.getImageData(0, 0, w, h);
 
-// BGRA readback -> [r, g, b]
 const px = (image, w, x, y) => {
   const i = (y * w + x) * 4;
-  return [image.data[i + 2], image.data[i + 1], image.data[i]];
+  return [image.data[i], image.data[i + 1], image.data[i + 2]];
 };
 
 function freshCtx(size = 64) {
@@ -273,10 +269,10 @@ test('MarkdownView: block decoration reaches an arbitrary 2d context', async (t)
   view.draw(ctx, 10, 10);
 
   const image = await readPixels(ctx, 300, 200);
-  // scan for the fence background #00ff00 (BGRA readback)
+  // scan for the fence background #00ff00
   let filled = 0;
   for (let i = 0; i < image.data.length; i += 4) {
-    if (image.data[i + 2] === 0x00 && image.data[i + 1] === 0xff && image.data[i] === 0x00) filled++;
+    if (image.data[i] === 0x00 && image.data[i + 1] === 0xff && image.data[i + 2] === 0x00) filled++;
   }
   assert.ok(filled > 200, `fence background pixels present (${filled})`);
   pixmap.destroy();

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -81,13 +81,11 @@ test('2d context: fillRect pixels round-trip through the server', async (t) => {
   ctx.fillStyle = 'red';
   ctx.fillRect(0, 0, 32, 32);
 
-  const image = await new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, 64, 64, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+  const image = await ctx.getImageData(0, 0, 64, 64);
 
   const px = (x, y) => {
-    const i = (y * 64 + x) * 4; // BGRA
-    return [image.data[i + 2], image.data[i + 1], image.data[i]];
+    const i = (y * 64 + x) * 4;
+    return [image.data[i], image.data[i + 1], image.data[i + 2]];
   };
   assert.deepEqual(px(10, 10), [255, 0, 0], 'inside red rect');
   assert.deepEqual(px(50, 50), [255, 255, 255], 'outside red rect');
@@ -113,13 +111,11 @@ test('2d context: gradients and paths render', async (t) => {
   ctx.lineTo(32, 56);
   ctx.fill();
 
-  const image = await new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, 64, 64, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+  const image = await ctx.getImageData(0, 0, 64, 64);
   // triangle centroid should be blue-dominant
   const i = (20 * 64 + 32) * 4;
-  assert.ok(image.data[i] > 200, `blue channel dominant, got ${image.data[i]}`);
-  assert.ok(image.data[i + 2] < 100, 'red channel low inside triangle');
+  assert.ok(image.data[i + 2] > 200, `blue channel dominant, got ${image.data[i + 2]}`);
+  assert.ok(image.data[i] < 100, 'red channel low inside triangle');
 
   pixmap.destroy();
 });
@@ -132,10 +128,7 @@ const countDark = (image) => {
   return dark;
 };
 
-const readPixels = (ctx, w, h) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, w, h, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+const readPixels = (ctx, w, h) => ctx.getImageData(0, 0, w, h);
 
 test('text rendering: fillText draws shaped glyphs, measureText advances', async (t) => {
   if (skip) return t.skip(skip);
@@ -231,10 +224,8 @@ test('backing store: window 2d context draws into backing pixmap', async (t) => 
   // backing pixmap so the result is deterministic
   ctx.fillStyle = 'red';
   ctx.fillRect(0, 0, 64, 64);
-  const image = await new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, 64, 64, (err, data) => (err ? reject(err) : resolve(data)))
-  );
-  assert.deepEqual([image.data[2], image.data[1], image.data[0]], [255, 0, 0]);
+  const image = await ctx.getImageData(0, 0, 64, 64);
+  assert.deepEqual([image.data[0], image.data[1], image.data[2]], [255, 0, 0]);
 
   wnd.destroy();
 });
@@ -428,8 +419,8 @@ test('images: drawImage composites decoded PNG pixels, alpha blends', async (t) 
 
   const image = await readPixels(ctx, 8, 8);
   const px = (x, y) => {
-    const i = (y * 8 + x) * 4; // BGRA
-    return [image.data[i + 2], image.data[i + 1], image.data[i]];
+    const i = (y * 8 + x) * 4;
+    return [image.data[i], image.data[i + 1], image.data[i + 2]];
   };
   assert.deepEqual(px(1, 1), [255, 0, 0], 'red pixel');
   assert.deepEqual(px(2, 1), [0, 255, 0], 'green pixel');
@@ -460,10 +451,10 @@ test('images: drawImage scales server-side with filtering', async (t) => {
 
   const image = await readPixels(ctx, 32, 32);
   const at = (x, y) => (y * 32 + x) * 4;
-  assert.ok(image.data[at(16, 16) + 2] > 200, 'center scaled area red');
-  assert.ok(image.data[at(16, 16)] < 60, 'center blue channel low');
-  assert.equal(image.data[at(1, 1) + 2], 255, 'outside white');
+  assert.ok(image.data[at(16, 16)] > 200, 'center scaled area red');
+  assert.ok(image.data[at(16, 16) + 2] < 60, 'center blue channel low');
   assert.equal(image.data[at(1, 1)], 255, 'outside white');
+  assert.equal(image.data[at(1, 1) + 2], 255, 'outside white');
 
   // second draw reuses the cached upload (no re-upload path errors)
   ctx.drawImage(img, 0, 0, 1, 1, 4, 4, 8, 8);
@@ -588,7 +579,7 @@ test('markdown: links record hit rectangles and linkAt resolves them', async (t)
   const image = await readPixels(ctx, 300, 120);
   let blueish = 0;
   for (let i = 0; i < image.data.length; i += 4) {
-    if (image.data[i] > 140 && image.data[i + 2] < 100) blueish++; // BGRA
+    if (image.data[i + 2] > 140 && image.data[i] < 100) blueish++;
   }
   assert.ok(blueish > 20, `expected link color/underline pixels, got ${blueish}`);
 
@@ -629,8 +620,8 @@ test('html: HtmlView renders backgrounds, borders, text, links and images', asyn
 
   const image = await readPixels(ctx, 320, 300);
   const px = (x, y) => {
-    const i = (y * 320 + x) * 4; // BGRA
-    return [image.data[i + 2], image.data[i + 1], image.data[i]];
+    const i = (y * 320 + x) * 4;
+    return [image.data[i], image.data[i + 1], image.data[i + 2]];
   };
   assert.deepEqual(px(10, 10), [0x22, 0x44, 0xcc], 'background div');
   assert.deepEqual(px(1, 21), [0xcc, 0x22, 0x22], 'border left edge');

--- a/test/xserver.test.js
+++ b/test/xserver.test.js
@@ -40,15 +40,11 @@ after(async () => {
   if (app) await app.close();
 });
 
-const readPixels = (ctx, w, h) =>
-  new Promise((resolve, reject) =>
-    ctx.getImageData(0, 0, w, h, (err, data) => (err ? reject(err) : resolve(data)))
-  );
+const readPixels = (ctx, w, h) => ctx.getImageData(0, 0, w, h);
 
-// BGRA readback -> [r, g, b]
 const px = (image, w, x, y) => {
   const i = (y * w + x) * 4;
-  return [image.data[i + 2], image.data[i + 1], image.data[i]];
+  return [image.data[i], image.data[i + 1], image.data[i + 2]];
 };
 
 const near = (got, want, tol, what) =>


### PR DESCRIPTION
Closes #151.

## The problem

`getImageData` was a bare pass-through of `X.GetImage`, so what came back was not BGRA by convention — it was `image_byte_order` × the visual's masks × the drawable's depth, which lands on B,G,R,pad only for a little-endian server with the standard visual. Two more things leaked out with it:

- the fourth byte of a depth-24 drawable is **undefined padding, not alpha**, so anything reading the result as RGBA got a fully transparent image (XQuartz has no depth-32 TrueColor visual at all, so every window there is depth 24);
- the colours are **premultiplied**, because XRender is.

ntk had already picked the other side everywhere else: `Image` throws unless handed straight RGBA and premultiplies on upload, and `drawImage` converted node-canvas pixels the same way. This was the one hole in a convention the library already had — and the neighbours were broken because of it: `createImageData` → fill RGBA → `putImageData` swapped red and blue.

## The change

```js
const img = await ctx.getImageData(0, 0, 64, 64);
img.data[0] = 255;              // red channel, like anywhere else
ctx.putImageData(img, 0, 0);
```

- **`getImageData(x, y, w, h)`** resolves to a canvas `ImageData` — straight RGBA in a `Uint8ClampedArray`. A trailing `cb(err, data)` still works.
- **`putImageData(data, x, y[, dirtyX, dirtyY, dirtyWidth, dirtyHeight])`** takes straight RGBA, writes at the target's depth instead of a hardcoded 24, and honours the dirty rectangle.
- **`createImageData`** gains the `createImageData(imagedata)` form.
- **`readPixels(x, y, w, h)`** is the raw escape hatch. Unlike a bare `GetImage` it reports what the bytes mean:
  ```
  { width, height, data, depth, bitsPerPixel, byteOrder, masks, premultiplied }
  ```
- **`lib/imagedata.js`** owns every conversion, driven by `display.image_byte_order` rather than assuming little-endian, with a fast path for the common LSBFirst/standard-masks case.

`ImageData` is shape-compatible with `Image`'s constructor, so `new Image(await ctx.getImageData(...))` now needs no conversion in user code — which is the composition #151 was after.

## Two bugs fell out on the way

- `Image.picture()` hardcoded BGRA — the same latent big-endian problem, now sharing the one implementation.
- The node-canvas branch of `drawImage` swapped channels **without premultiplying**, while uploading into an `rgba32` picture XRender reads as premultiplied — so translucent canvases composited at full brightness. Same call also passed the source offset as the destination, writing the pixels off the pixmap edge.

## Cost

The conversion is a pass over the pixels: ~0.04 ms at 128×128, ~0.7 ms at 640×480, ~4.6 ms at 1920×1080. `readPixels()` skips it.

## Tests

492 pass (460 before, 32 new in `test/imagedata.test.js`). The byte-order cases are unit tests against the pure conversions — no X server available to CI is MSBFirst, so `fromStraightRgba`/`toStraightRgba` are tested directly under both orders, including an assertion that the two really do produce different bytes. The rest runs against node-x11's in-process pure-JS X server. Also spot-checked against XQuartz, which is a separate implementation from the one the suite uses:

```
getImageData    : [ 17, 34, 51, 255 ] (Uint8ClampedArray)
readPixels      : [ 51, 34, 17, 255 ] depth=24 byteOrder=lsb premul=false alphaMask=0x0
put/get roundtrip: [ 200, 100, 50, 255 ]
```

## BREAKING CHANGE

`getImageData` returns straight RGBA rather than the server's bytes, and resolves a promise rather than only taking a callback. Code indexing `[i+2], [i+1], [i]` for r, g, b now wants `[i], [i+1], [i+2]`; code that wants the old bytes wants `readPixels()`. Every in-repo caller is migrated in this PR.