### PR TITLE
feat(clipboard): watch a selection instead of polling it

### DIFF
--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -56,6 +56,48 @@ Reads the current text of a selection from whoever owns it.
 Concurrent `read()` calls on one app are serialized internally (they share
 one transfer property on the helper window).
 
+## `app.clipboard.watch(selection, handler) → Promise<function>`
+
+Call `handler` whenever a selection changes hands — the event an edit menu
+needs to grey out Paste, and what a clipboard-manager-style tool is built on.
+
+```js
+const unwatch = await app.clipboard.watch('CLIPBOARD', (ev) => {
+  pasteItem.disabled = ev.owner === 0;
+});
+
+unwatch(); // stop listening
+```
+
+The handler gets:
+
+| field | |
+| --- | --- |
+| `selection` | the name you asked for, e.g. `'CLIPBOARD'` |
+| `owner` | window now owning it, or `0` when it is unowned |
+| `timestamp` | server time of the change |
+| `selectionTimestamp` | time the current owner acquired it |
+| `reason` | `'new-owner'`, `'destroyed'` or `'closed'` |
+
+`'destroyed'` means the owning window went away, `'closed'` that the owning
+client disconnected. Both usually leave `owner` at `0`, which is the case
+worth acting on: there is nothing to paste.
+
+The alternative is polling `read()`, which is a full conversion round trip
+against whatever foreign client owns the selection — and a two second wait
+when that client is wedged. This is a server-side subscription instead, so it
+costs nothing until something changes.
+
+Watchers share one server-side registration per selection: watching
+`CLIPBOARD` twice is one extra callback and no extra protocol, and the
+registration is dropped only when the last watcher for that selection
+unsubscribes. `unwatch()` is idempotent. A handler that throws is reported
+with `console.warn` and does not cost the other watchers their event.
+
+Built on XFixes `SelectSelectionInput`. Every X server since about 2004 has
+the extension; on one that does not, `watch()` rejects saying so, rather than
+silently never firing.
+
 ## Limitations
 
 - Text only — no image or rich-content targets (yet).

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -37,6 +37,9 @@ export default class Clipboard {
     this._transferProp = null; // property reads are converted into
     this._ready = null;
     this._readQueue = Promise.resolve();
+    this._fixes = null; // XFixes extension, required on first watch()
+    this._fixesFirstEvent = -1; // its event base, to recognise its events
+    this._selectionWatchers = new Map(); // selection atom -> { name, handlers }
     this._onXEvent = this._onXEvent.bind(this);
   }
 
@@ -143,6 +146,117 @@ export default class Clipboard {
     return this._ready;
   }
 
+  /**
+   * Call `handler` whenever a selection changes hands.
+   *
+   *   const unwatch = await app.clipboard.watch('CLIPBOARD', (ev) => {
+   *     pasteItem.disabled = ev.owner === 0;
+   *   });
+   *   unwatch();
+   *
+   * The alternative is polling `read()`, which is a full conversion round
+   * trip against whatever foreign client owns the selection — and a two
+   * second wait when that client is wedged. This is a server-side
+   * subscription instead: the server tells us, and it costs nothing until
+   * something actually changes.
+   *
+   * `ev` is `{ selection, owner, timestamp, selectionTimestamp, reason }`,
+   * where `reason` is `'new-owner'` when someone took the selection,
+   * `'destroyed'` when the owning window went away, and `'closed'` when the
+   * owning client disconnected. `owner` is 0 when the selection ends up
+   * unowned, which is the case an edit menu wants: nothing to paste.
+   *
+   * Watchers share one server-side registration per selection, so watching
+   * the same selection twice costs one extra callback and no extra protocol.
+   *
+   * @param {string} selection selection atom name, e.g. 'CLIPBOARD' or 'PRIMARY'
+   * @param {function} handler called with the event
+   * @returns {Promise<function>} call it to stop watching
+   */
+  async watch(selection, handler) {
+    if (typeof handler !== 'function') {
+      throw new TypeError('clipboard: watch needs a handler function');
+    }
+    await this._ensure();
+    const fixes = await this._ensureFixes();
+    const sel = await this._atom(selection);
+
+    let entry = this._selectionWatchers.get(sel);
+    if (!entry) {
+      entry = { name: selection, handlers: new Set() };
+      this._selectionWatchers.set(sel, entry);
+      const mask =
+        fixes.SelectionEventMask.SetSelectionOwner |
+        fixes.SelectionEventMask.SelectionWindowDestroy |
+        fixes.SelectionEventMask.SelectionClientClose;
+      safeRelease(this.X, () => fixes.SelectSelectionInput(this._window.id, sel, mask));
+    }
+    entry.handlers.add(handler);
+
+    let stopped = false;
+    return () => {
+      if (stopped) return;
+      stopped = true;
+      const current = this._selectionWatchers.get(sel);
+      if (!current) return;
+      current.handlers.delete(handler);
+      if (current.handlers.size) return;
+      // last watcher for this selection: drop the server-side registration
+      this._selectionWatchers.delete(sel);
+      safeRelease(this.X, () => fixes.SelectSelectionInput(this._window.id, sel, 0));
+    };
+  }
+
+  /** XFixes, required once. Rejects with something readable on a server
+   * without it — every X server since about 2004 has had it, so this is a
+   * "your server is unusual" error rather than a routine fallback. */
+  _ensureFixes() {
+    if (this._fixes) return this._fixes;
+    this._fixes = new Promise((resolve, reject) => {
+      this.X.require('fixes', (err, fixes) => {
+        if (err || !fixes) {
+          this._fixes = null; // let a later call try again
+          return reject(
+            new Error(
+              'clipboard: this X server has no XFixes extension, so selection ' +
+                `changes cannot be watched${err ? `: ${err.message}` : ''}`
+            )
+          );
+        }
+        this._fixesFirstEvent = fixes.firstEvent;
+        resolve(fixes);
+      });
+    });
+    return this._fixes;
+  }
+
+  /** An XFixes SelectionNotify: translate the subtype and fan out. */
+  _onSelectionChange(ev, fixes) {
+    const entry = this._selectionWatchers.get(ev.selection);
+    if (!entry) return;
+    const reason =
+      ev.subtype === fixes.SelectionEvent.SelectionWindowDestroy
+        ? 'destroyed'
+        : ev.subtype === fixes.SelectionEvent.SelectionClientClose
+          ? 'closed'
+          : 'new-owner';
+    const detail = {
+      selection: entry.name,
+      owner: ev.owner,
+      timestamp: ev.timestamp,
+      selectionTimestamp: ev.selectionTimestamp,
+      reason
+    };
+    // a throwing handler must not cost the others their event
+    for (const handler of [...entry.handlers]) {
+      try {
+        handler(detail);
+      } catch (err) {
+        console.warn(`ntk: clipboard watch handler threw: ${err.message}`);
+      }
+    }
+  }
+
   _atom(name) {
     // predefined atoms (PRIMARY = 1, STRING = 31, ...) resolve without a
     // round-trip; node-x11 caches interned ones after the first reply
@@ -152,7 +266,17 @@ export default class Clipboard {
   }
 
   _onXEvent(ev) {
-    if (!this._window || (ev.type !== 29 && ev.type !== 30)) return;
+    if (!this._window) return;
+    // XFixes events carry a server-assigned type above the core range, so
+    // this cannot be confused with core SelectionNotify, which is 31
+    if (ev.type === this._fixesFirstEvent && this._selectionWatchers.size) {
+      this._fixes?.then(
+        (fixes) => this._onSelectionChange(ev, fixes),
+        () => {}
+      );
+      return;
+    }
+    if (ev.type !== 29 && ev.type !== 30) return;
     if (ev.owner !== this._window.id) return;
     if (ev.type === 29) {
       // SelectionClear: another client copied — we no longer answer for it

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -213,3 +213,21 @@ test('INCR transfer reassembles chunks split mid-codepoint', async () => {
     X.removeListener('event', onEvent);
   }
 });
+
+// --- selection watching, without XFixes ------------------------------------
+//
+// The in-process server has no XFixes, which makes it the right place to pin
+// what happens on a server that lacks it: a readable error, not a crash and
+// not silence. The working path needs a real server — see
+// test/selection-watch.test.js.
+
+test('watch() explains itself on a server without XFixes', async () => {
+  await assert.rejects(
+    () => reader.clipboard.watch('CLIPBOARD', () => {}),
+    /no XFixes extension/
+  );
+});
+
+test('watch() rejects a missing handler before touching the server', async () => {
+  await assert.rejects(() => reader.clipboard.watch('CLIPBOARD'), /needs a handler/);
+});

--- a/test/selection-watch.test.js
+++ b/test/selection-watch.test.js
@@ -1,0 +1,180 @@
+// Selection-change events (XFixes SelectSelectionInput).
+//
+// Needs a real X server: node-x11's in-process server has no XFixes, which
+// clipboard.test.js asserts separately as the documented fallback. Skipped
+// when no display is reachable, like smoke.test.js.
+//
+// Deliberately loose about *how many* events arrive. On a real desktop other
+// clients own the clipboard too — XQuartz's pasteboard bridge takes CLIPBOARD
+// back the moment anything else claims it — so these assert that the change we
+// caused was reported, not that nothing else happened.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import { createClient } from '../lib/index.js';
+
+let app = null;
+let skip = false;
+let keepalive = null;
+
+before(async () => {
+  if (!process.env.DISPLAY) {
+    skip = 'no DISPLAY set';
+    return;
+  }
+  // a ref'd handle for the file's lifetime: waiting on an X event refs the
+  // socket, but a dropped connection would otherwise let node exit mid-run
+  // and the runner could only report every subtest as cancelledByParent
+  keepalive = setInterval(() => {}, 1000);
+  try {
+    app = await createClient();
+  } catch (err) {
+    skip = `cannot connect to X server: ${err.message}`;
+  }
+});
+
+after(async () => {
+  clearInterval(keepalive);
+  if (app) await app.close();
+});
+
+/** Resolve once `predicate` accepts an event, or reject after `ms`. */
+function nextEvent(events, predicate, ms = 4000) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const poll = setInterval(() => {
+      const hit = events.find(predicate);
+      if (hit) {
+        clearInterval(poll);
+        return resolve(hit);
+      }
+      if (Date.now() - started > ms) {
+        clearInterval(poll);
+        reject(new Error(`no matching selection event within ${ms}ms`));
+      }
+    }, 25);
+  });
+}
+
+test('a watcher hears another client take the selection', async (t) => {
+  if (skip) return t.skip(skip);
+  const events = [];
+  const unwatch = await app.clipboard.watch('CLIPBOARD', (ev) => events.push(ev));
+  const other = await createClient();
+  try {
+    await other.clipboard.write('from another client');
+    const ev = await nextEvent(events, (e) => e.reason === 'new-owner');
+    assert.equal(ev.selection, 'CLIPBOARD');
+    assert.ok(ev.owner > 0, 'the new owner window is reported');
+    assert.ok(ev.timestamp > 0, 'and the server timestamp that goes with it');
+  } finally {
+    unwatch();
+    await other.close();
+  }
+});
+
+test('unwatching stops delivery', async (t) => {
+  if (skip) return t.skip(skip);
+  const events = [];
+  const unwatch = await app.clipboard.watch('CLIPBOARD', (ev) => events.push(ev));
+  unwatch();
+  const other = await createClient();
+  try {
+    await other.clipboard.write('nobody is listening');
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    assert.deepEqual(events, []);
+  } finally {
+    await other.close();
+  }
+});
+
+test('unwatching twice is harmless', async (t) => {
+  if (skip) return t.skip(skip);
+  const unwatch = await app.clipboard.watch('CLIPBOARD', () => {});
+  unwatch();
+  unwatch();
+});
+
+test('two watchers on one selection both hear it', async (t) => {
+  if (skip) return t.skip(skip);
+  const a = [];
+  const b = [];
+  const unA = await app.clipboard.watch('CLIPBOARD', (ev) => a.push(ev));
+  const unB = await app.clipboard.watch('CLIPBOARD', (ev) => b.push(ev));
+  const other = await createClient();
+  try {
+    await other.clipboard.write('two listeners');
+    await Promise.all([
+      nextEvent(a, (e) => e.reason === 'new-owner'),
+      nextEvent(b, (e) => e.reason === 'new-owner')
+    ]);
+  } finally {
+    unA();
+    unB();
+    await other.close();
+  }
+});
+
+test('dropping one of two watchers leaves the other listening', async (t) => {
+  if (skip) return t.skip(skip);
+  // the registration is shared, so releasing one watcher must not deregister
+  // the selection out from under the other
+  const kept = [];
+  const unDropped = await app.clipboard.watch('CLIPBOARD', () => {});
+  const unKept = await app.clipboard.watch('CLIPBOARD', (ev) => kept.push(ev));
+  unDropped();
+  const other = await createClient();
+  try {
+    await other.clipboard.write('still listening');
+    await nextEvent(kept, (e) => e.reason === 'new-owner');
+  } finally {
+    unKept();
+    await other.close();
+  }
+});
+
+test('a throwing handler does not cost the others their event', async (t) => {
+  if (skip) return t.skip(skip);
+  const warned = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warned.push(args.join(' '));
+  const seen = [];
+  const unBad = await app.clipboard.watch('CLIPBOARD', () => {
+    throw new Error('handler blew up');
+  });
+  const unGood = await app.clipboard.watch('CLIPBOARD', (ev) => seen.push(ev));
+  const other = await createClient();
+  try {
+    await other.clipboard.write('one bad listener');
+    await nextEvent(seen, (e) => e.reason === 'new-owner');
+    assert.ok(
+      warned.some((w) => w.includes('handler blew up')),
+      'and the failure is reported rather than swallowed'
+    );
+  } finally {
+    console.warn = realWarn;
+    unBad();
+    unGood();
+    await other.close();
+  }
+});
+
+test('PRIMARY is watched independently of CLIPBOARD', async (t) => {
+  if (skip) return t.skip(skip);
+  const primary = [];
+  const unwatch = await app.clipboard.watch('PRIMARY', (ev) => primary.push(ev));
+  const other = await createClient();
+  try {
+    await other.clipboard.write('middle-click text', { selection: 'PRIMARY' });
+    const ev = await nextEvent(primary, (e) => e.reason === 'new-owner');
+    assert.equal(ev.selection, 'PRIMARY');
+  } finally {
+    unwatch();
+    await other.close();
+  }
+});
+
+test('watch needs a handler', async (t) => {
+  if (skip) return t.skip(skip);
+  await assert.rejects(() => app.clipboard.watch('CLIPBOARD'), /needs a handler/);
+});


### PR DESCRIPTION
Closes #120.

There was no way for an ntk app to learn that the clipboard changed. An edit menu that greys out Paste when there is nothing to paste had to call `read()` on a timer or on every menu-open — a full `ConvertSelection` round trip against whatever foreign client owns the selection, and a two second wait when that client is wedged. XFixes answers exactly this question, node-x11 has shipped the binding and the event parser since 3.3.0, and nothing used it.

```js
function onChange(ev) {
  pasteItem.disabled = ev.owner === 0;
}
const unwatch = await app.clipboard.watch('CLIPBOARD', onChange);

unwatch();
```

The handler gets `{ selection, owner, timestamp, selectionTimestamp, reason }`, where `reason` is `new-owner`, `destroyed` or `closed` — the three XFixes subtypes, named rather than numbered. `owner` is `0` when the selection ends up unowned, which is the case the edit menu actually wants.

## Design notes

- **No second hidden window.** This registers on the one `Clipboard` already creates for ownership and transfers, which is what the issue asked for.
- **Shared, refcounted registrations.** Watching `CLIPBOARD` twice is one extra callback and no extra protocol; the server-side registration is dropped only when the *last* watcher for that selection goes away. There is a test that drops one of two watchers and asserts the other keeps hearing.
- **`unwatch()` is idempotent**, and a handler that throws is warned about rather than costing the other watchers their event.
- **XFixes is required lazily**, on first `watch()`. A server without it rejects with a sentence saying so rather than silently never firing.

## Testing

Eight tests against a real server, plus two hermetic ones. Both halves matter:

The real-server tests are deliberately loose about *how many* events arrive. On a real desktop other clients own the clipboard too — XQuartz's pasteboard bridge grabs `CLIPBOARD` back the moment anything else claims it — so they assert that the change we caused was reported, not that nothing else happened. Being strict there would have produced a test that passes on CI's bare Xvfb and fails on any developer's actual desktop.

The no-XFixes path is pinned hermetically, because node-x11's in-process server does not implement the extension — which makes it the ideal place to assert the fallback is a readable error rather than a crash or silence.

540 pass.

## About #119

While picking this up I found that **#119 is already implemented** — INCR on the write side, `TIMESTAMP`/`MULTIPLE`, multi-format `write()`, and real ownership timestamps — sitting uncommitted in a local working tree, with 18 passing tests. It is not in any branch here.

This PR is deliberately independent of it: it builds on `master`'s clipboard, touches only code #119 does not, and the two rebase over each other without conflict. So whichever lands first, the other still applies.
