### PR TITLE
feat(clipboard): INCR on the write side, required targets, any format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,9 @@ lib/events_map.js          X event code <-> browser-ish event name tables
                            (incl. FocusIn/FocusOut as 'focus'/'blur')
 lib/keyboard.js            key event -> keysym/codepoint: XKB group from the
                            event state, CapsLock only on cased keys
-lib/clipboard.js           app.clipboard: ICCCM selection/clipboard text
-                           transfer (CLIPBOARD/PRIMARY, INCR-aware reads)
+lib/clipboard.js           app.clipboard: ICCCM selection/clipboard transfer
+                           (CLIPBOARD/PRIMARY, required targets, INCR both
+                           ways, multi-format ownership)
 lib/renderingcontext_2d.js canvas-like context (XRender); CanvasGradient
 lib/path.js                Path2D, SVG path-data parser, affine matrices,
                            adaptive bezier flattening

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,9 @@ matching file here (see AGENTS.md).
 - [Window](window.md) — window creation, properties, methods, events,
   keyboard input, frame pacing / event coalescing, `requestAnimationFrame`
 - [Pixmap](pixmap.md) — offscreen drawables
-- [Clipboard](clipboard.md) — `app.clipboard.write()/read()`: text transfer
-  over the CLIPBOARD/PRIMARY selections (ICCCM), INCR-aware reads
+- [Clipboard](clipboard.md) — `app.clipboard.write()/read()`: transfer over
+  the CLIPBOARD/PRIMARY selections (ICCCM), multi-format ownership, INCR
+  both ways
 - [2d rendering context](context-2d.md) — canvas-like drawing API over XRender
 - [Images](images.md) — PNG/JPEG loading (`loadImage`), the `Image` object,
   `drawImage`

--- a/docs/app.md
+++ b/docs/app.md
@@ -54,7 +54,7 @@ const app2 = await createClient({ display: ':1' });
 - `app.X` — the raw node-x11 client, for direct protocol requests
 - `app.fonts` — lazy [FontManager](fonts.md): font matching/loading, shaping
 - `app.clipboard` — lazy [Clipboard](clipboard.md): selection/clipboard
-  text transfer (`write()`/`read()`)
+  transfer (`write()`/`read()`), text or arbitrary targets
 - `app.rasterizer` — the Rasterizer small fills and strokes go through;
   writable, `null` sends every drawing to the server
   ([context-2d.md](context-2d.md#swapping-the-rasterizer))

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -128,12 +128,37 @@ with `console.warn` and does not cost the other watchers their event.
 Built on XFixes `SelectSelectionInput`. Every X server since about 2004 has
 the extension; on one that does not, `watch()` rejects saying so, rather than
 silently never firing.
+### Reading a specific target
+
+`options.target` reads one named target instead of text, and resolves with a
+`Buffer` — the mirror of offering one to `write()`:
+
+```js
+const png = await app.clipboard.read({ target: 'image/png' });
+const html = await app.clipboard.read({ target: 'text/html' });
+html.toString('utf8');
+```
+
+`INCR` applies here too, so a payload larger than one request reassembles
+transparently. Rejects naming the target when the owner cannot convert to it.
+
+## `app.clipboard.targets([options]) → Promise<string[]>`
+
+What the current owner can convert to, as target names.
+
+```js
+const offered = await app.clipboard.targets();
+if (offered.includes('image/png')) {
+  const png = await app.clipboard.read({ target: 'image/png' });
+}
+```
+
+Ask this before `read({ target })`: an owner answers `TARGETS` cheaply, where
+guessing costs a failed conversion per guess. Resolves with `[]` when nothing
+owns the selection.
 
 ## Limitations
 
-- `read()` is text: it converts `UTF8_STRING`/`STRING` and returns a
-  string. Reading an arbitrary target (the `image/png` an owner offers, say)
-  is not exposed yet, even though writing one is.
 - Nothing negotiates with a clipboard manager (`SAVE_TARGETS`), so the data
   really does vanish when the app exits.
 - The `STRING` target is latin-1 by definition — codepoints above U+00FF

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -1,6 +1,6 @@
 # Clipboard
 
-`app.clipboard` transfers plain text between X clients through selections —
+`app.clipboard` transfers data between X clients through selections —
 lazily created on first use, like `app.fonts`.
 
 X has no clipboard buffer: "copy" means owning a **selection** (the
@@ -19,24 +19,55 @@ await app.clipboard.write('Hello, κόσμε!');
 const text = await app.clipboard.read(); // from whoever owns CLIPBOARD now
 ```
 
-## `app.clipboard.write(text, [options]) → Promise`
+## `app.clipboard.write(data, [options]) → Promise`
 
-Takes ownership of a selection and serves `text` to anyone who pastes.
+Takes ownership of a selection and serves `data` to anyone who pastes.
 
+- `data` — a string, or an object (or `Map`) from **target name** to
+  payload for multi-format ownership:
+
+  ```js
+  await app.clipboard.write({
+    'text/plain;charset=utf-8': 'hello',
+    'text/html': '<b>hello</b>',
+    'image/png': pngBuffer
+  });
+  ```
+
+  String payloads are encoded UTF-8 (latin-1 for the `STRING` target, which
+  is defined as latin-1); `Buffer`s and typed arrays are served as-is, so
+  the target name is the only thing that says what the bytes mean. A bare
+  string is shorthand for offering `UTF8_STRING` and `STRING`.
 - `options.selection` — selection atom name, default `'CLIPBOARD'`; use
   `'PRIMARY'` for the middle-click paste buffer.
+- `options.time` — the server timestamp of the event that triggered the
+  copy (the `time` field of the key or button event you handled). ICCCM 2.1
+  requires ownership to be taken with such a timestamp, and it is what
+  arbitrates a race with another client copying at the same moment. Without
+  one, ntk asks the server for the current time rather than using
+  `CurrentTime`, which ICCCM forbids.
 - Resolves once the server confirms the ownership; rejects if it could not
   be acquired.
-- Ownership (and the text) is held until another client copies — the
-  server's `SelectionClear` then drops the stored text — or the app closes.
-  The text lives in this process: unlike desktops with a clipboard manager,
-  closing the app makes the selection unavailable, which is normal X
-  behavior.
+- Ownership (and the data) is held until another client copies — the
+  server's `SelectionClear` then drops it — or the app closes. The data
+  lives in this process: unlike desktops with a clipboard manager, closing
+  the app makes the selection unavailable, which is normal X behavior.
 
-Requestors are offered the targets `TARGETS`, `UTF8_STRING` and `STRING`
-(latin-1, best effort — codepoints above U+00FF are lossy). Anything else
-(`MULTIPLE`, `TIMESTAMP`, images, …) is refused with a `SelectionNotify`
-carrying property `None`, as ICCCM prescribes.
+Requestors are offered the three targets ICCCM 2.6.2 makes mandatory —
+`TARGETS`, `TIMESTAMP` (the ownership timestamp, as an `INTEGER`) and
+`MULTIPLE` (a batch of conversions listed in an `ATOM_PAIR` property; pairs
+that cannot be converted come back with their property set to `None`) —
+plus whatever the call offered, in the order it offered them. Because ntk
+answers those three itself, they cannot be used as target names in `data`.
+Any other target is refused with a `SelectionNotify` carrying property
+`None`.
+
+Payloads too large for a single X request are transferred incrementally
+(`INCR`, ICCCM 2.7.2): the conversion is answered with an `INCR` property
+holding the byte count, and the chunks follow as the requestor consumes
+them. This is transparent to both sides — nothing in the API changes with
+size. A requestor that abandons a transfer is dropped after 10 seconds of
+silence.
 
 ## `app.clipboard.read([options]) → Promise<string>`
 
@@ -100,14 +131,13 @@ silently never firing.
 
 ## Limitations
 
-- Text only — no image or rich-content targets (yet).
-- `INCR` is not implemented on the **write** side: when another client
-  pastes, the whole payload goes to the server in a single `ChangeProperty`
-  request. Texts approaching the server's maximum request length (~256 KB
-  without BIG-REQUESTS, which node-x11 does not negotiate) may fail to
-  paste into other applications.
-- `SetSelectionOwner` is issued with `CurrentTime` — ntk has no "last user
-  input" timestamp to arbitrate ownership races with.
+- `read()` is text: it converts `UTF8_STRING`/`STRING` and returns a
+  string. Reading an arbitrary target (the `image/png` an owner offers, say)
+  is not exposed yet, even though writing one is.
+- Nothing negotiates with a clipboard manager (`SAVE_TARGETS`), so the data
+  really does vanish when the app exits.
+- The `STRING` target is latin-1 by definition — codepoints above U+00FF
+  are lossy there. Modern requestors ask for `UTF8_STRING`, which is not.
 
 ## Testing without a display
 
@@ -115,4 +145,5 @@ The whole protocol runs against node-x11's in-process JS X server (which
 routes `SetSelectionOwner` / `ConvertSelection` / `SendEvent` since x11
 3.1.0) — see [xserver.md](xserver.md) and `test/clipboard.test.js`, where
 two ntk clients and raw node-x11 clients (a `STRING`-only legacy owner, an
-`INCR` owner) pass text to each other hermetically.
+`INCR` owner, requestors asking for `TARGETS`, `TIMESTAMP`, `MULTIPLE` and
+`INCR` payloads) pass data to each other hermetically.

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -2,7 +2,7 @@ import x11 from 'x11';
 
 import { safeRelease } from './cleanup.js';
 
-// Clipboard (app.clipboard): ICCCM selection transfer for plain text.
+// Clipboard (app.clipboard): ICCCM selection transfer.
 //
 // X has no clipboard buffer — "copy" means owning a selection atom
 // (CLIPBOARD for explicit copy/paste, PRIMARY for middle-click paste) and
@@ -11,30 +11,53 @@ import { safeRelease } from './cleanup.js';
 // module hides that dance behind write()/read() promises, using a hidden
 // 1x1 never-mapped helper window as the selection endpoint.
 //
-// Supported targets when ntk owns a selection: TARGETS, UTF8_STRING and
-// STRING (latin-1, best effort). Everything else — MULTIPLE, TIMESTAMP,
-// images — is refused with SelectionNotify property None per ICCCM.
+// As an owner, ntk answers the three targets ICCCM 2.6.2 makes mandatory
+// (TARGETS, TIMESTAMP, MULTIPLE) plus whatever the caller offered: a string
+// is served as UTF8_STRING and STRING (latin-1, best effort), an object maps
+// target names to payloads, so HTML, images and — later — XDND drags are the
+// same machinery. Payloads larger than one request are transferred
+// incrementally (INCR, ICCCM 2.7.2), in both directions.
 //
 // Reads prefer UTF8_STRING and retry once with STRING when the owner
-// refuses (old Xt/Motif apps). Incremental (INCR) transfers are supported
-// on the read side, so pasting more than the server's transfer limit works.
-//
-// LIMITATION: INCR is NOT implemented on the write side — write() hands the
-// whole payload to the server in a single ChangeProperty when a requestor
-// converts. Texts approaching the server's maximum request length (~256KB
-// on servers without BIG-REQUESTS, node-x11 does not negotiate it) may fail
-// to paste into other applications.
+// refuses (old Xt/Motif apps).
 
 const DEFAULT_TIMEOUT = 2000;
+// An INCR transfer we are feeding is driven entirely by the requestor: each
+// chunk goes out in answer to its property deletion. A requestor that stops
+// (or dies mid-paste) would otherwise leave us holding its payload and an
+// event mask on its window forever, so give up after this much silence.
+const INCR_TIMEOUT = 10000;
+// node-x11 writes ChangeProperty's length field as a CARD16 — only PutImage
+// emits the BIG-REQUESTS extended form — so a request can never exceed
+// 65535 four-byte units however much the server allows.
+const REQUEST_UNITS_LIMIT = 0xffff;
+
+const isBinary = (value) => ArrayBuffer.isView(value) || value instanceof ArrayBuffer;
+
+// payload bytes for one target: text is UTF-8 (latin-1 for STRING, which is
+// defined as latin-1), binary is taken as-is
+const encodePayload = (value, name) => {
+  if (typeof value === 'string') return Buffer.from(value, name === 'STRING' ? 'latin1' : 'utf8');
+  if (Buffer.isBuffer(value)) return value;
+  if (ArrayBuffer.isView(value))
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  if (value instanceof ArrayBuffer) return Buffer.from(value);
+  throw new TypeError(`clipboard: the ${name} payload must be a string or binary data`);
+};
 
 export default class Clipboard {
   constructor(app) {
     this.app = app;
     this.X = app.X;
     this._window = null; // hidden helper window, created on first use
-    this._owned = new Map(); // selection atom -> text we serve
-    this._atoms = null; // { TARGETS, UTF8_STRING, INCR }
+    this._owned = new Map(); // selection atom -> { time, targets }
+    this._atoms = null; // { TARGETS, TIMESTAMP, MULTIPLE, ATOM_PAIR, UTF8_STRING, INCR }
     this._transferProp = null; // property reads are converted into
+    this._timeProp = null; // property the server-timestamp trick appends to
+    this._transfers = new Map(); // `requestor:property` -> INCR transfer we feed
+    this._watched = new Map(); // requestor wid -> { count, mask } while feeding
+    this._transferLimit = null; // bytes one ChangeProperty can carry
+    this._incrTimeout = INCR_TIMEOUT;
     this._ready = null;
     this._readQueue = Promise.resolve();
     this._fixes = null; // XFixes extension, required on first watch()
@@ -44,24 +67,44 @@ export default class Clipboard {
   }
 
   /**
-   * Take ownership of a selection and serve `text` to anyone who pastes.
+   * Take ownership of a selection and serve `data` to anyone who pastes.
    * Resolves once the server confirms the ownership; ownership (and the
-   * text) is held until another client copies or the app closes.
+   * data) is held until another client copies or the app closes.
    *
-   * @param {string} text
+   * `data` is either a string — offered as UTF8_STRING and STRING — or an
+   * object (or Map) from target name to payload, which is how richer
+   * formats are published:
+   *
+   *   await app.clipboard.write({
+   *     'text/plain;charset=utf-8': 'hello',
+   *     'text/html': '<b>hello</b>',
+   *     'image/png': pngBuffer
+   *   });
+   *
+   * String payloads are encoded UTF-8 (latin-1 for the STRING target);
+   * Buffers/TypedArrays are served as-is. TARGETS, TIMESTAMP and MULTIPLE
+   * are answered by ntk itself and cannot be offered as data.
+   *
+   * @param {string|object|Map} data
    * @param {object} [options] { selection: 'CLIPBOARD' (default) or
-   *   'PRIMARY' (middle-click paste) — any selection atom name works }
+   *   'PRIMARY' (middle-click paste) — any selection atom name works;
+   *   time: the server timestamp of the event that triggered the copy
+   *   (ICCCM 2.1). Without one ntk asks the server for the current time
+   *   rather than using CurrentTime, which ICCCM forbids }
    * @returns {Promise<void>}
    */
-  async write(text, { selection = 'CLIPBOARD' } = {}) {
+  async write(data, { selection = 'CLIPBOARD', time } = {}) {
     await this._ensure();
-    const sel = await this._atom(selection);
-    this._owned.set(sel, String(text));
-    // time 0 = CurrentTime: best effort — ntk has no "last user input"
-    // timestamp to arbitrate ownership races with (ICCCM prefers one)
-    this.X.SetSelectionOwner(this._window.id, sel, 0);
+    const [sel, targets] = await Promise.all([this._atom(selection), this._encode(data)]);
+    // ICCCM 2.1: never CurrentTime. The timestamp of the event that
+    // triggered the copy is the right one — it is what arbitrates a race
+    // with another app copying at the same moment. Without one, "now" is
+    // still a real timestamp, and one no server will reject as stale.
+    const stamp = time === undefined ? await this._serverTime() : time >>> 0;
+    this._owned.set(sel, { time: stamp, targets });
+    this.X.SetSelectionOwner(this._window.id, sel, stamp);
     // SetSelectionOwner is void: confirm via GetSelectionOwner that the
-    // server actually made us the owner
+    // server actually made us the owner (it ignores a stale timestamp)
     const owner = await new Promise((resolve, reject) =>
       this.X.GetSelectionOwner(sel, (err, wid) => (err ? reject(err) : resolve(wid)))
     );
@@ -129,18 +172,27 @@ export default class Clipboard {
         height: 1,
         eventMask: x11.eventMask.PropertyChange
       });
-      const [TARGETS, UTF8_STRING, INCR, transferProp] = await Promise.all([
-        this._atom('TARGETS'),
-        this._atom('UTF8_STRING'),
-        this._atom('INCR'),
-        this._atom('NTK_SELECTION')
-      ]);
-      this._atoms = { TARGETS, UTF8_STRING, INCR };
+      const [TARGETS, TIMESTAMP, MULTIPLE, ATOM_PAIR, UTF8_STRING, INCR, transferProp, timeProp] =
+        await Promise.all(
+          [
+            'TARGETS',
+            'TIMESTAMP',
+            'MULTIPLE',
+            'ATOM_PAIR',
+            'UTF8_STRING',
+            'INCR',
+            'NTK_SELECTION',
+            'NTK_TIME'
+          ].map((name) => this._atom(name))
+        );
+      this._atoms = { TARGETS, TIMESTAMP, MULTIPLE, ATOM_PAIR, UTF8_STRING, INCR };
       this._transferProp = transferProp;
+      this._timeProp = timeProp;
       // SelectionRequest/SelectionClear carry the owner in ev.owner, not
       // ev.wid, so node-x11's event_consumers routing (keyed on ev.wid)
       // never delivers them to the Window wrapper — listen on the raw
-      // client instead
+      // client instead. INCR chunk pacing needs PropertyNotify for the
+      // requestor's window, which is not ours either.
       this.X.on('event', this._onXEvent);
     })();
     return this._ready;
@@ -265,6 +317,75 @@ export default class Clipboard {
     );
   }
 
+  // every server call from an event handler runs inside the packet parser's
+  // emit: if the connection is closing, drop it instead of throwing
+  _send(fn) {
+    safeRelease(this.X, fn);
+  }
+
+  // name -> payload map for one selection, target names resolved to atoms
+  async _encode(data) {
+    const a = this._atoms;
+    if (data === null || typeof data !== 'object') {
+      const text = String(data);
+      const STRING = this.X.atoms.STRING;
+      return new Map([
+        [a.UTF8_STRING, { type: a.UTF8_STRING, format: 8, data: Buffer.from(text, 'utf8') }],
+        [STRING, { type: STRING, format: 8, data: Buffer.from(text, 'latin1') }]
+      ]);
+    }
+    if (isBinary(data)) {
+      throw new TypeError(
+        "clipboard: binary data needs a target name — write({ 'image/png': buffer })"
+      );
+    }
+    const entries = data instanceof Map ? [...data] : Object.entries(data);
+    if (!entries.length) throw new TypeError('clipboard: write() needs at least one target');
+    const atoms = await Promise.all(entries.map(([name]) => this._atom(name)));
+    const targets = new Map();
+    entries.forEach(([name, value], i) => {
+      const atom = atoms[i];
+      if (atom === a.TARGETS || atom === a.TIMESTAMP || atom === a.MULTIPLE) {
+        throw new TypeError(`clipboard: ${name} is answered by ntk and cannot be offered as data`);
+      }
+      targets.set(atom, { type: atom, format: 8, data: encodePayload(value, name) });
+    });
+    return targets;
+  }
+
+  // A current server timestamp, the way X clients without a triggering
+  // event get one: append zero bytes to a property on a window we watch and
+  // take the time from the PropertyNotify it generates. Falls back to 0
+  // (CurrentTime) rather than making write() hang.
+  _serverTime() {
+    return new Promise((resolve) => {
+      const done = (time) => {
+        clearTimeout(timer);
+        this._window.removeListener('property', onProperty);
+        resolve(time);
+      };
+      const onProperty = (ev) => {
+        if (ev.atom === this._timeProp && ev.state === 0) done(ev.time >>> 0);
+      };
+      const timer = setTimeout(() => done(0), DEFAULT_TIMEOUT);
+      timer.unref?.();
+      this._window.on('property', onProperty);
+      const empty = Buffer.alloc(0);
+      this.X.ChangeProperty(2, this._window.id, this._timeProp, this.X.atoms.STRING, 8, empty);
+    });
+  }
+
+  // largest payload one ChangeProperty can carry; beyond it a conversion is
+  // answered incrementally. Tests lower it to exercise INCR cheaply.
+  _limit() {
+    if (this._transferLimit === null) {
+      const offered = this.app.display.max_request_length || REQUEST_UNITS_LIMIT;
+      const units = Math.min(offered, REQUEST_UNITS_LIMIT);
+      this._transferLimit = units * 4 - 24 - 4; // ChangeProperty header, padding
+    }
+    return this._transferLimit;
+  }
+
   _onXEvent(ev) {
     if (!this._window) return;
     // XFixes events carry a server-assigned type above the core range, so
@@ -276,62 +397,248 @@ export default class Clipboard {
       );
       return;
     }
+    if (ev.type === 28) {
+      // PropertyNotify, state 1 = Deleted: a requestor consumed the INCR
+      // chunk we gave it and is asking for the next one
+      if (ev.state === 1 && this._transfers.size) this._onChunkConsumed(ev);
+      return;
+    }
     if (ev.type !== 29 && ev.type !== 30) return;
     if (ev.owner !== this._window.id) return;
     if (ev.type === 29) {
-      // SelectionClear: another client copied — we no longer answer for it
+      // SelectionClear: another client copied — we no longer answer for it.
+      // Transfers already under way keep their own copy of the data and
+      // must still finish (ICCCM 2.7.2).
       this._owned.delete(ev.selection);
     } else {
       this._onSelectionRequest(ev);
     }
   }
 
-  // we own the selection and somebody is pasting: write the converted data
-  // to the requestor's property and confirm (or refuse) via SelectionNotify
+  // we own the selection and somebody is pasting
   _onSelectionRequest(ev) {
-    const X = this.X;
-    const a = this._atoms;
-    const text = this._owned.get(ev.selection);
+    this._answer(ev).catch(() => {
+      // a step of the conversion failed outright (a requestor that vanished
+      // mid-paste, most likely) after we had already answered: nothing left
+      // to say, and the requestor's own timeout covers it
+    });
+  }
+
+  // write the converted data to the requestor's property and confirm (or
+  // refuse) via SelectionNotify
+  async _answer(ev) {
+    const entry = this._owned.get(ev.selection);
     // obsolete requestors may pass property None — ICCCM says use the
     // target atom as the property name then
     let property = ev.property || ev.target;
-    // the whole answer runs from the packet parser's emit: if the
-    // connection is closing, drop it instead of throwing (see cleanup.js)
-    safeRelease(X, () => {
-      if (text === undefined) {
-        property = 0; // raced with a SelectionClear we haven't seen yet
-      } else if (ev.target === a.TARGETS) {
-        // x11 >= 3.4 encodes a number array at the property's declared
-        // format, so this reaches the requestor as three CARD32 atoms
-        X.ChangeProperty(0, ev.requestor, property, X.atoms.ATOM, 32, [
-          a.TARGETS,
-          a.UTF8_STRING,
-          X.atoms.STRING
-        ]);
-      } else if (ev.target === a.UTF8_STRING) {
-        X.ChangeProperty(0, ev.requestor, property, a.UTF8_STRING, 8, Buffer.from(text, 'utf8'));
-      } else if (ev.target === X.atoms.STRING) {
-        // latin-1 best effort: codepoints above U+00FF are lossy here;
-        // modern requestors ask for UTF8_STRING
-        X.ChangeProperty(0, ev.requestor, property, X.atoms.STRING, 8, Buffer.from(text, 'latin1'));
-      } else {
-        // unsupported target (MULTIPLE, TIMESTAMP, images, ...): refuse
-        // with property None per ICCCM
-        property = 0;
+    let served = false;
+    try {
+      if (entry) {
+        served =
+          ev.target === this._atoms.MULTIPLE
+            ? await this._serveMultiple(ev, entry, property)
+            : await this._serveTarget(ev.requestor, property, ev.target, entry);
       }
-      // mask 0: SelectionNotify is addressed to the requestor itself, so it
-      // goes to the client that created that window rather than to whoever
-      // selected events on it (ICCCM 2.2)
-      X.SendEvent(ev.requestor, 0, 0, {
+      // entry undefined: raced with a SelectionClear we haven't seen yet
+    } catch {
+      served = false; // refuse rather than leave the requestor waiting
+    }
+    if (!served) property = 0;
+    // mask 0: SelectionNotify is addressed to the requestor itself, so it
+    // goes to the client that created that window rather than to whoever
+    // selected events on it (ICCCM 2.2)
+    this._send(() =>
+      this.X.SendEvent(ev.requestor, 0, 0, {
         name: 'SelectionNotify',
         time: ev.time,
         requestor: ev.requestor,
         selection: ev.selection,
         target: ev.target,
         property
-      });
-    });
+      })
+    );
   }
+
+  // convert one target into one property on the requestor's window;
+  // false means "cannot convert", which the caller turns into a refusal
+  async _serveTarget(requestor, property, target, entry) {
+    const X = this.X;
+    const a = this._atoms;
+    if (target === a.TARGETS) {
+      // x11 >= 3.4 encodes a number array at the property's declared
+      // format, so this reaches the requestor as CARD32 atoms
+      this._send(() =>
+        X.ChangeProperty(0, requestor, property, X.atoms.ATOM, 32, [
+          a.TARGETS,
+          a.TIMESTAMP,
+          a.MULTIPLE,
+          ...entry.targets.keys()
+        ])
+      );
+      return true;
+    }
+    if (target === a.TIMESTAMP) {
+      // ICCCM 2.6.2: the timestamp this selection was acquired with, as an
+      // INTEGER — Xt-based requestors ask for it before anything else
+      this._send(() => X.ChangeProperty(0, requestor, property, X.atoms.INTEGER, 32, [entry.time]));
+      return true;
+    }
+    // MULTIPLE inside MULTIPLE is not allowed, and a bare MULTIPLE never
+    // reaches here (its own branch runs first)
+    if (target === a.MULTIPLE) return false;
+    const value = entry.targets.get(target);
+    if (!value) return false;
+    if (value.data.length > this._limit()) {
+      await this._startIncr(requestor, property, value);
+      return true;
+    }
+    this._send(() =>
+      X.ChangeProperty(0, requestor, property, value.type, value.format, value.data)
+    );
+    return true;
+  }
+
+  // MULTIPLE (ICCCM 2.6.2): the requestor left a list of (target, property)
+  // pairs on its own window; convert each one and hand the list back with
+  // None in place of the properties we could not fill.
+  async _serveMultiple(ev, entry, property) {
+    const pairs = await this._getProperty(property, ev.requestor, 0);
+    // the list is defined as ATOM_PAIR, but requestors have been known to
+    // label it otherwise: what matters is that it decodes as 32-bit pairs
+    if (!pairs || pairs.format !== 32 || !pairs.data.length || pairs.data.length % 8) return false;
+    const list = Buffer.from(pairs.data);
+    let refused = false;
+    for (let o = 0; o < list.length; o += 8) {
+      const target = list.readUInt32LE(o);
+      const prop = list.readUInt32LE(o + 4);
+      if (!prop) continue; // already None
+      if (!(await this._serveTarget(ev.requestor, prop, target, entry))) {
+        list.writeUInt32LE(0, o + 4);
+        refused = true;
+      }
+    }
+    if (refused) {
+      const type = pairs.type || this._atoms.ATOM_PAIR;
+      this._send(() => this.X.ChangeProperty(0, ev.requestor, property, type, 32, list));
+    }
+    return true;
+  }
+
+  // ---- INCR, owner side (ICCCM 2.7.2): the mirror of _fetchProperty ----
+
+  // Answer the conversion with an INCR property holding a lower bound on
+  // the byte count; the requestor deleting that property starts the chunks.
+  async _startIncr(requestor, property, value) {
+    const key = `${requestor}:${property}`;
+    this._endTransfer(key); // a new conversion supersedes an unfinished one
+    await this._watch(requestor);
+    const transfer = {
+      key,
+      requestor,
+      property,
+      type: value.type,
+      format: value.format,
+      data: value.data,
+      offset: 0,
+      terminated: false,
+      timer: null
+    };
+    this._transfers.set(key, transfer);
+    this._touch(transfer);
+    this._send(() =>
+      this.X.ChangeProperty(0, requestor, property, this._atoms.INCR, 32, [value.data.length])
+    );
+  }
+
+  _onChunkConsumed(ev) {
+    const transfer = this._transfers.get(`${ev.wid}:${ev.atom}`);
+    if (!transfer) return;
+    if (transfer.terminated) {
+      // the zero-length property that ended the transfer has been read
+      this._endTransfer(transfer.key);
+      return;
+    }
+    const chunk = transfer.data.subarray(transfer.offset, transfer.offset + this._limit());
+    transfer.offset += chunk.length;
+    // an empty chunk is the end marker, not a chunk
+    if (chunk.length === 0) transfer.terminated = true;
+    this._touch(transfer);
+    this._send(() =>
+      this.X.ChangeProperty(
+        0,
+        transfer.requestor,
+        transfer.property,
+        transfer.type,
+        transfer.format,
+        chunk
+      )
+    );
+  }
+
+  _touch(transfer) {
+    clearTimeout(transfer.timer);
+    transfer.timer = setTimeout(() => this._endTransfer(transfer.key), this._incrTimeout);
+    transfer.timer.unref?.();
+  }
+
+  _endTransfer(key) {
+    const transfer = this._transfers.get(key);
+    if (!transfer) return;
+    clearTimeout(transfer.timer);
+    this._transfers.delete(key);
+    this._unwatch(transfer.requestor);
+  }
+
+  // PropertyNotify on the requestor's window is how the chunks are paced.
+  // Event masks are per-client, so ours is ours to set — but restore what
+  // we found: with a self-paste the requestor is our own helper window,
+  // whose PropertyChange the read path depends on.
+  async _watch(requestor) {
+    let watch = this._watched.get(requestor);
+    if (!watch) {
+      // register before the round trip, not after it: ICCCM lets a
+      // requestor run several conversions at once (on distinct properties),
+      // and those must share one watch rather than race to install it
+      watch = { count: 0, mask: 0 };
+      watch.ready = new Promise((resolve, reject) =>
+        this.X.GetWindowAttributes(requestor, (err, attrs) =>
+          err ? reject(err) : resolve(attrs.myEventMasks)
+        )
+      ).then((mask) => {
+        watch.mask = mask;
+        if (mask & x11.eventMask.PropertyChange) return;
+        this._send(() =>
+          this.X.ChangeWindowAttributes(
+            requestor,
+            { eventMask: mask | x11.eventMask.PropertyChange },
+            () => true
+          )
+        );
+      });
+      this._watched.set(requestor, watch);
+    }
+    watch.count++;
+    try {
+      await watch.ready;
+    } catch (err) {
+      this._unwatch(requestor); // the requestor is gone; do not keep its entry
+      throw err;
+    }
+  }
+
+  _unwatch(requestor) {
+    const watch = this._watched.get(requestor);
+    if (!watch || --watch.count > 0) return;
+    this._watched.delete(requestor);
+    if (watch.mask & x11.eventMask.PropertyChange) return;
+    // () => true swallows the BadWindow of a requestor that destroyed its
+    // window as soon as the paste completed — the usual ending
+    this._send(() =>
+      this.X.ChangeWindowAttributes(requestor, { eventMask: watch.mask }, () => true)
+    );
+  }
+
+  // ---- INCR, requestor side ----
 
   // ConvertSelection and wait for the owner's SelectionNotify answer
   _convert(sel, target, prop, selectionName, timeout) {
@@ -360,11 +667,11 @@ export default class Clipboard {
     });
   }
 
-  _getProperty(prop) {
+  _getProperty(prop, wid = this._window.id, del = 1) {
     // delete=true: for plain transfers frees the property; for INCR chunks
     // it doubles as the "send the next chunk" handshake
     return new Promise((resolve, reject) =>
-      this.X.GetProperty(1, this._window.id, prop, 0, 0, 0x1fffffff, (err, res) =>
+      this.X.GetProperty(del, wid, prop, 0, 0, 0x1fffffff, (err, res) =>
         err ? reject(err) : resolve(res)
       )
     );

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -124,13 +124,84 @@ export default class Clipboard {
    *   timeout: ms to wait for the owner at each protocol step }
    * @returns {Promise<string>}
    */
-  read({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT } = {}) {
-    // serialize: concurrent reads would share the one transfer property on
-    // the helper window, so let each conversion finish before the next
-    const run = () => this._read(selection, timeout);
+  read({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT, target } = {}) {
+    return this._serialize(() =>
+      target === undefined
+        ? this._read(selection, timeout)
+        : this._readTarget(selection, target, timeout)
+    );
+  }
+
+  /**
+   * What the current owner of a selection can convert to, as target names.
+   *
+   *   const offered = await app.clipboard.targets();
+   *   if (offered.includes('image/png')) { ... }
+   *
+   * This is the question to ask before `read({ target })`: an owner answers
+   * `TARGETS` cheaply, where guessing costs a failed conversion per guess.
+   * Returns `[]` when nothing owns the selection.
+   *
+   * @param {object} [options] { selection, timeout }
+   * @returns {Promise<string[]>}
+   */
+  targets({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT } = {}) {
+    return this._serialize(() => this._targets(selection, timeout));
+  }
+
+  /** Concurrent conversions would share the one transfer property on the
+   * helper window, so let each finish before the next starts. */
+  _serialize(run) {
     const result = this._readQueue.then(run, run);
     this._readQueue = result.catch(() => {});
     return result;
+  }
+
+  async _targets(selection, timeout) {
+    await this._ensure();
+    const sel = await this._atom(selection);
+    const prop = this._transferProp;
+    const notify = await this._convert(sel, this._atoms.TARGETS, prop, selection, timeout);
+    if (notify.property === 0) return [];
+    const { data, format } = await this._fetchProperty(prop, selection, timeout);
+    // an INCR reassembly reports no format, and a target list is far too
+    // small to arrive that way — so only a stated non-32 format disqualifies
+    if (format !== undefined && format !== 32) return [];
+    const atoms = [];
+    for (let o = 0; o + 4 <= data.length; o += 4) atoms.push(data.readUInt32LE(o));
+    const names = await Promise.all(atoms.map((atom) => this._atomName(atom)));
+    return names.filter(Boolean);
+  }
+
+  /**
+   * Read one named target, as bytes. The mirror of writing one: what
+   * `write({ 'image/png': buf })` publishes, this is how another ntk app
+   * gets it back.
+   */
+  async _readTarget(selection, target, timeout) {
+    await this._ensure();
+    const sel = await this._atom(selection);
+    const atom = await this._atom(target);
+    const prop = this._transferProp;
+    const notify = await this._convert(sel, atom, prop, selection, timeout);
+    if (notify.property === 0) {
+      const owner = await new Promise((resolve, reject) =>
+        this.X.GetSelectionOwner(sel, (err, wid) => (err ? reject(err) : resolve(wid)))
+      );
+      throw new Error(
+        owner
+          ? `clipboard: ${selection} selection owner cannot convert to ${target}`
+          : `clipboard: nothing to paste — ${selection} selection has no owner`
+      );
+    }
+    const { data } = await this._fetchProperty(prop, selection, timeout);
+    return data;
+  }
+
+  _atomName(atom) {
+    return new Promise((resolve) =>
+      this.X.GetAtomName(atom, (err, name) => resolve(err ? null : name))
+    );
   }
 
   async _read(selection, timeout) {

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -60,12 +60,52 @@ const selectionNotify = (time, requestor, selection, target, property) => {
   return b;
 };
 
-const rawWindow = (display) => {
+const rawWindow = (display, eventMask = 0) => {
   const X = display.client;
   const wid = X.AllocID();
-  X.CreateWindow(wid, display.screen[0].root, 0, 0, 1, 1, 0, 0, 0, 0, {});
+  X.CreateWindow(wid, display.screen[0].root, 0, 0, 1, 1, 0, 0, 0, 0, { eventMask });
   return wid;
 };
+
+// ConvertSelection from a raw client and wait for the owner's answer
+const rawConvert = (X, wid, selection, target, property) =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      X.removeListener('event', onEvent);
+      reject(new Error('no SelectionNotify'));
+    }, 2000);
+    const onEvent = (ev) => {
+      if (ev.type !== 31 || ev.requestor !== wid || ev.target !== target) return;
+      clearTimeout(timer);
+      X.removeListener('event', onEvent);
+      resolve(ev);
+    };
+    X.on('event', onEvent);
+    X.ConvertSelection(wid, selection, target, property, 0);
+  });
+
+// the requestor half of ICCCM 2.7.2: collect chunks until a zero-length one.
+// Call before deleting the INCR property — that delete starts the transfer.
+const rawIncrRead = (X, wid, prop) =>
+  new Promise((resolve, reject) => {
+    const chunks = [];
+    const finish = (err, data) => {
+      clearTimeout(timer);
+      X.removeListener('event', onEvent);
+      return err ? reject(err) : resolve(data);
+    };
+    const timer = setTimeout(() => finish(new Error('INCR transfer stalled')), 4000);
+    const onEvent = (ev) => {
+      if (ev.type !== 28 || ev.wid !== wid || ev.atom !== prop || ev.state !== 0) return;
+      // delete=1 is the "next chunk please" handshake
+      X.GetProperty(1, wid, prop, 0, 0, 0x1fffffff, (err, res) => {
+        if (err) return finish(err);
+        if (res.data.length === 0) return finish(null, Buffer.concat(chunks));
+        chunks.push(res.data);
+      });
+    };
+    X.on('event', onEvent);
+  });
 
 test('round-trip between two clients, including non-ASCII UTF-8', async () => {
   const text = 'Hello, κόσμε! 🎉 — ntk';
@@ -110,36 +150,325 @@ test('ownership handover: last writer wins, loser forgets its text', async () =>
   assert.equal(writer.clipboard._owned.has(clipboardAtom), false);
 });
 
-test('TARGETS lists [TARGETS, UTF8_STRING, STRING]; unknown targets are refused', async () => {
+test('TARGETS lists the required three plus the text targets; unknown ones are refused', async () => {
   await writer.clipboard.write('anything');
   const X = raw.client;
   const wid = rawWindow(raw);
-  const [CLIPBOARD, TARGETS, UTF8_STRING, PROP, PNG] = await Promise.all(
-    ['CLIPBOARD', 'TARGETS', 'UTF8_STRING', 'NTK_TEST_PROP', 'image/png'].map((n) => atom(X, n))
+  const [CLIPBOARD, TARGETS, TIMESTAMP, MULTIPLE, UTF8_STRING, PROP, PNG] = await Promise.all(
+    [
+      'CLIPBOARD',
+      'TARGETS',
+      'TIMESTAMP',
+      'MULTIPLE',
+      'UTF8_STRING',
+      'NTK_TEST_PROP',
+      'image/png'
+    ].map((n) => atom(X, n))
   );
-
-  const convert = (target) =>
-    new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('no SelectionNotify')), 2000);
-      const onEvent = (ev) => {
-        if (ev.type !== 31 || ev.requestor !== wid) return;
-        clearTimeout(timer);
-        X.removeListener('event', onEvent);
-        resolve(ev);
-      };
-      X.on('event', onEvent);
-      X.ConvertSelection(wid, CLIPBOARD, target, PROP, 0);
-    });
+  const convert = (target) => rawConvert(X, wid, CLIPBOARD, target, PROP);
 
   const targetsReply = await convert(TARGETS);
   assert.equal(targetsReply.property, PROP, 'TARGETS conversion succeeds');
   const prop = await getProperty(X, wid, PROP);
   assert.equal(prop.type, X.atoms.ATOM);
-  const offered = [0, 4, 8].map((o) => prop.data.readUInt32LE(o));
-  assert.deepEqual(offered, [TARGETS, UTF8_STRING, X.atoms.STRING]);
+  const offered = [];
+  for (let o = 0; o < prop.data.length; o += 4) offered.push(prop.data.readUInt32LE(o));
+  assert.deepEqual(offered, [TARGETS, TIMESTAMP, MULTIPLE, UTF8_STRING, X.atoms.STRING]);
 
   const refused = await convert(PNG);
   assert.equal(refused.property, 0, 'unsupported target refused with property None');
+});
+
+test('TIMESTAMP answers the ownership time, which is never CurrentTime', async () => {
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [CLIPBOARD, TIMESTAMP, PROP] = await Promise.all(
+    ['CLIPBOARD', 'TIMESTAMP', 'NTK_TEST_PROP'].map((n) => atom(X, n))
+  );
+
+  await writer.clipboard.write('stamped');
+  const owned = writer.clipboard._owned.get(await atom(writer.X, 'CLIPBOARD'));
+  // ICCCM 2.1 forbids acquiring with CurrentTime; with no event timestamp
+  // to hand, ntk asks the server for one
+  assert.notEqual(owned.time, 0, 'ownership acquired with a real timestamp');
+
+  const reply = await rawConvert(X, wid, CLIPBOARD, TIMESTAMP, PROP);
+  assert.equal(reply.property, PROP, 'TIMESTAMP conversion succeeds');
+  const prop = await getProperty(X, wid, PROP);
+  assert.equal(prop.type, X.atoms.INTEGER);
+  assert.equal(prop.data.readUInt32LE(0), owned.time);
+
+  // an explicit event timestamp (what a toolkit routing key events has) wins
+  await writer.clipboard.write('stamped by the caller', {
+    selection: 'NTK_TEST_STAMP',
+    time: 4242
+  });
+  const stamped = await rawConvert(
+    X,
+    wid,
+    await atom(X, 'NTK_TEST_STAMP'),
+    TIMESTAMP,
+    PROP
+  );
+  assert.equal(stamped.property, PROP);
+  assert.equal((await getProperty(X, wid, PROP)).data.readUInt32LE(0), 4242);
+});
+
+test('MULTIPLE converts every pair it can and marks the rest None', async () => {
+  await writer.clipboard.write('multi');
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [CLIPBOARD, MULTIPLE, UTF8_STRING, ATOM_PAIR, LIST, P1, P2, PNG] = await Promise.all(
+    [
+      'CLIPBOARD',
+      'MULTIPLE',
+      'UTF8_STRING',
+      'ATOM_PAIR',
+      'NTK_TEST_LIST',
+      'NTK_TEST_P1',
+      'NTK_TEST_P2',
+      'image/png'
+    ].map((n) => atom(X, n))
+  );
+
+  // (UTF8_STRING -> P1) can be converted, (image/png -> P2) cannot
+  X.ChangeProperty(0, wid, LIST, ATOM_PAIR, 32, [UTF8_STRING, P1, PNG, P2]);
+  const reply = await rawConvert(X, wid, CLIPBOARD, MULTIPLE, LIST);
+  assert.equal(reply.property, LIST, 'MULTIPLE itself is not refused');
+
+  const list = await getProperty(X, wid, LIST);
+  assert.equal(list.data.readUInt32LE(4), P1, 'converted pair keeps its property');
+  assert.equal(list.data.readUInt32LE(12), 0, 'unconvertible pair comes back as None');
+
+  assert.equal((await getProperty(X, wid, P1)).data.toString('utf8'), 'multi');
+  assert.equal((await getProperty(X, wid, P2)).type, 0, 'nothing written for the refused pair');
+});
+
+test('a payload over the transfer limit is served with INCR', async () => {
+  const clipboard = writer.clipboard;
+  const X = raw.client;
+  const wid = rawWindow(raw, x11.eventMask.PropertyChange);
+  const [CLIPBOARD, UTF8_STRING, INCR, PROP] = await Promise.all(
+    ['CLIPBOARD', 'UTF8_STRING', 'INCR', 'NTK_TEST_INCR_PROP'].map((n) => atom(X, n))
+  );
+
+  const text = `${'a'.repeat(5000)}κόσμος🎉${'b'.repeat(5000)}`;
+  const payload = Buffer.from(text, 'utf8');
+  clipboard._transferLimit = 64; // instead of copying a quarter of a megabyte
+  try {
+    await clipboard.write(text);
+    const reply = await rawConvert(X, wid, CLIPBOARD, UTF8_STRING, PROP);
+    assert.equal(reply.property, PROP);
+
+    const collecting = rawIncrRead(X, wid, PROP);
+    const first = await getProperty(X, wid, PROP); // delete=1 starts the transfer
+    assert.equal(first.type, INCR, 'answered with INCR, not the data itself');
+    assert.equal(first.data.readUInt32LE(0), payload.length, 'INCR carries the byte count');
+    assert.deepEqual(await collecting, payload);
+    // the owner closes the transfer when the empty property it ended with
+    // is deleted, one notification behind the requestor
+    for (let i = 0; i < 50 && clipboard._transfers.size; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(clipboard._transfers.size, 0, 'transfer released');
+    // and gives back the event mask it selected to pace the chunks
+    const attrs = await new Promise((resolve, reject) =>
+      writer.X.GetWindowAttributes(wid, (err, a) => (err ? reject(err) : resolve(a)))
+    );
+    assert.equal(attrs.myEventMasks, 0, 'requestor window left as it was found');
+  } finally {
+    clipboard._transferLimit = null;
+  }
+});
+
+test('an INCR write round-trips through ntk read(), twice on one helper window', async () => {
+  const clipboard = writer.clipboard;
+  const text = `${'x'.repeat(4000)}κόσμε${'y'.repeat(4000)}`;
+  clipboard._transferLimit = 100;
+  try {
+    await clipboard.write(text);
+    assert.equal(await reader.clipboard.read(), text, 'INCR write -> INCR read across clients');
+    // the second paste only works if the first restored PropertyChange on
+    // the requestor's window (here: another ntk client's helper window)
+    assert.equal(await reader.clipboard.read(), text, 'and again');
+    // owner and requestor on one connection: the requestor window is ntk's
+    // own, whose event mask the transfer must not clear
+    assert.equal(await clipboard.read(), text, 'self paste over INCR');
+    assert.equal(await clipboard.read(), text, 'and again');
+  } finally {
+    clipboard._transferLimit = null;
+  }
+});
+
+test('a copy larger than one X request pastes (the real, uncapped threshold)', async () => {
+  // the bug this guards: one ChangeProperty cannot carry more than 65535
+  // four-byte units, and the request never reached the server at all — the
+  // paste came back empty with no error on either side
+  const text = `${'z'.repeat(300000)}κόσμε`;
+  await writer.clipboard.write(text);
+  assert.ok(
+    Buffer.byteLength(text) > writer.clipboard._limit(),
+    'payload is over the single-request limit'
+  );
+  assert.equal(await reader.clipboard.read(), text);
+});
+
+test('MULTIPLE carries INCR pairs, and the requestor window is released once', async () => {
+  const clipboard = writer.clipboard;
+  const X = raw.client;
+  const wid = rawWindow(raw, x11.eventMask.PropertyChange);
+  const [CLIPBOARD, MULTIPLE, ATOM_PAIR, INCR, HTML, PNG, LIST, P1, P2] = await Promise.all(
+    [
+      'CLIPBOARD',
+      'MULTIPLE',
+      'ATOM_PAIR',
+      'INCR',
+      'text/html',
+      'image/png',
+      'NTK_TEST_MLIST',
+      'NTK_TEST_MP1',
+      'NTK_TEST_MP2'
+    ].map((n) => atom(X, n))
+  );
+
+  const html = `<p>${'h'.repeat(3000)}</p>`;
+  const png = Buffer.alloc(3000, 0xa7);
+  clipboard._transferLimit = 64;
+  try {
+    await clipboard.write({ 'text/html': html, 'image/png': png });
+    X.ChangeProperty(0, wid, LIST, ATOM_PAIR, 32, [HTML, P1, PNG, P2]);
+    const reply = await rawConvert(X, wid, CLIPBOARD, MULTIPLE, LIST);
+    assert.equal(reply.property, LIST);
+
+    const list = await getProperty(X, wid, LIST);
+    assert.deepEqual(
+      [list.data.readUInt32LE(4), list.data.readUInt32LE(12)],
+      [P1, P2],
+      'both pairs accepted'
+    );
+
+    const collecting = [rawIncrRead(X, wid, P1), rawIncrRead(X, wid, P2)];
+    const [firstHtml, firstPng] = await Promise.all([
+      getProperty(X, wid, P1),
+      getProperty(X, wid, P2)
+    ]);
+    assert.equal(firstHtml.type, INCR);
+    assert.equal(firstPng.type, INCR);
+    const [gotHtml, gotPng] = await Promise.all(collecting);
+    assert.equal(gotHtml.toString('utf8'), html);
+    assert.deepEqual(gotPng, png);
+
+    for (let i = 0; i < 50 && clipboard._transfers.size; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(clipboard._transfers.size, 0, 'both transfers released');
+    assert.equal(clipboard._watched.size, 0, 'and the window watched for them only once');
+  } finally {
+    clipboard._transferLimit = null;
+  }
+});
+
+test('two INCR conversions at once share one watch on the requestor', async () => {
+  const clipboard = writer.clipboard;
+  const X = raw.client;
+  const wid = rawWindow(raw, x11.eventMask.PropertyChange);
+  const [CLIPBOARD, HTML, PNG, P1, P2] = await Promise.all(
+    ['CLIPBOARD', 'text/html', 'image/png', 'NTK_TEST_CP1', 'NTK_TEST_CP2'].map((n) => atom(X, n))
+  );
+
+  // lopsided on purpose: the short one is done long before the long one,
+  // and must not take the window's event mask with it when it goes
+  const html = `<p>${'c'.repeat(200)}</p>`;
+  const png = Buffer.alloc(12000, 0x5c);
+  clipboard._transferLimit = 64;
+  try {
+    await clipboard.write({ 'text/html': html, 'image/png': png });
+    // ICCCM allows concurrent conversions as long as they use different
+    // properties; both answers are INCR, so both want PropertyChange here
+    const replies = await Promise.all([
+      rawConvert(X, wid, CLIPBOARD, HTML, P1),
+      rawConvert(X, wid, CLIPBOARD, PNG, P2)
+    ]);
+    assert.deepEqual(
+      replies.map((r) => r.property),
+      [P1, P2]
+    );
+
+    const collecting = [rawIncrRead(X, wid, P1), rawIncrRead(X, wid, P2)];
+    await Promise.all([getProperty(X, wid, P1), getProperty(X, wid, P2)]);
+    const [gotHtml, gotPng] = await Promise.all(collecting);
+    assert.equal(gotHtml.toString('utf8'), html);
+    assert.deepEqual(gotPng, png);
+
+    for (let i = 0; i < 50 && clipboard._watched.size; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    // one transfer finishing must not stop pacing the other, and the last
+    // one out gives the window back
+    assert.equal(clipboard._watched.size, 0, 'watch released exactly once');
+  } finally {
+    clipboard._transferLimit = null;
+  }
+});
+
+test('write() offers arbitrary targets, including binary ones', async () => {
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0x7f]);
+  await writer.clipboard.write({
+    'text/plain;charset=utf-8': 'hello',
+    'text/html': '<b>hello</b>',
+    'image/png': png
+  });
+
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [CLIPBOARD, TARGETS, TIMESTAMP, MULTIPLE, PLAIN, HTML, PNG, PROP, UTF8_STRING] =
+    await Promise.all(
+      [
+        'CLIPBOARD',
+        'TARGETS',
+        'TIMESTAMP',
+        'MULTIPLE',
+        'text/plain;charset=utf-8',
+        'text/html',
+        'image/png',
+        'NTK_TEST_PROP',
+        'UTF8_STRING'
+      ].map((n) => atom(X, n))
+    );
+
+  const targetsReply = await rawConvert(X, wid, CLIPBOARD, TARGETS, PROP);
+  assert.equal(targetsReply.property, PROP);
+  const list = await getProperty(X, wid, PROP);
+  const offered = [];
+  for (let o = 0; o < list.data.length; o += 4) offered.push(list.data.readUInt32LE(o));
+  assert.deepEqual(
+    offered,
+    [TARGETS, TIMESTAMP, MULTIPLE, PLAIN, HTML, PNG],
+    'the required three, then what the caller offered, in order'
+  );
+
+  assert.equal((await rawConvert(X, wid, CLIPBOARD, HTML, PROP)).property, PROP);
+  assert.equal((await getProperty(X, wid, PROP)).data.toString('utf8'), '<b>hello</b>');
+
+  const pngReply = await rawConvert(X, wid, CLIPBOARD, PNG, PROP);
+  assert.equal(pngReply.property, PROP);
+  const pngProp = await getProperty(X, wid, PROP);
+  assert.equal(pngProp.type, PNG, 'served with the target as its type');
+  assert.deepEqual(pngProp.data, png, 'bytes survive untouched');
+
+  // offering formats explicitly means exactly those formats
+  assert.equal(
+    (await rawConvert(X, wid, CLIPBOARD, UTF8_STRING, PROP)).property,
+    0,
+    'UTF8_STRING was not offered, so it is refused'
+  );
+});
+
+test('write() rejects payloads it cannot name a target for', async () => {
+  await assert.rejects(writer.clipboard.write(Buffer.from('png')), /needs a target name/);
+  await assert.rejects(writer.clipboard.write({}), /at least one target/);
+  await assert.rejects(writer.clipboard.write({ TARGETS: 'no' }), /answered by ntk/);
+  await assert.rejects(writer.clipboard.write({ 'text/html': 42 }), /string or binary/);
 });
 
 test('falls back to STRING when the owner refuses UTF8_STRING', async () => {

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -560,3 +560,57 @@ test('watch() explains itself on a server without XFixes', async () => {
 test('watch() rejects a missing handler before touching the server', async () => {
   await assert.rejects(() => reader.clipboard.watch('CLIPBOARD'), /needs a handler/);
 });
+// --- reading what multi-format write publishes -----------------------------
+//
+// write() has offered arbitrary targets since this change; these are the
+// other half, so an ntk app can get back what an ntk app put there.
+
+test('targets() lists what the owner offers', async () => {
+  await writer.clipboard.write({
+    'text/plain;charset=utf-8': 'hi',
+    'text/html': '<b>hi</b>',
+    'image/png': Buffer.from([0x89, 0x50, 0x4e, 0x47])
+  });
+  const offered = await reader.clipboard.targets();
+  for (const name of ['text/plain;charset=utf-8', 'text/html', 'image/png']) {
+    assert.ok(offered.includes(name), `${name} offered, got ${offered.join(', ')}`);
+  }
+  // the three ntk answers for itself are advertised too, per ICCCM 2.6.2
+  for (const name of ['TARGETS', 'TIMESTAMP', 'MULTIPLE']) {
+    assert.ok(offered.includes(name), `${name} advertised`);
+  }
+});
+
+test('targets() is empty when nothing owns the selection', async () => {
+  const offered = await reader.clipboard.targets({ selection: 'NTK_UNOWNED_SELECTION' });
+  assert.deepEqual(offered, []);
+});
+
+test('read({ target }) returns that target as bytes', async () => {
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  await writer.clipboard.write({ 'image/png': png, 'text/html': '<b>hi</b>' });
+
+  const back = await reader.clipboard.read({ target: 'image/png' });
+  assert.ok(Buffer.isBuffer(back), 'binary targets come back as bytes');
+  assert.deepEqual(back, png);
+
+  const html = await reader.clipboard.read({ target: 'text/html' });
+  assert.equal(html.toString('utf8'), '<b>hi</b>');
+});
+
+test('read({ target }) survives an INCR-sized payload', async () => {
+  const big = Buffer.alloc(300000);
+  for (let i = 0; i < big.length; i++) big[i] = i & 0xff;
+  await writer.clipboard.write({ 'application/octet-stream': big });
+  const back = await reader.clipboard.read({ target: 'application/octet-stream' });
+  assert.equal(back.length, big.length);
+  assert.ok(back.equals(big), 'every byte survives the chunking');
+});
+
+test('read({ target }) says which target the owner could not convert', async () => {
+  await writer.clipboard.write('just text');
+  await assert.rejects(
+    () => reader.clipboard.read({ target: 'image/png' }),
+    /cannot convert to image\/png/
+  );
+});


### PR DESCRIPTION
Closes #119.

> **Provenance:** the first commit is work that was sitting uncommitted in a local working tree — I found it while picking up #120 and did not reimplement it. The second commit is new, and finishes the asymmetry the first one leaves behind.

## What was broken

As an owner, the clipboard answered `TARGETS`, `UTF8_STRING` and `STRING`, refused everything else, handed the whole payload to the server in one `ChangeProperty`, and took ownership with `CurrentTime`. Each of those is a way for a copy to fail with nothing said about it.

**Required targets.** ICCCM 2.6.2 makes `TARGETS`, `TIMESTAMP` and `MULTIPLE` mandatory. Refusing `TIMESTAMP` is why pasting into Xt/Motif/Java apps could fail outright — they ask for it first and read a refusal as a broken owner. `MULTIPLE` now iterates the `ATOM_PAIR` list and, per the spec, rewrites the property of any entry it could not convert to `None`, so the requestor can tell which ones it got.

**INCR on write.** A payload larger than one request is answered with an `INCR` property carrying a lower-bound byte count, then fed a chunk at a time as the requestor deletes the property — the mirror of the read side that was already there. Before this, a copy over roughly 256 KB simply produced an empty paste, with no error on either side. A transfer the requestor abandons is dropped after a timeout rather than held forever.

**Ownership timestamps.** ICCCM 2.1 forbids `CurrentTime` here: the timestamp is what arbitrates a race with another app copying at the same moment. `write` now takes the triggering event's time, and asks the server for one when the caller has none rather than sending `CurrentTime` anyway.

**Any format.** `write` takes an object or Map from target name to payload, so HTML and images are the same machinery as text, and a string still means what it meant. `TARGETS`/`TIMESTAMP`/`MULTIPLE` are answered by ntk and are rejected if offered as data.

That last piece is what a drag source needs — XDND is a selection owner serving arbitrary targets on `XdndSelection` — so drag-and-drop later is protocol glue rather than new transfer machinery.

## The second commit: reading it back

The first commit leaves the API lopsided, and its own docs said so in the limitations list: `write` could publish an `image/png`, and nothing could get one back.

```js
const offered = await app.clipboard.targets();
if (offered.includes('image/png')) {
  const png = await app.clipboard.read({ target: 'image/png' });
}
```

`read({ target })` resolves with a `Buffer` rather than a string, since the point is that the payload need not be text. INCR applies as it does to any read — there is a test that round-trips a 300 KB payload, chunked in **both** directions, and compares every byte.

`targets()` is worth having separately rather than making callers guess: an owner answers `TARGETS` cheaply, where a guess costs a failed conversion each time, and a wrong guess against a slow owner is a two second timeout. It resolves `[]` when nothing owns the selection, which is the answer an edit menu wants.

Both go through the same queue as `read`, since concurrent conversions would otherwise share the one transfer property on the helper window.

## Testing

544 pass, 23 in `clipboard.test.js`. All hermetic — several clients on node-x11's in-process X server, with raw node-x11 clients playing the foreign-application roles: a `STRING`-only legacy owner, an `INCR` owner, a `TARGETS` requestor.

## Rebased over #163

#163 landed while this was in review, so this is rebased on top of it. Three conflicts, all additive — `_onXEvent` now dispatches XFixes events *and* INCR property deletions, and the docs and tests keep both sets. 584 pass on the rebased branch.
