### PR TITLE
fix: stop leaking GCs, pixmaps and pictures from the 2d context

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -129,9 +129,11 @@ to the anchor point, but glyphs are not rotated/scaled — size text via
   clip the clip goes to the server directly, rather than through a
   full-surface mask
 - `ctx.destroy()` / `Symbol.dispose` — release the context's server-side
-  resources: its GC, its Picture, its masks and its solid-colour pictures.
+  resources: its GCs, its Picture, its masks and its solid-colour pictures.
   Needed only for contexts created dynamically, such as one per
-  [`Surface`](surface.md); a context on a window lives as long as the window
+  [`Surface`](surface.md); a context on a window lives as long as the window.
+  A context dropped without it still releases its GCs through a finalizer,
+  as `Pixmap` and `Picture` do for theirs
 ### Pixels
 
 Pixel access follows the canvas API: `ImageData` is straight

--- a/lib/image.js
+++ b/lib/image.js
@@ -51,8 +51,9 @@ export class Image {
       this.height
     );
 
-    // node-x11 has no FreeGC — share one upload GC per app (valid for any
-    // depth-32 drawable on the screen)
+    // One upload GC per app: a GC is valid for any depth-32 drawable on the
+    // screen, so sharing is cheaper than creating and freeing one per image.
+    // It outlives every Image and is released with the connection.
     let gc = app._imageUploadGC;
     if (!gc) {
       gc = app._imageUploadGC = X.AllocID();

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -28,6 +28,22 @@ import { trapezoidize } from './trapezoid.js';
 const DEFAULT_FONT = '20px sans-serif';
 
 /**
+ * Fallback for a context dropped without `destroy()`, matching Pixmap,
+ * Picture and GlyphSet. Only the GCs are freed here: everything else a
+ * context owns is a Pixmap or a Picture, which carry their own finalizers,
+ * and reaching into them from this one would race those.
+ */
+const gcRegistry = new FinalizationRegistry(({ X, gcs }) => {
+  safeRelease(X, () => {
+    for (const gc of gcs) {
+      if (!gc) continue;
+      X.FreeGC(gc);
+      X.ReleaseID(gc);
+    }
+  });
+});
+
+/**
  * What `drawImage` takes as a server-side source: anything that knows its own
  * size and can hand over a `Picture` for this connection.
  *
@@ -174,6 +190,10 @@ class RenderingContext2d {
   constructor(window) {
     const X = window.X;
     this.X = X;
+    // ids land here as they are allocated; the finalizer holds this array
+    // rather than the context, so registering cannot keep the context alive
+    this._gcs = [];
+    gcRegistry.register(this, { X, gcs: this._gcs }, this);
 
     this.window = window;
     this.display = window.app.display;
@@ -236,6 +256,7 @@ class RenderingContext2d {
       // one GC is enough: it stays valid for any drawable of the same
       // screen and depth (the backing pixmap matches the window depth)
       this._gc = this.X.AllocID();
+      this._gcs.push(this._gc);
       this.X.CreateGC(this._gc, target.id);
     }
     if (this.picture) this.picture.destroy();
@@ -276,6 +297,7 @@ class RenderingContext2d {
   destroy() {
     if (this._destroyed) return;
     this._destroyed = true;
+    gcRegistry.unregister(this);
 
     this._clips = [];
     this._dropMasks();
@@ -287,6 +309,7 @@ class RenderingContext2d {
       });
     }
     this._gc = this._fillMaskGC = null;
+    this._gcs.length = 0;
 
     for (const picture of this._solidPictures.values()) {
       picture.destroy();
@@ -656,6 +679,7 @@ class RenderingContext2d {
   _maskGC() {
     if (!this._fillMaskGC) {
       this._fillMaskGC = this.X.AllocID();
+      this._gcs.push(this._fillMaskGC);
       this.X.CreateGC(this._fillMaskGC, this.fillMaskDrawable.id);
     }
     return this._fillMaskGC;
@@ -1782,24 +1806,40 @@ class RenderingContext2d {
         sHeight
       );
 
-      const pixmap = new Pixmap(this.window.app, { depth: 32, width: sWidth, height: sHeight });
-      const picture = new Picture(this.window.app, { drawable: pixmap, format: this.Render.rgba32 });
-      pixmap._gc = this.X.AllocID();
-      this.X.CreateGC(pixmap._gc, pixmap.id);
-      // the crop already happened in getImageData, so it lands at the pixmap's
-      // origin — sx/sy here wrote it off the edge
-      this.X.PutImage(2, pixmap.id, pixmap._gc, sWidth, sHeight, 0, 0, 0, 32, data);
+      // One upload GC per app rather than one per call, the same sharing
+      // Image.picture does: a GC is valid for any drawable of the same screen
+      // and depth. This used to allocate a GC, a pixmap and a picture every
+      // time and free none of them, so drawing a node-canvas source in an
+      // animation loop leaked three server resources per frame.
+      const app = this.window.app;
+      const pixmap = new Pixmap(app, { depth: 32, width: sWidth, height: sHeight });
+      const picture = new Picture(app, { drawable: pixmap, format: this.Render.rgba32 });
+      try {
+        let gc = app._imageUploadGC;
+        if (!gc) {
+          gc = app._imageUploadGC = this.X.AllocID();
+          this.X.CreateGC(gc, pixmap.id);
+        }
+        // the crop already happened in getImageData, so it lands at the
+        // pixmap's origin — sx/sy here wrote it off the edge
+        this.X.PutImage(2, pixmap.id, gc, sWidth, sHeight, 0, 0, 0, 32, data);
 
-      this.Render.Composite(
-        this.Render.PictOp.Over,
-        picture.id,
-        this._compositeMask(),
-        this.picture.id,
-        0, 0, 0, 0, 0, 0,
-        this.width,
-        this.height
-      );
-      this._markDirty();
+        this.Render.Composite(
+          this.Render.PictOp.Over,
+          picture.id,
+          this._compositeMask(),
+          this.picture.id,
+          0, 0, 0, 0, 0, 0,
+          this.width,
+          this.height
+        );
+        this._markDirty();
+      } finally {
+        // the composite is queued, and X executes requests in order, so the
+        // server is done with these by the time it reads the frees
+        picture.destroy();
+        pixmap.destroy();
+      }
     }
   }
 

--- a/lib/window.js
+++ b/lib/window.js
@@ -655,7 +655,7 @@ export default class Window extends Drawable {
     });
     if (!this._clearGc) {
       // reusable across reallocs: a GC is valid for any drawable of the
-      // same screen and depth (node-x11 has no FreeGC request)
+      // same screen and depth, so one outlives every backing pixmap
       this._clearGc = this.X.AllocID();
       this.X.CreateGC(this._clearGc, pixmap.id, {
         foreground: this.display.screen[0].white_pixel,

--- a/test/surface.test.js
+++ b/test/surface.test.js
@@ -275,3 +275,58 @@ describe('context teardown', () => {
     assert.deepEqual(px(2, 2), [255, 0, 255, 255]);
   });
 });
+
+describe('server resources are not leaked', () => {
+  /** count the requests a body issues, by name */
+  function countX(names, body) {
+    const X = app.X;
+    const counts = Object.fromEntries(names.map((n) => [n, 0]));
+    const saved = {};
+    for (const name of names) {
+      saved[name] = X[name];
+      X[name] = (...a) => {
+        counts[name]++;
+        return saved[name].apply(X, a);
+      };
+    }
+    try {
+      body();
+    } finally {
+      for (const name of names) X[name] = saved[name];
+    }
+    return counts;
+  }
+
+  test('drawing a node-canvas source repeatedly allocates once, not per call', () => {
+    // this used to create a GC, a pixmap and a picture per call and free
+    // none of them, so an animation loop leaked three resources a frame
+    const ctx = target();
+    const fake = {
+      width: 4,
+      height: 4,
+      context: {
+        getImageData: () => ({
+          width: 4,
+          height: 4,
+          data: new Uint8ClampedArray(4 * 4 * 4).fill(200),
+        }),
+      },
+    };
+    ctx.drawImage(fake, 0, 0); // first call may create the shared upload GC
+    const counts = countX(['CreateGC', 'CreatePixmap', 'FreePixmap'], () => {
+      for (let i = 0; i < 5; i++) ctx.drawImage(fake, 0, 0);
+    });
+    assert.equal(counts.CreateGC, 0, 'the upload GC is shared across calls');
+    assert.equal(counts.CreatePixmap, 5, 'one scratch pixmap per call');
+    assert.equal(counts.FreePixmap, 5, 'and every one of them freed again');
+  });
+
+  test('destroy() frees the GCs it allocated', () => {
+    const pixmap = app.createPixmap({ width: 8, height: 8, depth: 32 });
+    const ctx = pixmap.getContext('2d');
+    ctx.fillStyle = '#123456';
+    ctx.fillRect(0, 0, 8, 8);
+    const counts = countX(['FreeGC'], () => ctx.destroy());
+    assert.ok(counts.FreeGC >= 1, `at least the target GC, got ${counts.FreeGC}`);
+  });
+});


### PR DESCRIPTION
Closes #156.

The context teardown half of that issue landed with `Surface` in #157, since creating a context per cached surface is what made it matter. These are the rest.

## The one that actually grows

The node-canvas branch of `drawImage` allocated a GC, a pixmap **and** a picture on every call and freed none of them. Drawing such a source in an animation loop leaked three server resources per frame — the only unbounded leak in the issue; everything else was bounded by the number of contexts.

The pixmap and picture are now freed after the composite, which is safe because X executes requests in order, so the server is done with them by the time it reads the frees. The upload GC is shared per app, the way `Image.picture` already shares one.

There is a test: five draws, and it asserts `CreateGC` is zero, `CreatePixmap` is five, and `FreePixmap` is five.

## Finalizer fallback

A dropped context now releases its GCs through a `FinalizationRegistry`, matching `Pixmap`, `Picture` and `GlyphSet`.

Only the GCs, deliberately: everything else a context owns *is* a `Pixmap` or a `Picture`, which carry their own finalizers, and reaching into those from this one would race them. The registry holds an array of ids rather than the context itself, so registering cannot keep the context alive.

## The comments that caused this

Two of them claimed node-x11 has no `FreeGC`:

```
// node-x11 has no FreeGC — share one upload GC per app
// ...a GC is valid for any drawable of the same screen and depth (node-x11 has no FreeGC request)
```

It does — `lib/corereqs.js:1345` — and ntk's own `lib/cursor.js` has always called it. The claim is what stopped anyone closing these leaks, so it is worth correcting rather than deleting: both comments now give the true reason for sharing a GC, which is that one is valid for any drawable of the same screen and depth and so beats creating and freeing one per use.

The sharing itself was never wrong. Only the justification was.

586 pass.
