### PR TITLE
feat: Surface, and SVG documents that take their colour from the caller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ lib/index.js               createClient() -> App; package entry (ESM)
 lib/app.js                 App: one X connection, window/pixmap factory
 lib/window.js              Window (extends Drawable): events, geometry, WM bits
 lib/pixmap.js              offscreen drawable
+lib/surface.js             Surface: pixmap + Picture, drawn once and
+                           composited many times; a8 coverage surfaces take
+                           their colour from the drawing context
 lib/drawable.js            EventEmitter base + getContext() registry
 lib/events_map.js          X event code <-> browser-ish event name tables
                            (incl. FocusIn/FocusOut as 'focus'/'blur')

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ matching file here (see AGENTS.md).
 - [2d rendering context](context-2d.md) — canvas-like drawing API over XRender
 - [Images](images.md) — PNG/JPEG loading (`loadImage`), the `Image` object,
   `drawImage`
+- [Surface](surface.md) — draw once, composite many times; a8 coverage
+  surfaces for drawings that take their colour from the caller
 - [Fonts](fonts.md) — font lookup, loading, rasterization pipeline
 - [Text](text.md) — shaping (kerning/bidi/fallback), TextLayout, MarkdownView,
   wire-efficiency design, the vector (trapezoid) path for large/animated sizes

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -121,9 +121,17 @@ to the anchor point, but glyphs are not rotated/scaled — size text via
   [`Image`](images.md) (decoded PNG/JPEG). The image uploads to the server
   once and is cached; scaling (and any affine transform) happens server-side
   with bilinear filtering. Respects clip and `globalAlpha`. `image` can also
-  be another ntk 2d context (server-side composite of the whole drawable) or
-  a node-canvas-like object exposing `image.context.getImageData()` (pixels
-  are uploaded)
+  be a [`Surface`](surface.md) (pixels the server drew, including a8 coverage
+  surfaces that paint in the current `fillStyle`), anything else exposing
+  `width`/`height`/`picture(app)`, another ntk 2d context (server-side
+  composite of the whole drawable) or a node-canvas-like object exposing
+  `image.context.getImageData()` (pixels are uploaded). Under a rectangular
+  clip the clip goes to the server directly, rather than through a
+  full-surface mask
+- `ctx.destroy()` / `Symbol.dispose` — release the context's server-side
+  resources: its GC, its Picture, its masks and its solid-colour pictures.
+  Needed only for contexts created dynamically, such as one per
+  [`Surface`](surface.md); a context on a window lives as long as the window
 ### Pixels
 
 Pixel access follows the canvas API: `ImageData` is straight

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -1,0 +1,94 @@
+# Surface
+
+A `Surface` is something you draw **once** and composite **many times**: a
+[pixmap](pixmap.md), its XRender Picture, and enough of the
+[`Image`](images.md) shape that `ctx.drawImage` takes it as a source.
+
+```js
+import { createClient, Surface, SvgView } from 'ntk';
+
+const icon = new SvgView(null).setSvg(iconMarkup);
+const surface = new Surface(app, { width: 20, height: 20 });
+surface.render((ctx) => icon.draw(ctx, 0, 0, 20, 20));
+
+for (const { x, y } of cells) ctx.drawImage(surface, x, y); // one composite each
+```
+
+`Image` already does this for decoded PNG/JPEG pixels uploaded from the
+client. A Surface is the same contract for pixels the **server** drew, so
+nothing crosses the wire but the composite — which is the point when the
+drawing is expensive to produce and cheap to copy. Rendering an icon means
+walking a parsed document, building path geometry, flattening it and running
+the stroker; compositing the result is one request.
+
+## Coverage surfaces
+
+`format: 'a8'` stores **coverage** instead of colour. Drawn through
+`drawImage`, the surface becomes the *mask* and the context's current
+`fillStyle` becomes the source:
+
+```js
+const mask = new Surface(app, { width: 20, height: 20, format: 'a8' });
+mask.render((ctx) => icon.draw(ctx, 0, 0, 20, 20, { color: '#fff' }));
+
+ctx.fillStyle = theme.fg;      ctx.drawImage(mask, x, y);
+ctx.fillStyle = theme.accent;  ctx.drawImage(mask, x, y + 24); // same surface
+```
+
+One rendered copy then serves every colour it is ever asked for, so a hover,
+a disabled state and a theme change all reuse it instead of each needing
+their own. This is the trick the glyph cache already runs on text, applied to
+arbitrary drawings — and it is a quarter of the storage, one byte per pixel
+instead of four.
+
+Not every drawing qualifies: a document with two colours in it, or a
+gradient, has colours of its own that a mask cannot carry.
+[`SvgView.paintKind`](svg.md#paintkind-which-documents-can-be-recoloured)
+answers that question for SVG documents.
+
+`globalAlpha` still applies — it folds into the source colour rather than the
+mask, since the mask slot is taken.
+
+## API
+
+- `new Surface(app, { width, height, format })` — `format` is `'argb32'`
+  (default) or `'a8'`. Sizes must be positive integers. Contents start
+  transparent
+- `surface.width` / `surface.height` / `surface.format` / `surface.depth`
+- `surface.bytes` — server-side storage, which is what a cache budgets
+  against: `w * h * 4` for argb32, `w * h` for a8
+- `surface.render(fn)` — call `fn(ctx)` with a 2d context on the surface, in
+  surface-local coordinates where `(0, 0)` is its top-left corner. The
+  context is created for the call and destroyed after it
+- `surface.getContext('2d')` — a context the caller owns, and owes a
+  `destroy()`. Use this instead of `render()` for many draws into one surface
+- `surface.clear()` — reset every pixel to transparent
+- `surface.picture(app)` — the server-side Picture, mirroring
+  `Image.picture(app)`. Throws for a different connection
+- `surface.destroy()` / `Symbol.dispose` — free the pixmap and the picture.
+  Both carry finalizers, so a dropped surface still releases
+
+## Drawing sources in general
+
+`drawImage` does not check types: it takes anything that knows its own size
+and can hand over a Picture.
+
+```js
+ctx.drawImage({ width, height, picture: (app) => somePicture }, x, y);
+```
+
+That is the whole contract — `width`, `height`, `picture(app)`, plus an
+optional `format: 'a8'` to be treated as coverage. A caller keeping its own
+cache of rendered things can satisfy it without ntk knowing the type.
+
+## Context lifetime
+
+Contexts are not free: each one holds a GC, a Picture, and a 1x1 pixmap per
+fill colour it has seen. A context bound to a window normally lives as long
+as the window, so this rarely mattered — but creating them per surface makes
+it matter, which is why `RenderingContext2d` now has `destroy()` (and
+`Symbol.dispose`). `Surface.render()` calls it for you.
+
+```js
+using ctx = surface.getContext('2d'); // or ctx.destroy() when done
+```

--- a/docs/svg.md
+++ b/docs/svg.md
@@ -39,14 +39,19 @@ See `examples/svg-viewer.js` for a small viewer
   - `theme.background` — window-mode background fill (default `'white'`)
   - `fit` — window-mode fitting: `'contain'` (default; fitted + centered,
     preserving aspect ratio) or `'fill'` (stretch)
+  - `color` — what `currentColor` resolves to (default `'#000'`); see
+    [Taking colour from the caller](#taking-colour-from-the-caller)
 - `view.setSvg(svgText)` — parse and adopt a document (a string containing
   an `<svg>` element). Re-renders in window mode
 - `view.setSvgDom(element)` — adopt an already-parsed htmlparser2 `<svg>`
   element. Used by [HtmlView](html.md) for inline SVG; tolerates HTML-mode
   parses (lowercased tag/attribute names like `viewbox`, `lineargradient`)
-- `view.draw(ctx, x, y[, w, h])` — draw into any 2d context; `w`/`h` default
-  to the natural size. The `viewBox` (when present) is scaled to the target
-  box
+- `view.draw(ctx, x, y[, w, h][, opts])` — draw into any 2d context; `w`/`h`
+  default to the natural size. The `viewBox` (when present) is scaled to the
+  target box. `opts.color` sets what `currentColor` resolves to for this draw
+  only, overriding the view's own `color`
+- `view.paintKind` / `view.soloPaint` — how many colours the document commits
+  to, from the parse; see [Taking colour from the caller](#taking-colour-from-the-caller)
 - `view.render()` — window mode: clear the background and draw fitted;
   called automatically on `expose`
 - `view.naturalWidth` / `view.naturalHeight` — from the `width`/`height`
@@ -86,6 +91,50 @@ Not supported (skipped silently): CSS stylesheets/`<style>`, `clipPath`,
 `mask`, `filter`, `pattern`, `marker`, animation/SMIL, `foreignObject`,
 external references, `preserveAspectRatio` values other than the default
 behavior, stroke dashing, and full `text` layout (`tspan`, `textPath`).
+
+## Taking colour from the caller
+
+An icon set is written without colours: every shape says
+`fill="currentColor"` or `stroke="currentColor"`, and the surrounding UI
+decides what that means. One parsed document then serves a normal row, a
+hovered row and a disabled row.
+
+```js
+const icon = new SvgView(null).setSvg(iconMarkup);
+
+icon.draw(ctx, x, y, 20, 20, { color: theme.fg });
+icon.draw(ctx, x, y + 24, 20, 20, { color: theme.accent }); // same document
+```
+
+`opts.color` applies to that draw only. A default for every draw goes on the
+view, and window mode uses it too, since `render()` takes no options:
+
+```js
+const view = new SvgView(wnd, { color: '#0984e3' });
+```
+
+Both fall back to the CSS initial value, black. Note that only `currentColor`
+follows this: the initial `fill` is black, not `currentColor`, so a document
+that names no paint at all still fills black — as it does in a browser.
+
+### paintKind: which documents can be recoloured
+
+Parsing also records how many distinct paints the drawing actually commits
+to, which is what a caller caching rendered output needs in order to decide
+whether the colour belongs in its cache key:
+
+- `view.paintKind === 'mono'` — every fill and stroke that reaches a shape is
+  `none` or the *same* paint. The drawing is a coverage mask plus a colour,
+  so one rendered copy can be recoloured for every use. `view.soloPaint` is
+  that paint: a colour, or the literal `'currentColor'` when the document
+  defers to its caller.
+- `view.paintKind === 'multi'` — a second distinct paint, or a
+  gradient/pattern reference. Those colours belong to the drawing rather than
+  to the UI, so a rendered copy is only good for the colours baked into it,
+  and `soloPaint` is `null`.
+
+Opacity does not enter into it: `opacity`, `fill-opacity` and
+`stroke-opacity` scale coverage, which a mask carries perfectly well.
 
 ## SVG path data elsewhere
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ import {
   toStraightRgba,
   unpackIcons
 } from './imagedata.js';
+import { Surface } from './surface.js';
 import { Path2D, parseSvgPath } from './path.js';
 import Font from './text/font.js';
 import FontManager from './text/fontmanager.js';
@@ -157,6 +158,7 @@ export {
   resolveCursorShape,
   Pixmap,
   Picture,
+  Surface,
   Image,
   ImageData,
   pixelLayout,

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -1,6 +1,7 @@
 import parseFontStyle from 'canvas-fontstyle';
 import extrudePolyline from 'extrude-polyline';
 
+import { safeRelease } from './cleanup.js';
 import { cssColor } from './color.js';
 import Drawable from './drawable.js';
 import { Image } from './image.js';
@@ -25,6 +26,32 @@ import { reorderRuns } from './text/shape.js';
 import { trapezoidize } from './trapezoid.js';
 
 const DEFAULT_FONT = '20px sans-serif';
+
+/**
+ * What `drawImage` takes as a server-side source: anything that knows its own
+ * size and can hand over a `Picture` for this connection.
+ *
+ * `Image` is client pixels uploaded once; `Surface` is pixels the server drew
+ * itself. Neither is special — the contract is the two members, so a caller
+ * with its own cache of rendered things can satisfy it without ntk knowing
+ * the type. A `RenderingContext2d` deliberately does not match: its `picture`
+ * is a property rather than a method, and it keeps its own branch below.
+ */
+/** a fillStyle with a single colour behind it, as opposed to a gradient or a
+ * caller-supplied Picture */
+function isPlainColor(style) {
+  return typeof style === 'string' || Array.isArray(style);
+}
+
+function isPictureSource(image) {
+  return (
+    image instanceof Image ||
+    (image != null &&
+      typeof image.picture === 'function' &&
+      Number.isFinite(image.width) &&
+      Number.isFinite(image.height))
+  );
+}
 
 // canvas globalCompositeOperation -> XRender PictOp name. Porter-Duff ops
 // map directly; with a clip/shape mask active the op only applies inside
@@ -212,9 +239,16 @@ class RenderingContext2d {
       this.X.CreateGC(this._gc, target.id);
     }
     if (this.picture) this.picture.destroy();
-    // TODO: support a8
+    // a8 targets are coverage, not colour: drawing into one and using the
+    // result as a mask is how a monochrome drawing gets rendered once and
+    // recoloured on every use (see Surface).
     const depth = target.depth ?? this.window.depth;
-    const format = depth === 32 ? this.Render.rgba32 : this.Render.rgb24;
+    const format =
+      depth === 32
+        ? this.Render.rgba32
+        : depth === 8
+          ? this.Render.a8
+          : this.Render.rgb24;
     this.picture = new Picture(this.window.app, {
       drawable: target,
       format,
@@ -222,6 +256,59 @@ class RenderingContext2d {
       polyMode: 1
     });
     this._dropMasks();
+  }
+
+  /**
+   * Release everything this context allocated server-side. Idempotent, and
+   * the context must not be drawn with afterwards.
+   *
+   * A context bound to a window normally lives as long as the window and the
+   * connection outlives both, which is why this went missing for so long (see
+   * issue #156). It matters as soon as contexts are created *dynamically* —
+   * one per offscreen `Surface`, say — because without it each one
+   * permanently costs a GC, a Picture, and a 1x1 pixmap per fill colour used.
+   *
+   * `_backgroundPicture` and `_glyphSource` are deliberately not freed here:
+   * both are either aliases into `_solidPictures`, already freed below, or a
+   * `Picture`/`CanvasGradient` the caller passed in through `fillStyle`,
+   * which is not ours to free.
+   */
+  destroy() {
+    if (this._destroyed) return;
+    this._destroyed = true;
+
+    this._clips = [];
+    this._dropMasks();
+    for (const gc of [this._gc, this._fillMaskGC]) {
+      if (!gc) continue;
+      safeRelease(this.X, () => {
+        this.X.FreeGC(gc);
+        this.X.ReleaseID(gc);
+      });
+    }
+    this._gc = this._fillMaskGC = null;
+
+    for (const picture of this._solidPictures.values()) {
+      picture.destroy();
+      picture._sourcePixmap?.destroy();
+    }
+    this._solidPictures.clear();
+    this._backgroundPicture = this._glyphSource = null;
+
+    if (this.picture) {
+      // a picture on a *window* is freed by the server with the window;
+      // asking again would raise BadPicture. Same rule as `_destroyed`.
+      if (this._target === this.window && !(this.window instanceof Pixmap)) {
+        this.picture.forget();
+      } else {
+        this.picture.destroy();
+      }
+      this.picture = null;
+    }
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
   }
 
   _dropMasks() {
@@ -1470,8 +1557,127 @@ class RenderingContext2d {
    * RenderingContext2d, or a node-canvas-like object. Images honor the
    * current transform (server-side, via the picture transform).
    */
+  /**
+   * Clip and mask for a direct composite, as a bracket around it.
+   *
+   * A rectangular clip is something the server can do itself: two small
+   * requests around the composite instead of intersecting a full-surface a8
+   * mask, which costs the same on the wire and many times the pixel work.
+   * This is the fast path `drawGlyphs` already has — and a renderer that
+   * clips to a damage rect makes it the common case, not a rare one.
+   *
+   * Uniform alpha needs no surface-sized mask either: a 1x1 repeating
+   * picture is the same thing to the server, with no pixel work at all.
+   */
+  _beginDirectComposite() {
+    const rect = this.clipMask ? this._clipRect() : null;
+    if (!rect) return { mask: this._compositeMask(), clipped: false, empty: false };
+    if (rect.w === 0 || rect.h === 0) return { mask: 0, clipped: false, empty: true };
+    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+    const mask =
+      this.globalAlpha >= 1 ? 0 : this.createSolidPicture(0, 0, 0, this.globalAlpha).id;
+    return { mask, clipped: true, empty: false };
+  }
+
+  _endDirectComposite(state) {
+    if (!state.clipped) return;
+    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+  }
+
+  /** The source colour for a coverage composite, with `globalAlpha` folded
+   * into it. The mask slot is taken by the coverage, so the alpha has to go
+   * somewhere — and a 1x1 solid is free, where a surface-sized alpha mask is
+   * not. Falls back to the fill picture for gradients, which have no single
+   * colour to fold into; `_drawCoverage` routes those through the scratch. */
+  _coverageSource() {
+    const style = this._fillStyle;
+    if (this.globalAlpha >= 1 || !isPlainColor(style)) return this._backgroundPicture;
+    const c = parseColor(style);
+    return this.createSolidPicture(c[0], c[1], c[2], c[3] * this.globalAlpha);
+  }
+
+  /**
+   * Composite a coverage source: the a8 picture is the *mask* and the current
+   * `fillStyle` is what gets painted through it.
+   *
+   * This is the same shape as `drawGlyphs`, and for the same reason — a
+   * monochrome drawing rendered once as coverage can then be painted in any
+   * colour, so a hover, a disabled state and a theme change all reuse the one
+   * rendered copy instead of each needing their own.
+   */
+  _drawCoverage(picture, sx, sy, sw, sh, dx, dy, dw, dh, op) {
+    const R = this.Render;
+    const scaled = dw !== sw || dh !== sh;
+    if (scaled) {
+      R.SetPictureTransform(picture.id, [sw / dw, 0, sx, 0, sh / dh, sy, 0, 0, 1]);
+      picture.setFilter('bilinear');
+    }
+    // with a transform in place the mask is already sampled from (sx, sy)
+    const mx = scaled ? 0 : sx;
+    const my = scaled ? 0 : sy;
+
+    const rect = this.clipMask ? this._clipRect() : null;
+    // the mask slot can hold exactly one picture, so anything that cannot be
+    // folded into the colour or handed to the server as a clip rectangle has
+    // to be intersected into the scratch mask first
+    const scratch =
+      (this.clipMask && !rect) || (this.globalAlpha < 1 && !isPlainColor(this._fillStyle));
+
+    if (scratch) {
+      this._ensureFillMask();
+      R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
+      R.Composite(R.PictOp.Src, picture.id, 0, this.fillMask.id, mx, my, 0, 0, dx, dy, dw, dh);
+      if (this.globalAlpha < 1) {
+        R.Composite(
+          R.PictOp.InReverse,
+          this.createSolidPicture(0, 0, 0, this.globalAlpha).id,
+          0,
+          this.fillMask.id,
+          0, 0, 0, 0, 0, 0,
+          this.width, this.height
+        );
+      }
+      if (this.clipMask) {
+        R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+      }
+      R.Composite(
+        op,
+        this._backgroundPicture.id,
+        this.fillMask.id,
+        this.picture.id,
+        0, 0, 0, 0,
+        dx, dy,
+        dw, dh
+      );
+    } else if (!rect || (rect.w > 0 && rect.h > 0)) {
+      if (rect) {
+        R.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+      }
+      R.Composite(
+        op,
+        this._coverageSource().id,
+        picture.id,
+        this.picture.id,
+        0, 0,
+        mx, my,
+        dx, dy,
+        dw, dh
+      );
+      if (rect) {
+        R.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+      }
+    }
+
+    if (scaled) {
+      // restore defaults so the cached surface stays reusable as-is
+      R.SetPictureTransform(picture.id, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
+      picture.setFilter('nearest');
+    }
+    this._markDirty();
+  }
+
   drawImage(image, ...args) {
-    if (image instanceof Image) {
+    if (isPictureSource(image)) {
       let sx = 0;
       let sy = 0;
       let sw = image.width;
@@ -1499,7 +1705,14 @@ class RenderingContext2d {
         return;
       }
 
-      const mask = this._compositeMask();
+      if (image.format === 'a8') {
+        this._drawCoverage(picture, sx, sy, sw, sh, dx, dy, dw, dh, op);
+        return;
+      }
+
+      const state = this._beginDirectComposite();
+      if (state.empty) return;
+      const mask = state.mask;
       const scaled = dw !== sw || dh !== sh;
       if (scaled) {
         // the picture transform maps composite coordinates into source
@@ -1531,6 +1744,7 @@ class RenderingContext2d {
           dw, dh
         );
       }
+      this._endDirectComposite(state);
       this._markDirty();
       return;
     }
@@ -1540,7 +1754,8 @@ class RenderingContext2d {
     const sx = 0;
     const sy = 0;
 
-    // TODO: allow to draw Window, Pixmap, Picture
+    // Drawables reach the branch above by way of Surface, which is what a
+    // Window/Pixmap/Picture source actually needs: a size and a Picture.
     if (image instanceof RenderingContext2d) {
       // TODO: if need to scale, set transform
       // TODO: respect global compositing blend mode

--- a/lib/surface.js
+++ b/lib/surface.js
@@ -1,0 +1,118 @@
+import Picture from './picture.js';
+import Pixmap from './pixmap.js';
+
+/**
+ * An offscreen drawing surface: a pixmap, its Picture, and enough of the
+ * `Image` shape that `ctx.drawImage` takes it as a source.
+ *
+ *   const surface = new Surface(app, { width: 20, height: 20 });
+ *   surface.render((ctx) => icon.draw(ctx, 0, 0, 20, 20));
+ *   ctx.drawImage(surface, x, y);            // one server-side composite
+ *
+ * The point is drawing something once and compositing it many times. An
+ * `Image` already does that for decoded PNG/JPEG pixels uploaded from the
+ * client; a Surface is the same contract for pixels drawn *by* the server,
+ * so nothing crosses the wire but the composite.
+ *
+ * ### Coverage surfaces
+ *
+ * `format: 'a8'` makes a surface that stores coverage instead of colour.
+ * Drawn through `drawImage` it acts as a mask for the current `fillStyle`,
+ * so one rendered copy of a monochrome drawing serves every colour it is
+ * ever asked for — the trick the glyph cache already runs on text, applied
+ * to arbitrary drawings. See `SvgView.paintKind` for deciding when a drawing
+ * qualifies.
+ *
+ * ### Lifetime
+ *
+ * `destroy()` frees the pixmap and the picture; both of those carry their own
+ * finalizers, so a dropped surface still releases. `render()` builds a
+ * context, hands it over, and
+ * destroys it again, which keeps the steady-state cost of a surface to two
+ * server objects — a context is much heavier than it looks, and holding one
+ * per surface is what issue #156 is about.
+ */
+export class Surface {
+  constructor(app, { width, height, format = 'argb32' } = {}) {
+    if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+      throw new Error('Surface: width and height must be positive integers');
+    }
+    if (format !== 'argb32' && format !== 'a8') {
+      throw new Error(`Surface: unknown format ${JSON.stringify(format)} (argb32 or a8)`);
+    }
+    this.app = app;
+    this.width = width;
+    this.height = height;
+    this.format = format;
+    this.depth = format === 'a8' ? 8 : 32;
+
+    this.pixmap = new Pixmap(app, { depth: this.depth, width, height });
+    this._picture = new Picture(app, {
+      drawable: this.pixmap,
+      format: format === 'a8' ? app.display.Render.a8 : app.display.Render.rgba32
+    });
+    // a fresh pixmap's contents are undefined per the protocol, so a surface
+    // that is only partly drawn would otherwise composite server garbage
+    this.clear();
+  }
+
+  /** bytes of server-side storage — what a cache budgets against */
+  get bytes() {
+    return this.width * this.height * (this.depth === 8 ? 1 : 4);
+  }
+
+  /** The server-side Picture, on the app this surface belongs to. Mirrors
+   * `Image.picture(app)` so `drawImage` can take either without asking which
+   * it has. */
+  picture(app) {
+    if (app && app !== this.app) {
+      throw new Error('Surface: belongs to a different X connection');
+    }
+    return this._picture;
+  }
+
+  /** reset every pixel to fully transparent */
+  clear() {
+    const R = this.app.display.Render;
+    R.FillRectangles(R.PictOp.Src, this._picture.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
+    return this;
+  }
+
+  /**
+   * Draw into the surface through a 2d context, in surface-local coordinates
+   * where (0, 0) is its top-left corner.
+   *
+   * The context is created for the call and destroyed after it, so a surface
+   * kept in a cache holds no context of its own. Callers doing many draws
+   * into the same surface should `getContext('2d')` once and destroy it
+   * themselves instead.
+   */
+  render(fn) {
+    const ctx = this.getContext('2d');
+    try {
+      fn(ctx);
+    } finally {
+      ctx.destroy();
+    }
+    return this;
+  }
+
+  /** a rendering context on the backing pixmap — the caller owns it, and
+   * owes it a `destroy()` */
+  getContext(name, ...args) {
+    return this.pixmap.getContext(name, ...args);
+  }
+
+  destroy() {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._picture.destroy();
+    this.pixmap.destroy();
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
+  }
+}
+
+export default Surface;

--- a/lib/widgets/svgview.js
+++ b/lib/widgets/svgview.js
@@ -203,6 +203,95 @@ function pathBBox(path) {
 }
 
 /**
+ * How many distinct colours a document actually commits to, decided once at
+ * parse time.
+ *
+ * `mono` means every fill and stroke that reaches a shape is `none` or the
+ * *same* paint — one literal colour, or `currentColor` throughout. Such a
+ * drawing is really a coverage mask plus a colour, so a caller can render it
+ * once and recolour it on every draw. `multi` is everything else: a second
+ * distinct paint, or a gradient/pattern reference, whose colours belong to
+ * the drawing rather than to the UI around it.
+ *
+ * Opacity does not enter into it: `opacity`, `fill-opacity` and
+ * `stroke-opacity` scale coverage, which a mask carries perfectly well.
+ *
+ * The walk mirrors `_style` and `_renderNode` — fill and stroke inherit,
+ * inline `style` beats the presentation attribute, the initial fill is black
+ * and the initial stroke is none, `<line>` never fills, `<use>` paints its
+ * target with the *use* element's style, and non-rendered subtrees
+ * contribute nothing. It starts at the root's children rather than the root,
+ * because `draw` does: presentation attributes on the root `<svg>` are not
+ * applied, and a scan that applied them would disagree with what is painted.
+ *
+ * @returns {{ kind: 'mono'|'multi', solo: string|null }} `solo` is the one
+ *   paint a `mono` document uses — a colour, or the literal `'currentColor'`
+ *   when the document defers to its caller — and null when nothing paints.
+ */
+function scanPaints(root, ids) {
+  const paints = new Set();
+  let multi = false;
+
+  const paintOf = (node, name, inherited) => {
+    let v = attr(node, name);
+    for (const decl of (node.attribs?.style || '').split(';')) {
+      const idx = decl.indexOf(':');
+      if (idx > 0 && decl.slice(0, idx).trim() === name) v = decl.slice(idx + 1);
+    }
+    if (v === undefined || v === '' || v === 'inherit') return inherited;
+    return String(v).trim();
+  };
+
+  const note = (paint) => {
+    if (paint === 'none') return;
+    if (/^url\(/i.test(paint)) multi = true;
+    else paints.add(paint);
+  };
+
+  const kids = (node, fill, stroke, depth) => {
+    for (const child of node.children || []) {
+      if (child.type === 'tag') visit(child, fill, stroke, depth + 1);
+    }
+  };
+
+  const visit = (node, fill, stroke, depth) => {
+    if (multi || depth > 32) return;
+    const name = tag(node);
+    if (NON_RENDERED.has(name)) return;
+    const f = paintOf(node, 'fill', fill);
+    const s = paintOf(node, 'stroke', stroke);
+    switch (name) {
+      case 'svg':
+      case 'g':
+      case 'a':
+        kids(node, f, s, depth);
+        return;
+      case 'use': {
+        const href = node.attribs?.href || node.attribs?.['xlink:href'] || '';
+        const target = href.startsWith('#') ? ids.get(href.slice(1)) : null;
+        if (!target) return;
+        // <symbol> is non-rendered on its own but renders through <use>
+        if (tag(target) === 'symbol') kids(target, f, s, depth);
+        else visit(target, f, s, depth + 1);
+        return;
+      }
+      case 'text':
+        note(f);
+        return;
+      default:
+        if (name !== 'line') note(f);
+        note(s);
+    }
+  };
+
+  kids(root, INHERITED.fill, INHERITED.stroke, 0);
+  return {
+    kind: multi || paints.size > 1 ? 'multi' : 'mono',
+    solo: paints.size === 1 ? [...paints][0] : null
+  };
+}
+
+/**
  * Widget rendering a static SVG document into a window (or any 2d context
  * via `draw()`). Scripting, CSS stylesheets, filters, masks and external
  * references are not supported — see docs/svg.md.
@@ -213,12 +302,22 @@ export default class SvgView {
     this.theme = { background: 'white', ...(opts.theme || {}) };
     /** fit mode in window mode: 'contain' (default) | 'fill' */
     this.fit = opts.fit || 'contain';
+    /**
+     * What `currentColor` resolves to, for documents that defer their colour
+     * to the surrounding UI the way an icon set does. Per-draw `opts.color`
+     * overrides it; both fall back to the CSS initial value, black.
+     */
+    this.color = opts.color ?? INHERITED.color;
 
     this._root = null;
     this._ids = new Map();
     this.naturalWidth = 0;
     this.naturalHeight = 0;
     this.viewBox = null;
+    /** see `scanPaints`: 'mono' | 'multi', and the single paint of a mono
+     * document — `'currentColor'` when it defers its colour to the caller */
+    this.paintKind = 'mono';
+    this.soloPaint = null;
 
     if (this.window) {
       this._ctx = this.window.getContext('2d');
@@ -263,6 +362,10 @@ export default class SvgView {
     };
     collect(this._root);
 
+    const scanned = scanPaints(this._root, this._ids);
+    this.paintKind = scanned.kind;
+    this.soloPaint = scanned.solo;
+
     const a = this._root.attribs || {};
     const vb = (attr(this._root, 'viewBox') || '')
       .split(/[\s,]+/)
@@ -305,8 +408,15 @@ export default class SvgView {
   /**
    * Draw the document into any 2d context. `w`/`h` default to the
    * document's natural size; the viewBox (when present) is scaled to fit.
+   *
+   * `opts.color` is what `fill="currentColor"` and `stroke="currentColor"`
+   * resolve to for this draw, overriding the view's own `color`. That is how
+   * an icon takes its colour from the UI around it — the document itself
+   * names no colour, so the same parsed document paints in whatever the
+   * caller is using, and a caller caching the result can recolour a cached
+   * `paintKind === 'mono'` drawing without re-rendering it.
    */
-  draw(ctx, x = 0, y = 0, w = this.naturalWidth, h = this.naturalHeight) {
+  draw(ctx, x = 0, y = 0, w = this.naturalWidth, h = this.naturalHeight, opts = {}) {
     if (!this._root) return;
     ctx.save();
     ctx.translate(x, y);
@@ -319,7 +429,13 @@ export default class SvgView {
     } else if (this.naturalWidth > 0 && this.naturalHeight > 0) {
       ctx.scale(w / this.naturalWidth, h / this.naturalHeight);
     }
-    this._renderChildren(this._root, ctx, { ...INHERITED }, 1, 0);
+    this._renderChildren(
+      this._root,
+      ctx,
+      { ...INHERITED, color: opts.color ?? this.color },
+      1,
+      0
+    );
     ctx.restore();
   }
 

--- a/test/surface.test.js
+++ b/test/surface.test.js
@@ -1,0 +1,277 @@
+// Surface: draw something once, composite it many times.
+//
+// Runs against node-x11's in-process pure-JS X server, which implements
+// Render compositing for real — so these assert on *pixels*, not on the
+// requests that produced them. The one exception is the clip fast path,
+// where the whole point is which requests go out, so that one counts them.
+import assert from 'node:assert/strict';
+import { after, before, describe, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource, Surface } from '../lib/index.js';
+
+const W = 40;
+const H = 40;
+
+let app = null;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  await app?.close();
+});
+
+/** a transparent depth-32 target and its context */
+function target() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 32 });
+  const ctx = pixmap.getContext('2d');
+  const R = app.display.Render;
+  R.FillRectangles(R.PictOp.Src, ctx.picture.id, [0, 0, 0, 0], [0, 0, W, H]);
+  return ctx;
+}
+
+const readPixels = async (ctx) => {
+  const img = await ctx.getImageData(0, 0, W, H);
+  return (x, y) => [...img.data.slice((y * W + x) * 4, (y * W + x) * 4 + 4)];
+};
+
+/** an 8x8 block of full coverage, or of solid colour */
+function block(format, fill = '#ffffff') {
+  const surface = new Surface(app, { width: 8, height: 8, format });
+  surface.render((ctx) => {
+    ctx.fillStyle = fill;
+    ctx.fillRect(0, 0, 8, 8);
+  });
+  return surface;
+}
+
+/** count the Render requests a body issues */
+function countRender(names, body) {
+  const R = app.display.Render;
+  const counts = Object.fromEntries(names.map((n) => [n, 0]));
+  const saved = {};
+  for (const name of names) {
+    saved[name] = R[name];
+    R[name] = (...a) => {
+      counts[name]++;
+      return saved[name].apply(R, a);
+    };
+  }
+  try {
+    body();
+  } finally {
+    for (const name of names) R[name] = saved[name];
+  }
+  return counts;
+}
+
+describe('Surface', () => {
+  test('rejects sizes and formats it cannot honour', () => {
+    assert.throws(() => new Surface(app, { width: 0, height: 8 }), /positive integers/);
+    assert.throws(() => new Surface(app, { width: 8.5, height: 8 }), /positive integers/);
+    assert.throws(() => new Surface(app, { width: 8, height: 8, format: 'rgb24' }), /unknown format/);
+  });
+
+  test('reports the storage a cache would budget against', () => {
+    assert.equal(new Surface(app, { width: 20, height: 10 }).bytes, 800); // argb32
+    assert.equal(new Surface(app, { width: 20, height: 10, format: 'a8' }).bytes, 200);
+  });
+
+  test('refuses to hand its picture to another connection', () => {
+    const surface = new Surface(app, { width: 4, height: 4 });
+    assert.equal(surface.picture(app), surface.picture());
+    assert.throws(() => surface.picture({ different: true }), /different X connection/);
+  });
+
+  test('starts blank, because a fresh pixmap holds undefined bytes', async () => {
+    const surface = new Surface(app, { width: 8, height: 8 });
+    const ctx = target();
+    ctx.drawImage(surface, 0, 0);
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(4, 4), [0, 0, 0, 0]);
+  });
+});
+
+describe('drawImage(surface)', () => {
+  test('composites what was drawn into it, at the destination', async () => {
+    const ctx = target();
+    ctx.drawImage(block('argb32', '#ff0000'), 2, 2);
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(4, 4), [255, 0, 0, 255]);
+    assert.deepEqual(px(12, 12), [0, 0, 0, 0], 'outside the 8x8 block');
+  });
+
+  test('scales to the destination rect', async () => {
+    const ctx = target();
+    ctx.drawImage(block('argb32', '#ff0000'), 0, 0, 24, 24);
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(20, 20), [255, 0, 0, 255], 'inside the scaled-up block');
+    assert.deepEqual(px(30, 30), [0, 0, 0, 0]);
+  });
+
+  test('takes anything with a size and a picture, not just its own types', async () => {
+    const surface = block('argb32', '#00ff00');
+    // the contract is these three members; the type is nobody's business
+    const alike = {
+      width: surface.width,
+      height: surface.height,
+      picture: (a) => surface.picture(a)
+    };
+    const ctx = target();
+    ctx.drawImage(alike, 1, 1);
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(4, 4), [0, 255, 0, 255]);
+  });
+});
+
+describe('coverage surfaces', () => {
+  test('one rendered copy paints in every colour it is asked for', async () => {
+    const mask = block('a8');
+    const ctx = target();
+    ctx.fillStyle = '#00ff00';
+    ctx.drawImage(mask, 2, 2);
+    ctx.fillStyle = '#0000ff';
+    ctx.drawImage(mask, 2, 20);
+
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(4, 4), [0, 255, 0, 255]);
+    assert.deepEqual(px(4, 22), [0, 0, 255, 255]);
+  });
+
+  test('globalAlpha folds into the colour, since the mask slot is taken', async () => {
+    const ctx = target();
+    ctx.fillStyle = '#ff0000';
+    ctx.globalAlpha = 0.5;
+    ctx.drawImage(block('a8'), 2, 2);
+    ctx.globalAlpha = 1;
+
+    const px = await readPixels(ctx);
+    const [r, g, b, a] = px(4, 4);
+    assert.equal(g, 0);
+    assert.equal(b, 0);
+    assert.ok(Math.abs(a - 128) <= 2, `alpha ~128, got ${a}`);
+    assert.ok(r > 200, `colour survives the fold, got r=${r}`);
+  });
+
+  test('partial coverage comes through as partial alpha', async () => {
+    const mask = new Surface(app, { width: 8, height: 8, format: 'a8' });
+    mask.render((m) => {
+      m.fillStyle = '#ffffff';
+      m.globalAlpha = 0.5;
+      m.fillRect(0, 0, 8, 8);
+    });
+    const ctx = target();
+    ctx.fillStyle = '#ff0000';
+    ctx.drawImage(mask, 2, 2);
+    const px = await readPixels(ctx);
+    assert.ok(Math.abs(px(4, 4)[3] - 128) <= 4, `half coverage, got ${px(4, 4)[3]}`);
+  });
+});
+
+describe('clipping a surface composite', () => {
+  test('a rectangular clip goes to the server, not through a full-surface mask', async () => {
+    const red = block('argb32', '#ff0000'); // painted before anything is counted
+    const ctx = target();
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, 6, 40);
+    ctx.clip();
+    const counts = countRender(['SetPictureClipRectangles', 'Composite'], () => {
+      ctx.drawImage(red, 2, 2);
+    });
+    ctx.restore();
+
+    assert.equal(counts.SetPictureClipRectangles, 2, 'set and reset around the composite');
+    assert.equal(counts.Composite, 1, 'one composite, with no mask to intersect first');
+
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(4, 4), [255, 0, 0, 255], 'inside the clip');
+    assert.deepEqual(px(8, 4), [0, 0, 0, 0], 'outside the clip');
+  });
+
+  test('a rectangular clip clips coverage surfaces too', async () => {
+    const ctx = target();
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, 6, 40);
+    ctx.clip();
+    ctx.fillStyle = '#00ff00';
+    ctx.drawImage(block('a8'), 2, 2);
+    ctx.restore();
+
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(4, 4), [0, 255, 0, 255]);
+    assert.deepEqual(px(8, 4), [0, 0, 0, 0]);
+  });
+
+  test('a non-rectangular clip still clips, through the scratch mask', async () => {
+    const ctx = target();
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(4, 4, 4, 0, Math.PI * 2);
+    ctx.clip();
+    ctx.fillStyle = '#00ff00';
+    ctx.drawImage(block('a8'), 0, 0);
+    ctx.restore();
+
+    const px = await readPixels(ctx);
+    assert.ok(px(4, 4)[3] > 200, 'the middle of the circle is painted');
+    // the far corner of the 8x8 block is outside a radius-4 circle centred at 4,4
+    assert.equal(px(9, 9)[3], 0, 'outside the circular clip');
+  });
+
+  test('an empty clip draws nothing at all', () => {
+    const red = block('argb32', '#ff0000');
+    const ctx = target();
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, 6, 6);
+    ctx.clip();
+    ctx.beginPath();
+    ctx.rect(20, 20, 6, 6); // disjoint: the intersection is empty
+    ctx.clip();
+    const counts = countRender(['Composite'], () => {
+      ctx.drawImage(red, 2, 2);
+    });
+    ctx.restore();
+    assert.equal(counts.Composite, 0);
+  });
+});
+
+describe('context teardown', () => {
+  test('destroy() releases and is idempotent', () => {
+    const pixmap = app.createPixmap({ width: 8, height: 8, depth: 32 });
+    const ctx = pixmap.getContext('2d');
+    ctx.fillStyle = '#123456';
+    ctx.fillRect(0, 0, 8, 8);
+    assert.ok(ctx.picture);
+    ctx.destroy();
+    assert.equal(ctx.picture, null);
+    ctx.destroy(); // must not throw or double-free
+  });
+
+  test('render() does not leave a context behind', () => {
+    const surface = new Surface(app, { width: 8, height: 8 });
+    let seen = null;
+    surface.render((ctx) => {
+      seen = ctx;
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, 8, 8);
+    });
+    assert.equal(seen.picture, null, 'destroyed on the way out');
+  });
+
+  test('a surface still composites after the context that drew it is gone', async () => {
+    const surface = block('argb32', '#ff00ff');
+    const ctx = target();
+    ctx.drawImage(surface, 0, 0);
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(2, 2), [255, 0, 255, 255]);
+  });
+});

--- a/test/svgview.test.js
+++ b/test/svgview.test.js
@@ -57,7 +57,7 @@ function mockCtx() {
       calls.push(['stroke', path, this.strokeStyle, this.lineWidth, this.globalAlpha]);
     },
     fillText(text, x, y) {
-      calls.push(['fillText', text, x, y, this.font, this.textAlign]);
+      calls.push(['fillText', text, x, y, this.font, this.textAlign, this.fillStyle]);
     },
     createLinearGradient(x1, y1, x2, y2) {
       const g = { type: 'linear', x1, y1, x2, y2, stops: [], addColorStop(o, c) { this.stops.push([o, c]); return this; } };
@@ -217,4 +217,147 @@ test('nested svg documents inside html-ish wrappers still parse', () => {
   const view = new SvgView(null);
   view.setSvg('<?xml version="1.0"?><!-- c --><svg viewBox="0 0 4 4"><rect width="4" height="4"/></svg>');
   assert.equal(view.naturalWidth, 4);
+});
+
+// --- external currentColor, and the mono/multi paint scan ------------------
+
+const ICON = (paint) =>
+  `<svg viewBox="0 0 24 24"><g fill="none" stroke="${paint}" stroke-width="2">` +
+  '<circle cx="12" cy="12" r="9"/><line x1="6" y1="12" x2="18" y2="12"/></g></svg>';
+
+test('currentColor resolves to the colour the caller draws with', () => {
+  const view = new SvgView(null).setSvg(ICON('currentColor'));
+  const ctx = mockCtx();
+  view.draw(ctx, 0, 0, 24, 24, { color: '#e17055' });
+  assert.equal(of(ctx.calls, 'stroke')[0][2], '#e17055');
+});
+
+test('currentColor falls back to the view colour, then to black', () => {
+  const ctx = mockCtx();
+  new SvgView(null, { color: '#0984e3' })
+    .setSvg(ICON('currentColor'))
+    .draw(ctx, 0, 0, 24, 24);
+  assert.equal(of(ctx.calls, 'stroke')[0][2], '#0984e3');
+
+  const plain = mockCtx();
+  new SvgView(null).setSvg(ICON('currentColor')).draw(plain, 0, 0, 24, 24);
+  assert.equal(of(plain.calls, 'stroke')[0][2], '#000');
+});
+
+test('a per-draw colour overrides the view colour, and does not stick', () => {
+  const view = new SvgView(null, { color: '#0984e3' }).setSvg(ICON('currentColor'));
+  const once = mockCtx();
+  view.draw(once, 0, 0, 24, 24, { color: '#d63031' });
+  assert.equal(of(once.calls, 'stroke')[0][2], '#d63031');
+  // the same parsed document, drawn again with no options
+  const after = mockCtx();
+  view.draw(after, 0, 0, 24, 24);
+  assert.equal(of(after.calls, 'stroke')[0][2], '#0984e3');
+});
+
+test('currentColor reaches text too', () => {
+  const view = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 100 100"><text x="0" y="10" fill="currentColor">hi</text></svg>'
+  );
+  const ctx = mockCtx();
+  view.draw(ctx, 0, 0, 100, 100, { color: '#00b894' });
+  assert.equal(of(ctx.calls, 'fillText')[0][6], '#00b894');
+});
+
+test('paint scan: one paint is mono, whatever that paint is', () => {
+  const literal = new SvgView(null).setSvg(ICON('#2d3436'));
+  assert.equal(literal.paintKind, 'mono');
+  assert.equal(literal.soloPaint, '#2d3436');
+
+  const deferred = new SvgView(null).setSvg(ICON('currentColor'));
+  assert.equal(deferred.paintKind, 'mono');
+  assert.equal(deferred.soloPaint, 'currentColor');
+
+  // nothing specified anywhere: shapes take the initial fill, black
+  const bare = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><rect width="10" height="10"/></svg>'
+  );
+  assert.equal(bare.paintKind, 'mono');
+  assert.equal(bare.soloPaint, '#000');
+});
+
+test('paint scan: a second distinct paint is multi', () => {
+  const two = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><rect width="4" height="4" fill="#f00"/>' +
+      '<rect x="5" width="4" height="4" fill="#0f0"/></svg>'
+  );
+  assert.equal(two.paintKind, 'multi');
+
+  // a literal alongside currentColor is two colours, not one
+  const mixed = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><rect width="4" height="4" fill="currentColor"/>' +
+      '<rect x="5" width="4" height="4" fill="#0f0"/></svg>'
+  );
+  assert.equal(mixed.paintKind, 'multi');
+});
+
+test('paint scan: a gradient or pattern reference is multi', () => {
+  const grad = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><defs><linearGradient id="g">' +
+      '<stop offset="0" stop-color="#f00"/><stop offset="1" stop-color="#00f"/>' +
+      '</linearGradient></defs><rect width="10" height="10" fill="url(#g)"/></svg>'
+  );
+  assert.equal(grad.paintKind, 'multi');
+});
+
+test('paint scan: opacity does not make a document multi-coloured', () => {
+  const faded = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><g opacity="0.5" fill="currentColor">' +
+      '<rect width="4" height="4" fill-opacity="0.3"/>' +
+      '<rect x="5" width="4" height="4"/></g></svg>'
+  );
+  assert.equal(faded.paintKind, 'mono');
+  assert.equal(faded.soloPaint, 'currentColor');
+});
+
+test('paint scan: none never counts, and a <line> contributes no fill', () => {
+  // fill is inherited black here, but a <line> is stroke-only — counting its
+  // fill would call this two-coloured and cost the cache a mask entry
+  const line = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><line x1="0" y1="0" x2="10" y2="10" stroke="#333"/></svg>'
+  );
+  assert.equal(line.paintKind, 'mono');
+  assert.equal(line.soloPaint, '#333');
+});
+
+test('paint scan: inline style beats the presentation attribute', () => {
+  const styled = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="#f00" style="fill: #0f0"/></svg>'
+  );
+  assert.equal(styled.paintKind, 'mono');
+  assert.equal(styled.soloPaint, '#0f0');
+});
+
+test('paint scan: <use> paints its target with the use element style', () => {
+  const used = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 20 10"><defs><circle id="c" cx="5" cy="5" r="4"/></defs>' +
+      '<use href="#c" fill="currentColor"/><use href="#c" x="10" fill="currentColor"/></svg>'
+  );
+  assert.equal(used.paintKind, 'mono');
+  assert.equal(used.soloPaint, 'currentColor');
+});
+
+test('paint scan: defs that nothing references contribute nothing', () => {
+  // the gradient is declared but never used — the drawing is still one colour
+  const unused = new SvgView(null).setSvg(
+    '<svg viewBox="0 0 10 10"><defs><linearGradient id="g">' +
+      '<stop offset="0" stop-color="#f00"/></linearGradient></defs>' +
+      '<rect width="10" height="10" fill="currentColor"/></svg>'
+  );
+  assert.equal(unused.paintKind, 'mono');
+  assert.equal(unused.soloPaint, 'currentColor');
+});
+
+test('paint scan: re-adopting a document re-scans it', () => {
+  const view = new SvgView(null).setSvg(ICON('currentColor'));
+  assert.equal(view.soloPaint, 'currentColor');
+  view.setSvg('<svg viewBox="0 0 10 10"><rect width="4" height="4" fill="#f00"/>' +
+    '<rect x="5" width="4" height="4" fill="#0f0"/></svg>');
+  assert.equal(view.paintKind, 'multi');
+  assert.equal(view.soloPaint, null);
 });


### PR DESCRIPTION
The ntk half of react-x11's `<svg>` rasterization cache, sidorares/react-x11#149 — steps 0 and 2 of the staging there. Two commits, each useful on its own.

## currentColor comes from the caller

An icon set names no colours: every shape says `fill="currentColor"` and the UI around it decides. `SvgView` had no way to say what that is — `INHERITED.color` was hardcoded to black — so the one thing icon markup is written for did not work. Everything downstream was already in place; only the entry point was missing.

```js
view.draw(ctx, x, y, 20, 20, { color: theme.accent });
```

A default for every draw goes on the view instead, via a `color` constructor option, which is also how window mode gets one, since `render` takes no options.

Parsing now also records **how many distinct paints** a document commits to. `paintKind` is `mono` when every fill and stroke reaching a shape is `none` or the same paint, and `soloPaint` is that paint — a colour, or the literal `currentColor` when the document defers. Anything else is `multi`.

That distinction cannot be recovered from outside without reparsing, and it is what lets a caching caller keep colour out of its cache key entirely. The scan mirrors what `draw` actually paints rather than reading attributes loosely: inheritance, inline `style` beating the presentation attribute, `<line>` contributing no fill, `<use>` painting its target with the *use* element's style, unreferenced `<defs>` contributing nothing, and starting at the root's children because presentation attributes on the root `<svg>` are not applied.

## Surface

An `Image` is a drawing uploaded from the client and composited many times. There was no equivalent for a drawing the **server** produced, so anything expensive to render and cheap to copy was re-rendered every frame.

```js
const surface = new Surface(app, { width: 20, height: 20 });
surface.render(paintTheIcon);
ctx.drawImage(surface, x, y);
```

That last line is one composite, against a document walk plus path building plus flattening plus stroking.

`format: 'a8'` stores coverage rather than colour, and `drawImage` then treats the surface as the **mask** with the current `fillStyle` as the source — the same shape `drawGlyphs` has, for the same reason. One rendered copy serves every colour it is ever asked for, at a quarter of the storage:

```js
ctx.fillStyle = theme.fg;
ctx.drawImage(mask, x, y);
ctx.fillStyle = theme.accent;
ctx.drawImage(mask, x, y + 24);
```

Both of those draw the same surface.

### Four supporting changes

- **`drawImage` no longer gates on `instanceof Image`.** The contract is `width`, `height`, `picture`, plus an optional `format` of `a8` — so a caller with its own cache satisfies it without ntk knowing the type. A `RenderingContext2d` deliberately does not match, since its `picture` is a property rather than a method, and it keeps its own branch.
- **A rectangular clip now goes to the server** via `SetPictureClipRectangles` instead of intersecting a full-surface a8 mask. Same wire cost, a fraction of the pixel work — the fast path `drawGlyphs` already had. Uniform alpha likewise becomes a 1x1 repeating picture rather than a surface-sized mask.
- **`_bindTarget` understands depth 8**, closing its own TODO about a8 support.
- **`RenderingContext2d.destroy` plus `Symbol.dispose`** — the part of #156 this needs. A context holds a GC, a Picture and a 1x1 pixmap per fill colour, and freed none of it. That was bounded while contexts lived as long as their window; creating one per surface is what makes it matter. `Surface.render` builds a context, hands it over and destroys it, so a cached surface holds two server objects rather than a dozen.

The rest of #156 is untouched here: the per-call leak in the node-canvas branch of `drawImage`, the finalizer fallback, and the two stale comments claiming node-x11 has no FreeGC.

## Testing

522 pass, 17 new. The `Surface` tests run against node-x11's in-process pure-JS X server, which implements Render compositing for real, so they assert on **pixels** — one a8 surface really does come out green in one place and blue in another. The exception is the clip fast path, where the point is which requests go out, so that one counts them: 2 `SetPictureClipRectangles` and exactly 1 `Composite`, with no mask to intersect first.

## A flaky smoke test, worth its own issue

`smoke.test.js` intermittently dies with "Promise resolution is still pending but the event loop has already resolved" on the first subtest, cancelling the rest of the file. Seen on the first run of this PR and on master's own run at afb71d6, this branch's base; also on #154 and #155, where it landed on `test (22)` rather than `test (20)`. It passes on re-run with no code change every time, so it is a timing flake against the real X server under Xvfb, not a regression and not tied to a Node version.
