### PR TITLE
feat: a cancellable 'close' event for WM_DELETE_WINDOW

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -256,7 +256,8 @@ All return `this` unless noted.
   `removeWmState(names)` / `getWmStates()` — EWMH `_NET_WM_STATE`:
   fullscreen, maximized, skip-taskbar and the rest. Promises
 - `addProtocol(name)` / `removeProtocol(name)` / `setProtocols(names)` /
-  `getProtocols()` — WM_PROTOCOLS, returning promises; `setActions()` is the
+  `getProtocols()` — WM_PROTOCOLS, returning promises. For
+  `WM_DELETE_WINDOW`, `on('close')` opts in for you; `setActions()` is the
   older spelling of `addProtocol('WM_DELETE_WINDOW')`
 - `getProperty(name, options)`, `setProperty(name, value, options)`,
   `deleteProperty(name)`, `getTitle()`, `getSizeHints()`, `getWmHints()`,
@@ -340,11 +341,14 @@ Writes ICCCM `WM_PROTOCOLS`: the messages this window is willing to
 receive, each arriving as a `message` event.
 
 ```js
-await wnd.addProtocol('WM_DELETE_WINDOW'); // close button asks instead of killing
 await wnd.addProtocol('WM_TAKE_FOCUS');
 
 app.createWindow({ protocols: ['WM_DELETE_WINDOW'] });
 ```
+
+For `WM_DELETE_WINDOW` specifically there is no need to do this by hand:
+listening for [`close`](#closing--onclose-ev--evpreventdefault) advertises
+it for you.
 
 The property is a **set**, so these are read-modify-write and return
 promises: `addProtocol`, `removeProtocol`, `setProtocols(names)` to replace
@@ -355,6 +359,46 @@ adds are serialized, so two in the same tick both land.
 It used to write the property as a list of exactly one atom, so the next
 protocol added by any means erased it and the close button quietly stopped
 working — that is the bug the set-based API exists to prevent.
+
+### Closing — `on('close', ev => ev.preventDefault())`
+
+When the user hits the close button, a window manager does not close the
+window: it asks the client to, with a `WM_DELETE_WINDOW` message, and only
+kills the connection outright if the client never said it wanted to be
+asked. `close` is that question.
+
+```js
+wnd.on('close', (ev) => {
+  if (unsaved) {
+    ev.preventDefault();  // stay open
+    showSaveDialog();
+  }
+});
+```
+
+Listening is the opt-in — the handler is registered and `WM_PROTOCOLS` gains
+`WM_DELETE_WINDOW` in the same act, so there is nothing else to call and
+nothing to get wrong. Other protocols already on the window are kept.
+
+If no handler calls `preventDefault()`, the default action runs and the
+window is destroyed, which is what an application that just wants to save
+some state on the way out should want. `preventDefault()` has to be called
+**synchronously** — there is no point at which the answer could be awaited,
+so a handler that needs to ask the user declines first and closes later, by
+calling `destroy()` itself.
+
+The web parallel is close enough to be worth naming, and so is the
+difference: `beforeunload` can no longer really be cancelled by script,
+whereas declining `WM_DELETE_WINDOW` is completely normal — an
+unsaved-changes dialog is exactly this.
+
+A window with no `close` listener behaves as it always did: the request
+arrives as a raw `message` event and nothing happens to the window unless
+the application acts. When both are listened for, `message` fires first.
+
+Note the deliberate symmetry with the window-manager side: a frame calls
+[`client.close()`](#closing-and-focusing) to ask, and the application on the
+other end gets this event.
 
 ### Input model, urgency, icon — `setWmHints(hints)`
 
@@ -739,6 +783,7 @@ constructor arg) automatically extends the window's X event mask.
 | `destroy` | DestroyNotify | wrapper is removed from the cache |
 | `map_request`, `configure_request` | SubstructureRedirect | for window managers |
 | `statechange` | PropertyNotify | derived, not an X event: the window manager changed `_NET_WM_STATE`. The handler gets the state names, not an event object — see [Window states](#window-states--setwmstatenames-action) |
+| `close` | ClientMessage | the window manager asking this window to close. `ev.preventDefault()` declines; see [Closing](#closing--onclose-ev--evpreventdefault) |
 | `property`, `reparent`, `message`, `selection*` | | |
 
 Every event object gets `ev.window` and `ev.target` set to the `Window`.

--- a/lib/window.js
+++ b/lib/window.js
@@ -505,6 +505,9 @@ export default class Window extends Drawable {
       // them in the order they happened (a drag sees the move, then the up)
       this._flushCoalesced();
       this.emit(eventName, ntkev);
+      // a WM_DELETE_WINDOW ClientMessage is the window manager *asking*, and
+      // 'close' is that question in a form an application can answer
+      if (eventName === 'message') this._emitCloseRequest(ntkev);
       // anything drawn during the handlers becomes visible in one blit
       if (this._dirty) this._present();
     });
@@ -527,6 +530,18 @@ export default class Window extends Drawable {
     });
 
     this.on('newListener', (name) => {
+      // Listening for 'close' is the opt-in. WM_DELETE_WINDOW only reaches a
+      // client that advertised it in WM_PROTOCOLS — a window manager kills
+      // anyone else outright — and having to know that, on top of decoding a
+      // ClientMessage by hand, is the protocol showing through the toolkit.
+      if (name === 'close' && !this._closeArmed) {
+        this._closeArmed = true;
+        // interning WM_PROTOCOLS here as well as in addProtocol: the
+        // dispatch path matches against both atoms and node-x11 caches them
+        // per connection, so this costs one round trip and no more
+        this.atom('WM_PROTOCOLS').catch(() => {});
+        this.addProtocol('WM_DELETE_WINDOW').catch((err) => this.app.options.onXError?.(err));
+      }
       // 'statechange' is derived from a PropertyNotify, so it needs the atom
       // to compare against as well as the mask the table below selects
       if (name === 'statechange' && !this._netWmStateAtom) {
@@ -1414,6 +1429,9 @@ export default class Window extends Drawable {
    * ICCCM WM_PROTOCOLS — the messages this window is willing to receive, by
    * atom name: `'WM_DELETE_WINDOW'`, `'WM_TAKE_FOCUS'`, `'_NET_WM_PING'`,
    * `'_NET_WM_SYNC_REQUEST'`. Each arrives as a `'message'` event.
+   *
+   * `WM_DELETE_WINDOW` needs none of this by hand: listening for the
+   * `'close'` event adds the protocol and decodes the message for you.
    *
    * Replaces the whole list. `addProtocol`/`removeProtocol` are the
    * accumulating forms, and the ones to reach for: the property is a *set*,
@@ -2361,6 +2379,42 @@ export default class Window extends Drawable {
   setActions() {
     this.addProtocol('WM_DELETE_WINDOW').catch((err) => this.app.options.onXError?.(err));
     return this;
+  }
+
+  /**
+   * Turn a WM_DELETE_WINDOW ClientMessage into the `close` event.
+   *
+   * Only fires when something is listening, so a window that handles the
+   * raw `message` event itself — the only way to do this before `close`
+   * existed — keeps behaving exactly as it did, rather than suddenly
+   * acquiring a second handler that destroys it.
+   */
+  _emitCloseRequest(ev) {
+    if (ev.format !== 32 || !this.listenerCount('close')) return;
+    // node-x11 caches interned atoms per connection, so these are the ids
+    // the 'close' listener's addProtocol already interned
+    const X = this.X;
+    if (!X.atoms.WM_PROTOCOLS || ev.message_type !== X.atoms.WM_PROTOCOLS) return;
+    if (!X.atoms.WM_DELETE_WINDOW || ev.data?.[0] !== X.atoms.WM_DELETE_WINDOW) return;
+
+    let prevented = false;
+    this.emit('close', {
+      name: 'close',
+      window: this,
+      target: this,
+      // the timestamp the window manager stamped the request with, for
+      // passing back to setInputFocus and friends
+      time: ev.data[1],
+      preventDefault() {
+        prevented = true;
+      },
+      get defaultPrevented() {
+        return prevented;
+      }
+    });
+    // the default action, and the reason preventDefault has to be called
+    // synchronously: there is no point at which it could be awaited
+    if (!prevented && !this._destroyed) this.destroy();
   }
 
   destroy() {

--- a/test/close-event.test.js
+++ b/test/close-event.test.js
@@ -1,0 +1,223 @@
+// The 'close' event: WM_DELETE_WINDOW as a question an application can
+// answer, rather than a ClientMessage it has to decode.
+//
+// Both sides are exercised for real — a second client on the same in-process
+// server plays the window manager and calls `close()`, so the protocol runs
+// end to end rather than being simulated by emitting the event by hand.
+import assert from 'node:assert/strict';
+import { after, before, describe, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource, Window } from '../lib/index.js';
+
+let server = null;
+let app = null; // the application
+let wm = null; // a second client, playing the window manager
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+before(async () => {
+  server = xserver.createServer({ width: 200, height: 200 });
+  const mk = async () => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+  };
+  app = await mk();
+  wm = await mk();
+});
+
+after(async () => {
+  if (app) await app.close();
+  if (wm) await wm.close();
+});
+
+/** a window with a 'close' listener, and the wm's handle on the same id */
+async function pair(onClose) {
+  const wnd = app.createWindow({ width: 40, height: 40 });
+  wnd.on('close', onClose);
+  await sleep(30); // let addProtocol's read-modify-write reach the server
+  return { wnd, asWm: new Window(wm, { id: wnd.id }) };
+}
+
+describe("on('close')", () => {
+  test('listening advertises WM_DELETE_WINDOW without being asked', async () => {
+    // the ergonomics point: opting in is the same act as handling it
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    assert.equal(await wnd.getProperty('WM_PROTOCOLS'), null, 'nothing advertised yet');
+
+    wnd.on('close', () => {});
+    await sleep(30);
+
+    const protocols = await wnd.getProperty('WM_PROTOCOLS', { as: 'numbers' });
+    const del = await wnd.atom('WM_DELETE_WINDOW');
+    assert.ok(protocols.includes(del));
+    wnd.destroy();
+  });
+
+  test('a second listener does not rewrite the property', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    wnd.on('close', () => {});
+    wnd.on('close', () => {});
+    await sleep(30);
+    const protocols = await wnd.getProperty('WM_PROTOCOLS', { as: 'numbers' });
+    assert.equal(protocols.length, 1, 'one atom, not one per listener');
+    wnd.destroy();
+  });
+
+  test('other protocols the window declared survive', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await wnd.addProtocol('WM_TAKE_FOCUS');
+    wnd.on('close', () => {});
+    await sleep(30);
+
+    const protocols = await wnd.getProperty('WM_PROTOCOLS', { as: 'numbers' });
+    assert.equal(protocols.length, 2);
+    assert.ok(protocols.includes(await wnd.atom('WM_TAKE_FOCUS')));
+    assert.ok(protocols.includes(await wnd.atom('WM_DELETE_WINDOW')));
+    wnd.destroy();
+  });
+
+  test('a window manager asking politely fires it', async () => {
+    let fired = 0;
+    const { wnd, asWm } = await pair(() => fired++);
+
+    assert.equal(await asWm.close(), true, 'asked rather than killed');
+    await sleep(30);
+    assert.equal(fired, 1);
+  });
+
+  test('the default action is to destroy the window', async () => {
+    const { wnd, asWm } = await pair(() => {});
+    await asWm.close();
+    await sleep(30);
+    assert.equal(wnd._destroyed, true);
+  });
+
+  test('preventDefault keeps the window alive', async () => {
+    // an unsaved-changes dialog is exactly this, and unlike beforeunload on
+    // the web, declining is entirely normal here
+    let asked = 0;
+    const { wnd, asWm } = await pair((ev) => {
+      asked++;
+      ev.preventDefault();
+    });
+
+    await asWm.close();
+    await sleep(30);
+    assert.equal(asked, 1);
+    assert.equal(wnd._destroyed, false, 'still open');
+
+    // and asking again still works — declining is not a one-off
+    await asWm.close();
+    await sleep(30);
+    assert.equal(asked, 2);
+    assert.equal(wnd._destroyed, false);
+    wnd.destroy();
+  });
+
+  test('defaultPrevented reports what happened', async () => {
+    const seen = [];
+    const { wnd, asWm } = await pair((ev) => {
+      seen.push(ev.defaultPrevented);
+      ev.preventDefault();
+      seen.push(ev.defaultPrevented);
+    });
+    await asWm.close();
+    await sleep(30);
+    assert.deepEqual(seen, [false, true]);
+    wnd.destroy();
+  });
+
+  test('one listener vetoing is enough', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    wnd.on('close', () => {}); // indifferent
+    wnd.on('close', (ev) => ev.preventDefault()); // objects
+    await sleep(30);
+
+    await new Window(wm, { id: wnd.id }).close();
+    await sleep(30);
+    assert.equal(wnd._destroyed, false);
+    wnd.destroy();
+  });
+
+  test('the event carries the timestamp the request was stamped with', async () => {
+    let ev = null;
+    const { wnd, asWm } = await pair((e) => {
+      ev = e;
+      e.preventDefault();
+    });
+    await asWm.close();
+    await sleep(30);
+    assert.equal(typeof ev.time, 'number');
+    assert.equal(ev.target, wnd);
+    assert.equal(ev.window, wnd);
+    wnd.destroy();
+  });
+});
+
+describe("on('close') and the raw message event", () => {
+  test('a message that is not WM_DELETE_WINDOW does not close anything', async () => {
+    const { wnd, asWm } = await pair(() => {});
+    const wmProtocols = await wnd.atom('WM_PROTOCOLS');
+    const ping = await wnd.atom('_NET_WM_PING');
+
+    // _NET_WM_PING arrives down the same WM_PROTOCOLS channel
+    wm.X.SendClientMessage(wnd.id, wnd.id, wmProtocols, 32, [ping, 1, wnd.id, 0, 0], 0);
+    await sleep(30);
+    assert.equal(wnd._destroyed, false, 'a ping is not a close request');
+    wnd.destroy();
+  });
+
+  test('a message with an unrelated type is left alone', async () => {
+    const { wnd } = await pair(() => {});
+    const other = await wnd.atom('_NET_WM_STATE');
+    const del = await wnd.atom('WM_DELETE_WINDOW');
+
+    wm.X.SendClientMessage(wnd.id, wnd.id, other, 32, [del, 0, 0, 0, 0], 0);
+    await sleep(30);
+    assert.equal(wnd._destroyed, false, 'matched on data alone, ignoring the type');
+    wnd.destroy();
+  });
+
+  test('the raw message event still fires, and first', async () => {
+    // apps that decoded ClientMessage themselves keep working
+    const order = [];
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    wnd.on('message', () => order.push('message'));
+    wnd.on('close', (ev) => {
+      order.push('close');
+      ev.preventDefault();
+    });
+    await sleep(30);
+
+    await new Window(wm, { id: wnd.id }).close();
+    await sleep(30);
+    assert.deepEqual(order, ['message', 'close']);
+    wnd.destroy();
+  });
+
+  test('with no close listener nothing is destroyed behind the app’s back', async () => {
+    // the pre-existing way: advertise the protocol, handle 'message' yourself
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await wnd.addProtocol('WM_DELETE_WINDOW');
+    let messages = 0;
+    wnd.on('message', () => messages++);
+    await sleep(30);
+
+    await new Window(wm, { id: wnd.id }).close();
+    await sleep(30);
+    assert.equal(messages, 1, 'the message arrived');
+    assert.equal(wnd._destroyed, false, 'and ntk did not act on it');
+    wnd.destroy();
+  });
+});
+
+describe('the window manager side', () => {
+  test('a window that never listened is killed rather than asked', async () => {
+    const wnd = app.createWindow({ width: 40, height: 40 });
+    await sleep(20);
+    assert.equal(await new Window(wm, { id: wnd.id }).close(), false);
+  });
+});


### PR DESCRIPTION
Closes #36.

The protocol half of that issue landed in #131 — `addProtocol` is read-modify-write, and `close()` is the window manager's side. What was still missing is what it asked for in 2018: *"no easy way to set a close window request handler"*. The request arrived as a generic `message` event, so an application had to know that ClientMessage is event 33, intern `WM_DELETE_WINDOW` itself and compare `ev.data[0]` against it — protocol plumbing showing through a toolkit.

```js
function onClose(ev) {
  if (unsaved) {
    ev.preventDefault();   // stay open
    showSaveDialog();
  }
}
wnd.on('close', onClose);
```

**Listening is the opt-in.** Registering the handler and advertising `WM_DELETE_WINDOW` in `WM_PROTOCOLS` are the same act, so there is nothing else to call and nothing to get wrong — a window manager only *asks* a client that said it wanted to be asked, and kills anyone else outright. Protocols the window already declared are kept.

If nothing calls `preventDefault()`, the default action destroys the window, which is what an application that just wants to save state on the way out should want.

### On the naming

The issue suggested `onBeforeUnload`. The web parallel is close — the window manager is asking, the application may decline — but the difference argues for a distinct name: `beforeunload` cannot really be cancelled by script any more, whereas declining `WM_DELETE_WINDOW` is entirely normal. An unsaved-changes dialog is exactly that. So: `close`, with a `preventDefault()` that genuinely works.

It has to be called **synchronously**. There is no point at which the answer could be awaited, so a handler that needs to ask the user declines first and calls `destroy()` itself later. The docs say so.

### Nothing changes for existing code

A window with no `close` listener behaves exactly as before: the request arrives as a raw `message` and ntk does not act on it. An application that decodes ClientMessage itself is untouched — deliberately, so that adding this doesn't quietly give such a window a second handler that destroys it. When both are listened for, `message` fires first. There's a test for each.

Matching is on the message type **and** `data[0]`, so `_NET_WM_PING` — which arrives down the same `WM_PROTOCOLS` channel — is not mistaken for a close request. Tested, along with a `WM_DELETE_WINDOW` atom arriving under an unrelated message type.

### Tests

506 pass (492 before, 14 new in `test/close-event.test.js`). The protocol runs end to end rather than being simulated: a second client on the same in-process X server plays the window manager and calls `close()`, so both halves of #36 are exercised against each other. Covers the veto, the default action, declining twice in a row, one listener vetoing among several, and the timestamp on the event.

Also checked against the real X server on two live connections:

```
advertised WM_PROTOCOLS: [ 'WM_DELETE_WINDOW' ]

wm asks (handler vetoes):
  close() returned true
  close #1, defaultPrevented=true
  window destroyed? false (want false)

wm asks again (handler allows):
  close #2, defaultPrevented=false
  window destroyed? true (want true)
```
