### PR TITLE
feat: setIcon/getIcon — the _NET_WM_ICON writer

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -250,7 +250,8 @@ All return `this` unless noted.
 - `reparentTo(newParent, x, y)`, `raise()`, `lower()`
 - `setHints(hints)`, `setSizeHints(hints)`, `setWmHints(hints)`,
   `setTransientFor(owner)`, `setClass(instance, class)`,
-  `setWindowType(type)`, `setAlwaysOnTop(on)`, `setPid(pid, hostname)` — see
+  `setWindowType(type)`, `setAlwaysOnTop(on)`, `setPid(pid, hostname)`,
+  `setIcon(images)` / `getIcon()` — see
   [Window manager hints](#window-manager-hints) below
 - `setWmState(names, action)` / `addWmState(names)` /
   `removeWmState(names)` / `getWmStates()` — EWMH `_NET_WM_STATE`:
@@ -379,8 +380,9 @@ one call that legitimately writes an all-zero flags word — clearing
 attention means rewriting the struct without the bit — so it is written
 rather than warned about.
 
-`icon` is the old ICCCM pixmap mechanism; modern desktops prefer EWMH
-`_NET_WM_ICON`, which ntk does not write yet.
+`icon` is the old ICCCM pixmap mechanism — 1-bit or depth-matched, with no
+alpha. Modern desktops prefer EWMH `_NET_WM_ICON`; see
+[Icons](#icons--seticonimages--icon) below.
 
 ### Dialogs — `setTransientFor(owner)` / `transientFor`
 
@@ -417,6 +419,41 @@ toolkits set both.
 
 On an override-redirect window the property is inert, because the window
 manager never manages the window; ntk warns if you set it there.
+
+### Icons — `setIcon(images)` / `icon`
+
+Writes EWMH `_NET_WM_ICON`, the icon a taskbar, alt-tab switcher or titlebar
+draws for the window.
+
+```js
+wnd.setIcon(await loadImage('icon-48.png'));
+wnd.setIcon([icon16, icon32, icon48]);
+wnd.setIcon(await ctx.getImageData(0, 0, 64, 64)); // draw your own
+wnd.setIcon(null);                                  // remove it
+app.createWindow({ icon: icon48 });
+```
+
+An image is an ntk [`Image`](images.md), an `ImageData` from
+[`getImageData`](context-2d.md), or anything with `{ width, height, data }`
+where `data` is straight (non-premultiplied) RGBA. That is the same contract
+as the rest of ntk, so whatever `loadImage()` or `getImageData()` returns
+goes in unchanged — the byte order, channel packing and premultiplication
+that `_NET_WM_ICON` actually wants are ntk's problem, not yours.
+
+Passing several sizes is the useful case: the window manager picks whichever
+suits the slot it is filling rather than scaling one of them badly. No
+particular sizes are required; 16, 32 and 48 cover most desktops. Writing
+again replaces the whole set, and `setIcon(null)` (or `[]`) deletes the
+property outright rather than writing an empty one.
+
+`getIcon()` reads it back as an array of `ImageData`, or `null` when the
+window has none. That is mostly for the window-manager side — a frame
+drawing its own titlebars reads this off each client it manages — so it
+treats the bytes as untrusted: a truncated or nonsensical run yields the
+images that parsed cleanly instead of throwing.
+
+`examples/wm-icon.js` is a working demonstration: draw in the window with
+the mouse and the drawing becomes the window's own icon.
 
 ### Process identity — `setPid(pid, hostname)` / `pid: false`
 

--- a/examples/wm-icon.js
+++ b/examples/wm-icon.js
@@ -1,30 +1,22 @@
 // Draw with the mouse; what you draw becomes the window's icon.
 //
-// A proof of concept for ntk#118 item 5 (`setIcon` / `_NET_WM_ICON`). The
-// property writer is four lines — `wnd.setProperty(name, buf, {type:
-// 'CARDINAL', format: 32})` already exists. What is actually open is the
-// pixel format, and this example exists to make that concrete: it walks a
-// drawing from an XRender surface to an EWMH icon and has to cross three
-// separate conversions on the way.
-//
-//   1. byte order   GetImage hands back bytes in the *server's*
-//                   image_byte_order; property CARD32s are read in the
-//                   *connection's* byte order. Two different fields.
-//   2. channel order which byte is red depends on the source. Off a window
-//                   it is the visual's masks. Off a picture whose format we
-//                   chose it is fixed by RENDER — see below.
-//   3. alpha        XRender is premultiplied. EWMH is not.
-//
-// The trick this example leans on for (2): rather than reading the window
-// (depth 24 here — its fourth byte is padding, not alpha), it composites the
-// pad into a depth-32 pixmap through a picture *we* created with
-// Render.rgba32. PictStandardARGB32 pins A=24 R=16 G=8 B=0 inside the
-// CARD32 regardless of the visual, so only conversions (1) and (3) are left.
-//
 //   node examples/wm-icon.js            draw with the mouse
 //   node examples/wm-icon.js --selftest draw a fixed pattern, verify, exit
 //
 // Keys: c clears the pad, s saves the published icon to /tmp as a PNG.
+//
+// The interesting part is how little there is of it. `_NET_WM_ICON` wants
+// straight (non-premultiplied) ARGB packed into CARD32s, and this walks a
+// drawing all the way there without converting anything by hand:
+//
+//   composite the pad into a depth-32 pixmap -> getImageData() -> setIcon()
+//
+// `getImageData` hands back straight RGBA and `setIcon` takes straight RGBA,
+// so all three conversions between an XRender surface and an EWMH icon —
+// the server's image_byte_order, the visual's channel masks, and
+// premultiplied versus straight alpha — happen inside ntk. When this example
+// was first written the two APIs disagreed and it carried thirty lines of
+// bit-twiddling in their place.
 
 import { createClient, Pixmap, Picture } from '../lib/index.js';
 
@@ -46,17 +38,16 @@ const wnd = app.createWindow({
 });
 const ctx = wnd.getContext('2d');
 
-// ---------------------------------------------------------------------------
-// the icon scratch surface: depth 32, so alpha is real, and rgba32 so the
-// channel positions inside each CARD32 are fixed by RENDER rather than by
-// whatever visual the window happens to have
-// ---------------------------------------------------------------------------
+// The icon scratch surface. Depth 32 so alpha is real — the window itself is
+// depth 24 here, and a depth-24 drawable's fourth byte is padding rather than
+// opacity — and its context reads back as straight RGBA, which is exactly
+// what setIcon takes.
 const iconPixmap = new Pixmap(app, { depth: 32, width: ICON, height: ICON });
-const iconPicture = new Picture(app, { drawable: iconPixmap, format: Render.rgba32 });
+const iconCtx = iconPixmap.getContext('2d');
 
 // A round alpha mask, built here and uploaded once. Antialiased on purpose:
-// the partial alphas around the rim are what make the premultiply conversion
-// observable — get it wrong and the edge pixels come out too dark.
+// the partial alphas around the rim are what would look wrong if anything in
+// the chain forgot to un-premultiply, so they are worth having.
 const maskPixmap = new Pixmap(app, { depth: 8, width: ICON, height: ICON });
 const maskPicture = new Picture(app, { drawable: maskPixmap, format: Render.a8 });
 {
@@ -84,60 +75,12 @@ const maskPicture = new Picture(app, { drawable: maskPixmap, format: Render.a8 }
   X.PutImage(2, maskPixmap.id, gc8, ICON, ICON, 0, 0, 0, 8, mask);
 }
 
-// ---------------------------------------------------------------------------
-// XRender surface -> EWMH _NET_WM_ICON property bytes
-// ---------------------------------------------------------------------------
-/**
- * Pack a depth-32 GetImage reply into the `width, height, pixel...` CARD32
- * run `_NET_WM_ICON` wants. This is the function a real `setIcon()` would
- * own, and the reason item 5 is a decision rather than a patch.
- */
-function toIconProperty(img, width, height, display) {
-  const src = img.data;
-  const out = Buffer.allocUnsafe(8 + width * height * 4);
-
-  // (1) two different byte orders, and they are genuinely different fields:
-  // image_byte_order is the server's pixel order, byte_order is what this
-  // connection agreed to speak and therefore how the server will read the
-  // property back.
-  const readPixel = display.image_byte_order
-    ? (o) => src.readUInt32BE(o)
-    : (o) => src.readUInt32LE(o);
-  const writeWord = display.byte_order
-    ? (v, o) => out.writeUInt32BE(v, o)
-    : (v, o) => out.writeUInt32LE(v, o);
-
-  writeWord(width, 0);
-  writeWord(height, 4);
-
-  for (let i = 0; i < width * height; i++) {
-    const px = readPixel(i * 4);
-    // (2) fixed by Render.rgba32 (PictStandardARGB32), not by the visual
-    const a = (px >>> 24) & 0xff;
-    let r = (px >>> 16) & 0xff;
-    let g = (px >>> 8) & 0xff;
-    let b = px & 0xff;
-    // (3) XRender stores c*a; EWMH wants c. Fully transparent pixels carry
-    // no colour to recover, and clamping matters because a rounded-up
-    // premultiplied channel can exceed its own alpha.
-    if (a === 0) {
-      r = g = b = 0;
-    } else if (a < 255) {
-      r = Math.min(255, Math.round((r * 255) / a));
-      g = Math.min(255, Math.round((g * 255) / a));
-      b = Math.min(255, Math.round((b * 255) / a));
-    }
-    writeWord((((a << 24) | (r << 16) | (g << 8) | b) >>> 0), 8 + i * 4);
-  }
-  return out;
-}
-
-/** scale the pad into the icon surface, read it back, publish it */
+/** scale the pad into the icon surface and publish it */
 async function publishIcon() {
-  const src = ctx.picture; // the window's backing picture (depth 24 here)
+  const src = ctx.picture; // the window's backing picture
 
   // start from fully transparent so the mask's rim leaves real partial alpha
-  Render.FillRectangles(Render.PictOp.Src, iconPicture.id, [0, 0, 0, 0], [0, 0, ICON, ICON]);
+  Render.FillRectangles(Render.PictOp.Src, iconCtx.picture.id, [0, 0, 0, 0], [0, 0, ICON, ICON]);
 
   // dest pixel (i, j) samples (PAD_X + i*PAD/ICON, PAD_Y + j*PAD/ICON)
   Render.SetPictureTransform(src.id, [PAD / ICON, 0, PAD_X, 0, PAD / ICON, PAD_Y, 0, 0, 1]);
@@ -146,7 +89,7 @@ async function publishIcon() {
     Render.PictOp.Src,
     src.id,
     maskPicture.id,
-    iconPicture.id,
+    iconCtx.picture.id,
     0, 0, // src
     0, 0, // mask
     0, 0, // dst
@@ -155,17 +98,7 @@ async function publishIcon() {
   Render.SetPictureTransform(src.id, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
   src.setFilter('nearest');
 
-  const img = await new Promise((res, rej) =>
-    X.GetImage(2, iconPixmap.id, 0, 0, ICON, ICON, 0xffffffff, (e, i) => (e ? rej(e) : res(i)))
-  );
-  const data = toIconProperty(img, ICON, ICON, app.display);
-
-  // 128x128 is 65544 bytes of property data. Sizes from 256x256 up would
-  // overrun the classic 262140-byte request cap, but node-x11 turns on
-  // BIG-REQUESTS during handshake unless you pass `disableBigRequests`, so
-  // max_request_length here is 16 MB and even a full icon set fits in one go.
-  await wnd.setProperty('_NET_WM_ICON', data, { type: 'CARDINAL', format: 32 });
-  return data;
+  await wnd.setIcon(await iconCtx.getImageData(0, 0, ICON, ICON));
 }
 
 // ---------------------------------------------------------------------------
@@ -260,53 +193,37 @@ wnd.on('keydown', async (ev) => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// verification: read the property back off the server and decode it the way
-// a window manager would, so the conversion is checked rather than assumed
-// ---------------------------------------------------------------------------
-async function readBackIcon() {
-  const prop = await wnd.getProperty('_NET_WM_ICON');
-  if (!prop) return null;
-  const buf = prop.data;
-  const read = app.display.byte_order
-    ? (o) => buf.readUInt32BE(o)
-    : (o) => buf.readUInt32LE(o);
-  const w = read(0);
-  const h = read(4);
-  const rgba = Buffer.alloc(w * h * 4); // straight RGBA, what a decoder wants
-  for (let i = 0; i < w * h; i++) {
-    const px = read(8 + i * 4);
-    rgba[i * 4] = (px >>> 16) & 0xff;
-    rgba[i * 4 + 1] = (px >>> 8) & 0xff;
-    rgba[i * 4 + 2] = px & 0xff;
-    rgba[i * 4 + 3] = (px >>> 24) & 0xff;
-  }
-  return { width: w, height: h, data: rgba, words: buf.length / 4 };
-}
-
+/**
+ * Read the icon back off the server — the same call a window manager makes —
+ * and write it out, so the round trip is checked rather than assumed.
+ */
 async function savePublishedIcon(path) {
-  const { PNG } = await import('pngjs');
-  const icon = await readBackIcon();
-  if (!icon) {
+  const icons = await wnd.getIcon();
+  if (!icons) {
     console.log('no _NET_WM_ICON set yet');
     return null;
   }
-  const png = new PNG({ width: icon.width, height: icon.height });
-  icon.data.copy(png.data);
+  const { PNG } = await import('pngjs');
   const { writeFileSync } = await import('node:fs');
+  const icon = icons[0];
+  const png = new PNG({ width: icon.width, height: icon.height });
+  png.data.set(icon.data);
   writeFileSync(path, PNG.sync.write(png));
-  console.log(`wrote ${path} (${icon.width}x${icon.height}, ${icon.words} CARD32s)`);
+  console.log(`wrote ${path} (${icon.width}x${icon.height})`);
   return icon;
 }
 
 // ---------------------------------------------------------------------------
 paint();
-console.log(`window 0x${wnd.id.toString(16)} — image_byte_order=${app.display.image_byte_order} ` +
-  `connection byte_order=${app.display.byte_order} window depth=${wnd.depth || app.display.screen[0].root_depth}`);
+console.log(
+  `window 0x${wnd.id.toString(16)} — image_byte_order=${app.display.image_byte_order} ` +
+    `connection byte_order=${app.display.byte_order} ` +
+    `window depth=${wnd.depth || app.display.screen[0].root_depth}`
+);
 
 if (selftest) {
-  // a fixed pattern instead of the mouse: three strokes, one per primary, so
-  // the read-back can be checked against known colours
+  // a fixed pattern instead of the mouse: three strokes, so the read-back can
+  // be checked against known colours
   strokes.push([[PAD_X + 40, PAD_Y + 60], [PAD_X + 216, PAD_Y + 60]]);
   strokes.push([[PAD_X + 40, PAD_Y + 128], [PAD_X + 216, PAD_Y + 196]]);
   strokes.push([[PAD_X + 128, PAD_Y + 40], [PAD_X + 128, PAD_Y + 216]]);
@@ -315,7 +232,6 @@ if (selftest) {
   await publishIcon();
   const icon = await savePublishedIcon('/tmp/ntk-wm-icon.png');
 
-  // spot checks against what was drawn
   const at = (x, y) => {
     const o = (y * icon.width + x) * 4;
     return [icon.data[o], icon.data[o + 1], icon.data[o + 2], icon.data[o + 3]];
@@ -329,10 +245,10 @@ if (selftest) {
   console.log('paper  (expect ~251,241,199,255):', paper);
   console.log('corner (expect 0,0,0,0):', corner);
 
-  // The premultiply check, and the only one that would notice conversion (3)
-  // being skipped. Find a rim pixel with partial alpha and compare it to the
-  // opaque pixel 8px further in along the same radius: un-premultiplied they
-  // are the same colour, premultiplied the rim is scaled down by its alpha.
+  // The premultiply check, and the only one that would notice the alpha
+  // conversion being skipped. Find a rim pixel with partial alpha and compare
+  // it to the opaque pixel 8px further in along the same radius: straight
+  // they are the same colour, premultiplied the rim is scaled by its alpha.
   const c = (ICON - 1) / 2;
   let rim = null;
   let inner = null;
@@ -341,9 +257,7 @@ if (selftest) {
       const p = at(x, y);
       if (p[3] < 60 || p[3] > 200) continue;
       const len = Math.hypot(x - c, y - c) || 1;
-      const ix = Math.round(x - ((x - c) / len) * 8);
-      const iy = Math.round(y - ((y - c) / len) * 8);
-      const q = at(ix, iy);
+      const q = at(Math.round(x - ((x - c) / len) * 8), Math.round(y - ((y - c) / len) * 8));
       if (q[3] !== 255) continue;
       rim = p;
       inner = q;

--- a/lib/imagedata.js
+++ b/lib/imagedata.js
@@ -284,3 +284,105 @@ export class ImageData {
     return 'srgb';
   }
 }
+
+// --- EWMH _NET_WM_ICON -----------------------------------------------------
+//
+// The property is a run of CARD32s, repeated once per size:
+//
+//   width, height, pixel[0] … pixel[width*height-1]
+//
+// Each pixel is straight ARGB inside the word — A=24 R=16 G=8 B=0. Straight,
+// not premultiplied, which is the same thing ImageData holds, so this is a
+// repack rather than a conversion. The one thing to get right is which byte
+// order: a format-32 property is read back by the server in the *connection's*
+// byte order, which is a different handshake field from the image_byte_order
+// that `pixelLayout()` uses for GetImage.
+
+const wordIO = (display) =>
+  display.byte_order
+    ? { read: (b, o) => b.readUInt32BE(o), write: (b, v, o) => b.writeUInt32BE(v, o) }
+    : { read: (b, o) => b.readUInt32LE(o), write: (b, v, o) => b.writeUInt32LE(v, o) };
+
+/**
+ * Pack one or more images into `_NET_WM_ICON` property bytes.
+ *
+ * @param {Array<{width: number, height: number, data: Uint8Array}>} images
+ *   straight RGBA, as `Image` and `ImageData` both are
+ * @param {object} display
+ * @returns {Buffer}
+ */
+export function packIcons(images, display) {
+  let words = 0;
+  images.forEach((img, i) => {
+    const { width, height, data } = img ?? {};
+    if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+      throw new Error(`icon ${i}: width and height must be positive integers`);
+    }
+    if (!data || data.length !== width * height * 4) {
+      throw new Error(
+        `icon ${i}: data must be ${width * height * 4} RGBA bytes for ${width}x${height}, ` +
+          `got ${data ? data.length : 'nothing'}`
+      );
+    }
+    words += 2 + width * height;
+  });
+
+  const out = Buffer.allocUnsafe(words * 4);
+  const { write } = wordIO(display);
+  let o = 0;
+  for (const { width, height, data } of images) {
+    write(out, width, o);
+    write(out, height, o + 4);
+    o += 8;
+    for (let i = 0; i < width * height; i++) {
+      write(
+        out,
+        (((data[i * 4 + 3] << 24) |
+          (data[i * 4] << 16) |
+          (data[i * 4 + 1] << 8) |
+          data[i * 4 + 2]) >>>
+          0),
+        o
+      );
+      o += 4;
+    }
+  }
+  return out;
+}
+
+/**
+ * Read `_NET_WM_ICON` bytes back into images.
+ *
+ * Deliberately forgiving about what it is handed: a window manager runs this
+ * over properties written by other people's clients, so a truncated or
+ * nonsensical run stops the scan and returns whatever parsed cleanly rather
+ * than throwing or trying to allocate a claimed 4-gigapixel icon.
+ *
+ * @returns {ImageData[]}
+ */
+export function unpackIcons(buf, display) {
+  const { read } = wordIO(display);
+  const out = [];
+  let o = 0;
+  while (o + 8 <= buf.length) {
+    const width = read(buf, o);
+    const height = read(buf, o + 4);
+    // guard the multiplication itself, not just its result
+    if (width <= 0 || height <= 0 || width > 0xffff || height > 0xffff) break;
+    const pixels = width * height;
+    if (o + 8 + pixels * 4 > buf.length) break;
+    o += 8;
+
+    const rgba = new Uint8ClampedArray(pixels * 4);
+    for (let i = 0; i < pixels; i++) {
+      const px = read(buf, o + i * 4);
+      rgba[i * 4] = (px >>> 16) & 0xff;
+      rgba[i * 4 + 1] = (px >>> 8) & 0xff;
+      rgba[i * 4 + 2] = px & 0xff;
+      rgba[i * 4 + 3] = (px >>> 24) & 0xff;
+    }
+    o += pixels * 4;
+    out.push(new ImageData(rgba, width, height));
+  }
+  return out;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,14 @@ import { decodeKey, groupForState } from './keyboard.js';
 import Pixmap from './pixmap.js';
 import Picture from './picture.js';
 import { Image, decodeImage, loadImage } from './image.js';
-import { ImageData, fromStraightRgba, pixelLayout, toStraightRgba } from './imagedata.js';
+import {
+  ImageData,
+  fromStraightRgba,
+  packIcons,
+  pixelLayout,
+  toStraightRgba,
+  unpackIcons
+} from './imagedata.js';
 import { Path2D, parseSvgPath } from './path.js';
 import Font from './text/font.js';
 import FontManager from './text/fontmanager.js';
@@ -155,6 +162,8 @@ export {
   pixelLayout,
   toStraightRgba,
   fromStraightRgba,
+  packIcons,
+  unpackIcons,
   decodeImage,
   loadImage,
   Path2D,

--- a/lib/window.js
+++ b/lib/window.js
@@ -2,6 +2,7 @@ import x11 from 'x11';
 
 import { safeRelease } from './cleanup.js';
 import Drawable from './drawable.js';
+import { packIcons, unpackIcons } from './imagedata.js';
 import Pixmap from './pixmap.js';
 import * as xevents from './events_map.js';
 import { decodeKey } from './keyboard.js';
@@ -431,6 +432,11 @@ export default class Window extends Drawable {
     }
     if (args.windowType) {
       this.setWindowType(args.windowType);
+    }
+    if (args.icon) {
+      // needs the atom interned first, so unlike the writers above it is not
+      // on the wire by the time createWindow returns
+      this.setIcon(args.icon).catch((err) => app.options.onXError?.(err));
     }
     // ICCCM/EWMH hints at creation: `hints: { ... }`, the `sizeHints`/
     // `resizable` arguments that predate it, or the hint names on their own
@@ -1526,6 +1532,82 @@ export default class Window extends Drawable {
         X.ChangeProperty(0, this.id, atoms._NET_WM_PID, X.atoms.CARDINAL, 32, [id]);
       });
     });
+  }
+
+  /**
+   * EWMH `_NET_WM_ICON` — the icon a taskbar, alt-tab switcher or titlebar
+   * draws for this window.
+   *
+   *   wnd.setIcon(await loadImage('icon-48.png'));
+   *   wnd.setIcon([icon16, icon32, icon48]);
+   *   wnd.setIcon(await ctx.getImageData(0, 0, 64, 64));
+   *   wnd.setIcon(null);            // remove it
+   *
+   * An image is an ntk [`Image`](images.md), an `ImageData`, or anything
+   * with `{ width, height, data }` where `data` is straight
+   * (non-premultiplied) RGBA — the same contract as the rest of ntk, so
+   * whatever `loadImage()` or `getImageData()` gives you goes straight in.
+   *
+   * Passing several is the useful case: supply the sizes you have and the
+   * window manager picks whichever suits the slot it is filling, instead of
+   * scaling a single one badly. Nothing requires a particular order or a
+   * particular set of sizes; 16, 32 and 48 cover most desktops.
+   *
+   * This is the modern mechanism. `setWmHints({ icon })` writes the ICCCM
+   * pixmap instead, which is 1-bit-or-matched-depth and has no alpha; a
+   * window manager that understands both prefers this one.
+   *
+   * @param {object|object[]|null} images
+   * @returns {Promise<Window>}
+   */
+  async setIcon(images) {
+    const list = images == null ? [] : Array.isArray(images) ? images : [images];
+    if (!list.length) return this.deleteProperty('_NET_WM_ICON');
+
+    const data = packIcons(list, this.app.display);
+    const property = await this.atom('_NET_WM_ICON');
+    const cardinal = this.X.atoms.CARDINAL;
+    if (this._destroyed) return this;
+
+    // A ChangeProperty carries 24 bytes of header, so a full icon set can
+    // outrun the request limit on a connection created with
+    // `disableBigRequests` — 256x256 alone is 262152 bytes against a 262140
+    // cap. Replace with the first chunk, append the rest.
+    const maxBytes = ((this.app.display.max_request_length ?? 65535) - 6) * 4;
+    safeRelease(this.X, () => {
+      for (let o = 0; o < data.length; o += maxBytes) {
+        this.X.ChangeProperty(
+          o === 0 ? 0 : 2, // Replace, then Append
+          this.id,
+          property,
+          cardinal,
+          32,
+          data.subarray(o, Math.min(o + maxBytes, data.length))
+        );
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Read `_NET_WM_ICON` back — every size the window advertises, largest
+   * last or in whatever order its client wrote them, as `ImageData`.
+   *
+   * Useful on your own window, and the point of it on someone else's: a
+   * window manager drawing titlebars reads this off each client it frames.
+   * Property bytes from another client are not to be trusted, so a
+   * truncated or nonsensical run yields the images that parsed cleanly
+   * rather than throwing.
+   *
+   * Resolves to `null` when the window has no icon.
+   *
+   * @returns {Promise<ImageData[]|null>}
+   */
+  async getIcon() {
+    const prop = await this.getProperty('_NET_WM_ICON');
+    if (!prop || !prop.data.length) return null;
+    const icons = unpackIcons(prop.data, this.app.display);
+    return icons.length ? icons : null;
   }
 
   /** os.hostname(), looked up once, and absent in a browser bundle. */

--- a/test/icon.test.js
+++ b/test/icon.test.js
@@ -1,0 +1,278 @@
+// _NET_WM_ICON: setIcon/getIcon, and the packing underneath them.
+//
+// Hermetic — node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from 'node:assert/strict';
+import { after, before, describe, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, Image, ImageData, StaticFontSource } from '../lib/index.js';
+import { packIcons, unpackIcons } from '../lib/imagedata.js';
+
+// --- packing ---------------------------------------------------------------
+
+const lsb = { byte_order: 0 };
+const msb = { byte_order: 1 };
+
+/** a w*h image whose pixels are a recognisable function of their index */
+function ramp(w, h) {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = i & 0xff;
+    data[i * 4 + 1] = (i * 3) & 0xff;
+    data[i * 4 + 2] = (i * 7) & 0xff;
+    data[i * 4 + 3] = 255 - (i & 0x7f);
+  }
+  return { width: w, height: h, data };
+}
+
+describe('packIcons', () => {
+  test('lays out width, height, then ARGB pixels', () => {
+    const img = { width: 1, height: 1, data: new Uint8ClampedArray([0x11, 0x22, 0x33, 0x44]) };
+    const buf = packIcons([img], lsb);
+    assert.equal(buf.length, 12);
+    assert.equal(buf.readUInt32LE(0), 1);
+    assert.equal(buf.readUInt32LE(4), 1);
+    // A=0x44 R=0x11 G=0x22 B=0x33
+    assert.equal(buf.readUInt32LE(8) >>> 0, 0x44112233);
+  });
+
+  test('several images concatenate, each with its own header', () => {
+    const buf = packIcons([ramp(2, 2), ramp(4, 1)], lsb);
+    assert.equal(buf.length, (2 + 4) * 4 + (2 + 4) * 4);
+    assert.equal(buf.readUInt32LE(0), 2);
+    assert.equal(buf.readUInt32LE(4), 2);
+    assert.equal(buf.readUInt32LE(24), 4, 'second image width follows the first image');
+    assert.equal(buf.readUInt32LE(28), 1);
+  });
+
+  test('alpha is straight, not premultiplied', () => {
+    // a fully saturated red at half alpha stays 0xff in the red byte
+    const img = { width: 1, height: 1, data: new Uint8ClampedArray([255, 0, 0, 128]) };
+    const px = packIcons([img], lsb).readUInt32LE(8) >>> 0;
+    assert.equal((px >>> 24) & 0xff, 128);
+    assert.equal((px >>> 16) & 0xff, 255, 'premultiplying would have made this 128');
+  });
+
+  test('the connection byte order decides, and really is used', () => {
+    const img = { width: 1, height: 1, data: new Uint8ClampedArray([0x11, 0x22, 0x33, 0x44]) };
+    assert.deepEqual([...packIcons([img], lsb).subarray(8)], [0x33, 0x22, 0x11, 0x44]);
+    assert.deepEqual([...packIcons([img], msb).subarray(8)], [0x44, 0x11, 0x22, 0x33]);
+  });
+
+  test('a wrong-sized data buffer is rejected, naming which image', () => {
+    assert.throws(
+      () => packIcons([ramp(2, 2), { width: 4, height: 4, data: new Uint8ClampedArray(8) }], lsb),
+      /icon 1: data must be 64 RGBA bytes/
+    );
+  });
+
+  test('a bad size is rejected', () => {
+    assert.throws(() => packIcons([{ width: 0, height: 4, data: new Uint8ClampedArray(0) }], lsb),
+      /icon 0: width and height must be positive/);
+  });
+});
+
+describe('unpackIcons', () => {
+  for (const [name, display] of [['LSBFirst', lsb], ['MSBFirst', msb]]) {
+    test(`${name}: round-trips every image and pixel`, () => {
+      const images = [ramp(3, 5), ramp(8, 8)];
+      const back = unpackIcons(packIcons(images, display), display);
+      assert.equal(back.length, 2);
+      back.forEach((got, i) => {
+        assert.equal(got.width, images[i].width);
+        assert.equal(got.height, images[i].height);
+        assert.deepEqual([...got.data], [...images[i].data]);
+      });
+      assert.ok(back[0] instanceof ImageData);
+    });
+  }
+
+  test('a truncated run yields what parsed rather than throwing', () => {
+    // a window manager reads this off other people's windows
+    const buf = packIcons([ramp(2, 2), ramp(4, 4)], lsb);
+    const cut = buf.subarray(0, 24 + 8 + 16); // all of the first, part of the second
+    const back = unpackIcons(cut, lsb);
+    assert.equal(back.length, 1);
+    assert.equal(back[0].width, 2);
+  });
+
+  test('an absurd claimed size stops the scan instead of allocating', () => {
+    const buf = Buffer.alloc(16);
+    buf.writeUInt32LE(0xfffffff, 0); // width
+    buf.writeUInt32LE(0xfffffff, 4);
+    assert.deepEqual(unpackIcons(buf, lsb), []);
+  });
+
+  test('a zero dimension stops the scan', () => {
+    const buf = Buffer.alloc(16);
+    assert.deepEqual(unpackIcons(buf, lsb), []);
+  });
+
+  test('trailing bytes too short for a header are ignored', () => {
+    const buf = Buffer.concat([packIcons([ramp(2, 2)], lsb), Buffer.alloc(5)]);
+    assert.equal(unpackIcons(buf, lsb).length, 1);
+  });
+});
+
+// --- against the in-process X server ----------------------------------------
+
+let app = null;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+describe('setIcon / getIcon', () => {
+  test('a single image round-trips through the server', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    const icon = ramp(8, 8);
+    await wnd.setIcon(icon);
+
+    const back = await wnd.getIcon();
+    assert.equal(back.length, 1);
+    assert.equal(back[0].width, 8);
+    assert.deepEqual([...back[0].data], [...icon.data]);
+    wnd.destroy();
+  });
+
+  test('the property is CARDINAL/32 and the right length', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await wnd.setIcon(ramp(16, 16));
+
+    const prop = await wnd.getProperty('_NET_WM_ICON');
+    assert.equal(prop.type, app.X.atoms.CARDINAL, 'window managers check the type');
+    assert.equal(prop.data.length, (2 + 16 * 16) * 4);
+    wnd.destroy();
+  });
+
+  test('several sizes are written as one property', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await wnd.setIcon([ramp(16, 16), ramp(32, 32), ramp(48, 48)]);
+
+    const back = await wnd.getIcon();
+    assert.deepEqual(back.map((i) => i.width), [16, 32, 48]);
+    wnd.destroy();
+  });
+
+  test('an ntk Image goes straight in', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    const { width, height, data } = ramp(4, 4);
+    await wnd.setIcon(new Image({ width, height, data: Buffer.from(data) }));
+
+    const back = await wnd.getIcon();
+    assert.deepEqual([...back[0].data], [...data]);
+    wnd.destroy();
+  });
+
+  test('an ImageData from getImageData goes straight in', async () => {
+    // the composition the format alignment was for: draw, read, publish
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    const ctx = app.createPixmap({ width: 8, height: 8, depth: 24 }).getContext('2d');
+    ctx.fillStyle = 'rgb(10, 20, 30)';
+    ctx.fillRect(0, 0, 8, 8);
+
+    await wnd.setIcon(await ctx.getImageData(0, 0, 8, 8));
+
+    const back = await wnd.getIcon();
+    assert.deepEqual([...back[0].data.slice(0, 4)], [10, 20, 30, 255]);
+    wnd.destroy();
+  });
+
+  test('setIcon(null) removes the property rather than blanking it', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await wnd.setIcon(ramp(4, 4));
+    assert.ok(await wnd.getIcon());
+
+    await wnd.setIcon(null);
+    assert.equal(await wnd.getProperty('_NET_WM_ICON'), null, 'reads back as type None');
+    assert.equal(await wnd.getIcon(), null);
+    wnd.destroy();
+  });
+
+  test('an empty array removes it too', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await wnd.setIcon(ramp(4, 4));
+    await wnd.setIcon([]);
+    assert.equal(await wnd.getIcon(), null);
+    wnd.destroy();
+  });
+
+  test('setting again replaces rather than appending', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await wnd.setIcon([ramp(8, 8), ramp(16, 16)]);
+    await wnd.setIcon(ramp(4, 4));
+
+    const back = await wnd.getIcon();
+    assert.deepEqual(back.map((i) => i.width), [4]);
+    wnd.destroy();
+  });
+
+  test('getIcon is null on a window that never set one', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    assert.equal(await wnd.getIcon(), null);
+    wnd.destroy();
+  });
+
+  test('createWindow({ icon }) writes it', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40, icon: ramp(8, 8) });
+    // interning the atom defers the write, so give it a tick
+    await new Promise((r) => setTimeout(r, 20));
+    const back = await wnd.getIcon();
+    assert.equal(back.length, 1);
+    assert.equal(back[0].width, 8);
+    wnd.destroy();
+  });
+
+  test('a bad image throws before anything reaches the server', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await assert.rejects(
+      () => wnd.setIcon({ width: 4, height: 4, data: new Uint8ClampedArray(8) }),
+      /data must be 64 RGBA bytes/
+    );
+    assert.equal(await wnd.getProperty('_NET_WM_ICON'), null, 'nothing was written');
+    wnd.destroy();
+  });
+
+  test('an icon too big for one request is split and still reads back whole', async () => {
+    // node-x11 turns on BIG-REQUESTS during handshake, so the split only
+    // happens on a connection that opted out — which is the configuration
+    // this path exists for. 256x256 is 262152 bytes against a 262140 cap.
+    const server = xserver.createServer({ width: 200, height: 200 });
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    const small = await createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+      disableBigRequests: true
+    });
+    try {
+      assert.ok(
+        small.display.max_request_length <= 0xffff,
+        `expected the classic cap, got ${small.display.max_request_length}`
+      );
+      const wnd = small.createWindow({ width: 40, height: 40 });
+      const big = ramp(256, 256);
+      assert.ok(
+        (2 + 256 * 256) * 4 > small.display.max_request_length * 4 - 24,
+        'this icon has to overrun a single request or the test proves nothing'
+      );
+      await wnd.setIcon(big);
+
+      const back = await wnd.getIcon();
+      assert.equal(back.length, 1, 'one image, not one per chunk');
+      assert.equal(back[0].width, 256);
+      assert.deepEqual([...back[0].data], [...big.data]);
+      wnd.destroy();
+    } finally {
+      await small.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #118 — the last of its six items. Five landed in #130 and #131; item 5 was held back because it was a pixel-format decision rather than a missing writer. That decision was #151, implemented in #153, and with `getImageData` and `Image` both speaking straight RGBA there is no format left for `setIcon` to choose. It takes what the rest of ntk already produces.

```js
const icon48 = await loadImage('icon-48.png');
wnd.setIcon(icon48);
wnd.setIcon([icon16, icon32, icon48]);
const drawn = await ctx.getImageData(0, 0, 64, 64); // draw your own
wnd.setIcon(drawn);
wnd.setIcon(null);                                  // remove it
app.createWindow({ icon: icon48 });
```

An image is an ntk `Image`, an `ImageData`, or anything with `{ width, height, data }` in straight RGBA. Several sizes is the useful case — the window manager picks whichever fits the slot it is filling rather than scaling one badly. Writing again replaces the set; `setIcon(null)` or `[]` **deletes** the property rather than writing an empty one, which is the distinction a window manager actually reads.

`getIcon()` reads it back as `ImageData[]`, or `null`. That is mostly the window-manager side — a frame drawing its own titlebars reads this off each client it manages, which is the use case the issue cited from react-x11 — so it treats the bytes as untrusted: a truncated or nonsensical run yields whatever parsed cleanly instead of throwing or trying to allocate a claimed four-gigapixel icon.

### Details worth a look in review

- **Byte order.** `packIcons`/`unpackIcons` sit in `lib/imagedata.js` with the other pixel packing. The one thing they must get right is that a format-32 property is read back by the server in the **connection's** byte order — a different handshake field from the `image_byte_order` that `pixelLayout()` uses for `GetImage`. Both orders are exercised, including an assertion that they really do produce different bytes.
- **Oversized sets.** A full icon set can outrun the request limit on a connection created with `disableBigRequests` — 256×256 alone is 262152 bytes against a 262140 cap — so the write splits into `Replace` followed by `Append`. Tested against a client that opts out, since node-x11 enables BIG-REQUESTS by default and the path would otherwise never run.
- **Validation happens before anything is sent**, so a bad image throws without leaving a half-written property behind. There is a test for exactly that.

### The example

`examples/wm-icon.js` (added in #150 as the proof of concept) now goes through the public API and **loses thirty lines of bit-twiddling**, which is the clearest statement of what #153 bought:

```js
// composite the pad into a depth-32 pixmap, then:
const pixels = await iconCtx.getImageData(0, 0, ICON, ICON);
await wnd.setIcon(pixels);
```

All three conversions between an XRender surface and an EWMH icon — the server's `image_byte_order`, the visual's channel masks, and premultiplied versus straight alpha — now happen inside ntk. Its `--selftest` produces numbers identical to the hand-rolled version:

```
centre (expect ~204,36,29,255): [ 204, 36, 29, 255 ]
paper  (expect ~251,241,199,255): [ 251, 241, 199, 255 ]
corner (expect 0,0,0,0): [ 0, 0, 0, 0 ]
rim    (partial alpha): [ 251, 239, 199, 64 ]  8px inward (opaque): [ 251, 241, 199, 255 ]
  straight (what EWMH wants) ~ 251,241,199
  premultiplied would be     ~ 63,60,50

SELFTEST PASS
```

### Tests

516 pass (492 before, 24 new in `test/icon.test.js`) against node-x11's in-process pure-JS X server, plus the example verified against XQuartz.

### Caveat

Same one as #150: XQuartz's window manager does not render `_NET_WM_ICON`, so correctness here is established by reading the property back and decoding it. Still wants one run under a real EWMH window manager to confirm an icon visibly appears.
