### PR TITLE
feat(fonts): a font spec, for environments without fontconfig

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ lib/rasterize.js           pure-JS coverage rasterizer (signed-area
 lib/trapezoid.js           polygon -> XRender trapezoids (non-zero/even-odd;
                            vector text and all 2d path fills)
 lib/fontconfig.js          font matching + fallback chain via fc-match CLI
-lib/text/fontsource.js     pluggable FontSource seam: FontconfigFontSource
+lib/text/fontsource.js     pluggable FontSource seam and the font-spec
+                           resolver: FontconfigFontSource
                            (default), StaticFontSource (data-based, browser-
                            safe), process-wide default override
 lib/text/font.js           Font: fontkit face — metrics, coverage, shaping

--- a/docs/app.md
+++ b/docs/app.md
@@ -13,8 +13,10 @@ const app2 = await createClient({ display: ':1' });
 
 - `options` is passed through to `x11.createClient` (e.g. `{ display: ':1' }`).
   ntk additionally understands:
-  - `fontSource` — pluggable system-font lookup for `app.fonts`
-    (see [fonts.md](fonts.md#pluggable-font-sources));
+  - `fontSource` — where fonts come from: a FontSource, or a font spec such
+    as `'/app/fonts'` or `[bytes]` naming the faces the app ships, which is
+    what an environment without fontconfig needs
+    (see [fonts.md](fonts.md#environments-without-fontconfig));
   - `rasterizer` / `rasterPolicy` — where fills and strokes are rasterized,
     and the thresholds for that choice (see
     [context-2d.md](context-2d.md#where-drawings-are-rasterized));

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -35,8 +35,10 @@ ctx.font = 'bold italic 40px "DejaVu Sans", sans-serif';
 ctx.fillText('Hello', 10, 50);
 ```
 
-Requires `fc-match` on the system (any Linux with X11 has it; macOS:
-`brew install fontconfig`). Matches are cached.
+Requires `fc-match` on the system and font files for it to find. A Linux
+desktop has both; a slim container, a single-file build and stock macOS do
+not — see [Environments without fontconfig](#environments-without-fontconfig).
+Matches are cached.
 
 ## Loading a font file directly
 
@@ -73,6 +75,20 @@ const app = await createClient({ fontSource: source });   // per-app
 setDefaultFontSource(source);
 ```
 
+All three of those also take a **font spec** — a shorthand for the same
+thing, when the fonts are files or bytes you already have:
+
+```js
+await createClient({ fontSource: '/app/fonts' });     // every face in a directory
+await createClient({ fontSource: './Inter.ttf' });    // one file
+await createClient({ fontSource: [bytes, more] });    // bytes, no filesystem
+await createClient({ fontSource: 'system' });         // the default, said out loud
+```
+
+`createFontSource(spec)` is that resolution on its own, and it is idempotent
+— a FontSource passes straight through — which is why the same value works
+everywhere a source does.
+
 `StaticFontSource` matches with fontconfig-like semantics: requested
 families first (in list order), then closest weight and style; every added
 face doubles as a fallback candidate with real coverage data, so
@@ -94,8 +110,173 @@ a path, `loadImage()` accepts encoded bytes, `HtmlView` takes a
 `loadResource` callback, and TeX rendering accepts injected KaTeX assets
 via `configureTex({ katex, fonts })` ([tex.md](tex.md)).
 
+## Environments without fontconfig
+
+The default lookup needs two things from the host: the **`fc-match` binary**,
+and **font files** for it to find. **ntk ships neither.** Which typefaces an
+app draws with is the app's decision, so the toolkit has no fonts of its own
+to fall back on.
+
+Both are missing more often than a desktop suggests:
+
+| | |
+| --- | --- |
+| `node:*-slim`, `*-alpine` | neither, until you install them |
+| `gcr.io/distroless/*`, `scratch` | no package manager to install them with |
+| single-executable builds | one file, shipped to a machine you do not control |
+| kiosk / embedded images | fonts trimmed for size |
+| CI runners | often have fontconfig and no font packages |
+| stock macOS | 370-odd fonts in `/System/Library/Fonts` and no `fc-match` — it arrives with Homebrew or XQuartz |
+
+They are missing **independently**: a `fonts-*` package does not pull in
+fontconfig, and fontconfig does not pull in fonts. An image that picked up
+`libfontconfig1` through cairo or pango still has no `fc-match` CLI. Each
+combination gets its own message, all of them carrying `code:
+'ERR_NTK_NO_FONTS'`:
+
+```
+ntk: no fonts available — the fc-match CLI (fontconfig) is not installed here.
+…
+```
+
+Catch it if you would rather show something than crash:
+
+```js
+try {
+  app.fonts.match('sans-serif');
+} catch (err) {
+  if (err.code === 'ERR_NTK_NO_FONTS') showFontSetupScreen();
+  else throw err;
+}
+```
+
+### Where there is a package manager, install one
+
+This is the honest first answer and it needs no ntk API at all:
+
+```dockerfile
+RUN apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core
+# Alpine: apk add fontconfig font-dejavu
+```
+
+Two lines against any amount of application code. Note that
+`fonts-dejavu-core` ships six faces and no italics; add `fonts-dejavu-extra`
+if you draw italic text.
+
+### Otherwise, hand ntk the faces
+
+Copy the fonts in and point at them. No fontconfig, nothing to install:
+
+```dockerfile
+COPY fonts/ /app/fonts/
+```
+
+```js
+const app = await createClient({ fontSource: '/app/fonts' });
+```
+
+A directory is read once, at connect — so a wrong path is a rejected
+`createClient` rather than a surprise inside your first paint. Entries are
+sorted by name before anything is parsed, because the filesystem must never
+be what decides which face `sans-serif` lands on. Subdirectories need
+`{ fonts: dir, recursive: true }`.
+
+**Point it at your own faces, not at a system font tree.** Every file found
+is parsed and then held for the life of the process, which is right for the
+handful an app ships and wrong for `/usr/share/fonts` — on macOS a single
+`Apple Color Emoji.ttc` is 188 MB. Past 64 files ntk stops and says so;
+`maxFiles` raises it if you mean it.
+
+### Single-executable builds
+
+A SEA resolves built-in modules only, so there is nothing to read at runtime
+and no optional font package to import — the faces have to be *in* the
+binary, as assets:
+
+```json
+{ "main": "app.cjs", "output": "app",
+  "assets": { "DejaVuSans.ttf": "./fonts/DejaVuSans.ttf" } }
+```
+
+```js
+const sea = process.getBuiltinModule('node:sea');
+const app = await createClient({ fontSource: [sea.getRawAsset('DejaVuSans.ttf')] });
+```
+
+`getRawAsset` hands back an `ArrayBuffer` with no copy. Name the keys
+explicitly rather than enumerating them: `getAsset`/`getRawAsset` are
+available from Node 20.12, but `getAssetKeys()` only from 22.20.
+
+### Generic families
+
+`sans-serif`, `serif` and `monospace` are what every widget default asks for,
+so a source built from a spec infers them: `monospace` from the font's own
+metrics (`isFixedPitch`, then whether `i` and `W` are the same width — fonts
+lie about the flag), `sans-serif` and `serif` from the family name in the
+font's `name` table, never the filename.
+
+A generic with no evidence is deliberately **left unaliased** rather than
+guessed at. Inspect what was decided, and override it:
+
+```js
+const source = createFontSource('/app/fonts');
+source.aliases;   // { 'sans-serif': 'dejavu sans', monospace: 'dejavu sans mono' }
+
+await createClient({ fontSource: { fonts: '/app/fonts', alias: { serif: 'Charter' } } });
+```
+
+Explicit aliases always win. A hand-built `StaticFontSource` infers nothing
+unless it calls `inferGenerics()`.
+
+### Two things that surprise people
+
+**Registering fonts is not the same as replacing the source.**
+`app.fonts.load()` wins for the exact family string you register it under —
+and nothing else:
+
+```js
+app.fonts.load('/app/fonts/DejaVuSans.ttf', { family: 'sans-serif' });
+ctx.font = '16px sans-serif';   // fine
+ctx.font = '16px Arial';        // still goes to the source, and still fails
+```
+
+The same is true of any codepoint that face lacks: a bullet or a curly quote
+sends ntk to the source for a fallback. Where there is no source to ask, that
+now draws `.notdef` — a visible empty box — instead of throwing, but the way
+to actually get those glyphs is to give the source the fonts.
+
+**A `.ttc` collection contributes its first face only** when found by path or
+directory scan. Name the others explicitly:
+
+```js
+fontSource: [{ path: './Iosevka.ttc', postscriptName: 'Iosevka-Term' }]
+```
+
+And a `/usr/share/fonts` that is not empty can still yield "no fonts": ntk
+reads `.ttf`, `.otf`, `.woff`, `.woff2`, `.ttc` and `.dfont`, and bitmap
+`.pcf`/`.bdf` fonts are not among them.
+
+### The determinism dividend
+
+Supplying the faces buys more than portability. ntk's rasterizer has no
+hinting and computes exact analytic coverage, and a `StaticFontSource` never
+borrows a face from the host — so with a fixed set of fonts, text rasterizes
+to identical bytes on every machine. That is the precondition for
+image-snapshot testing an ntk app, and it is also the fix for
+family-resolution surprises: on a Mac with fontconfig installed,
+`fc-match sans-serif` answers Hiragino Sans — a CJK face.
+
+The guarantee holds across machines **at a pinned ntk version**, not across
+versions — the rasterizer has shifted text antialiasing before. Pin ntk
+exactly in a snapshot suite. System fonts make ntk *run*; they never make it
+reproducible.
+
 ## Font objects and matching
 
+- `createFontSource(spec)` → `FontSource` — resolve a font spec; idempotent,
+  and `null`/`undefined` pass through
+- `StaticFontSource`: `add(bytes, opts)`, `alias(generic, family)`,
+  `inferGenerics()`, `aliases`, `skipped` (files a spec could not parse)
 - `app.fonts.match(family, { weight, style })` → `Font`
 - `app.fonts.fallbackFor(codepoint, family, opts)` → `Font | null` — best
   installed font covering a codepoint (fontconfig coverage data, confirmed

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -44,7 +44,10 @@ Two rules follow from "the main is CommonJS":
 Inside a SEA, `require()` and `import()` resolve **built-in modules only** —
 a `data:` or `file:` URL import fails with `ERR_UNKNOWN_BUILTIN_MODULE`. That
 is fine for a bundle, which has nothing left to resolve, but it rules out
-loading anything at runtime.
+loading anything at runtime, including any optional package sitting on disk
+beside the binary. `fs` itself is unrestricted; it is the module loader that
+is sandboxed. This is why fonts reach a SEA as **assets** (below) rather than
+as a package ntk could resolve for you.
 
 ntk itself is built for this: nothing in `lib/` uses top-level await, and
 `test/packaging.test.js` keeps it that way. The one thing that would take it
@@ -63,7 +66,35 @@ The binary is large (~140 MB): most of it is node itself.
   `wmClass`, or the desktop groups your windows under the wrong icon
   ([window.md](window.md#application-identity--setclassinstance-class--wmclass)).
 - **Icons** under `usr/share/icons/hicolor/<size>/apps/`.
-- **Fonts**, if the target may not have fontconfig: `StaticFontSource` takes
-  font bytes directly and needs no `fc-match`
-  ([fonts.md](fonts.md#pluggable-font-sources)). Bundling the faces you draw
-  with also makes rendering identical across machines.
+- **Fonts.** ntk ships none, and the default lookup needs both the `fc-match`
+  binary and host font files — neither of which a slim image, a kiosk build or
+  a `.desktop`-launched app on macOS can be assumed to have
+  ([fonts.md](fonts.md#environments-without-fontconfig)).
+
+Fonts are the one item on that list that stops the app rather than making it
+look wrong, so, in order of preference:
+
+```dockerfile
+# where there is a package manager, this is the whole fix
+RUN apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core
+```
+
+```dockerfile
+# otherwise ship the faces …
+COPY fonts/ /app/fonts/
+```
+
+```js
+// … and point at them
+await createClient({ fontSource: '/app/fonts' });
+```
+
+```js
+// in a single file there is no directory to read — the faces are assets
+// { "assets": { "DejaVuSans.ttf": "./fonts/DejaVuSans.ttf" } } in sea-config.json
+const sea = process.getBuiltinModule('node:sea');
+await createClient({ fontSource: [sea.getRawAsset('DejaVuSans.ttf')] });
+```
+
+Shipping the faces you draw with also makes rendering identical across
+machines, which is what makes image-snapshot tests of an ntk app possible.

--- a/docs/xserver.md
+++ b/docs/xserver.md
@@ -15,7 +15,8 @@ const server = createServer({ width: 640, height: 480 });
 const [serverEnd, clientEnd] = createStreamPair();
 server.addClientStream(serverEnd);
 
-const app = await createClient({ stream: clientEnd, fontSource });
+// no display, and no fontconfig either: name the faces the test ships
+const app = await createClient({ stream: clientEnd, fontSource: './test/fonts' });
 ```
 
 Everything the 2d context does — path fills (trapezoids), text

--- a/lib/app.js
+++ b/lib/app.js
@@ -13,8 +13,10 @@ import Window from './window.js';
 export default class App {
   /**
    * @param {object} display node-x11 display
-   * @param {object} [options] environment hooks: { fontSource (see
-   *   text/fontsource.js), rasterizer and rasterPolicy (see rasterize.js),
+   * @param {object} [options] environment hooks: { fontSource — a FontSource
+   *   or a font spec (see text/fontsource.js); `createClient` resolves a spec
+   *   before it gets here, so a hand-built App may pass either —
+   *   rasterizer and rasterPolicy (see rasterize.js),
    *   glxVisual (visual id for getContext('opengl') instead of querying the
    *   server for one) }
    */

--- a/lib/fontconfig.js
+++ b/lib/fontconfig.js
@@ -4,11 +4,54 @@
 function execFileSync(...args) {
   const cp = globalThis.process?.getBuiltinModule?.('node:child_process');
   if (!cp) {
-    throw new Error(
-      'fontconfig matching needs node (fc-match CLI); in this environment pass a custom fontSource — see docs/fonts.md'
+    throw noFontsError(
+      'fontconfig matching needs node (the fc-match CLI) and this is not a node environment'
     );
   }
   return cp.execFileSync(...args);
+}
+
+const DOCS = 'https://github.com/sidorares/ntk/blob/master/docs/fonts.md#environments-without-fontconfig';
+
+/**
+ * The one error for "this environment has nothing to render text with" —
+ * fc-match missing, fc-match unhappy, fc-match matching nothing parseable, or
+ * a StaticFontSource with no faces.
+ *
+ * It exists because of where it lands. Font lookup is lazy, so the failure
+ * surfaces inside the first text layout with no hint that fonts are involved:
+ * a fontconfig-less container used to report exactly `spawnSync fc-match
+ * ENOENT` from deep inside shapeText, which reads as "ntk is broken in
+ * Docker". The message is long on purpose — it is thrown once, at a reader
+ * who does not yet know the subject.
+ *
+ * `code` is the load-bearing part rather than decoration: FontManager's
+ * fallbackFor distinguishes "this environment has no fonts" (degrade to
+ * .notdef) from "your custom source threw" (propagate), and it gives a host
+ * renderer something to branch on without matching message text.
+ *
+ * @param {string} reason first line — what specifically was missing
+ * @param {Error} [cause] the underlying failure, preserved for debugging
+ */
+export function noFontsError(reason, cause) {
+  const err = new Error(
+    `ntk: no fonts available — ${reason}.\n` +
+      '\n' +
+      'ntk ships no font files, so a slim/distroless container, a single-executable\n' +
+      'build, a kiosk image or a CI box without font packages has to supply them:\n' +
+      '\n' +
+      "    createClient({ fontSource: '/app/fonts' })   // a directory of .ttf/.otf files\n" +
+      '    createClient({ fontSource: [bytes] })        // font bytes — no filesystem needed\n' +
+      '\n' +
+      'Where a package manager is available, installing fontconfig plus a font package\n' +
+      'is simpler: Debian/Ubuntu `apt-get install -y --no-install-recommends fontconfig\n' +
+      'fonts-dejavu-core`; Alpine `apk add fontconfig font-dejavu`.\n' +
+      '\n' +
+      DOCS,
+    cause ? { cause } : undefined
+  );
+  err.code = 'ERR_NTK_NO_FONTS';
+  return err;
 }
 
 // css weight -> fontconfig weight constants
@@ -24,10 +67,31 @@ const cssToFcWeight = {
   900: 210 // black
 };
 
-// formats fontkit can parse
-const supported = /\.(ttf|otf|woff|woff2|ttc|dfont)$/i;
+// formats fontkit can parse. Exported so the font-spec resolver filters a
+// directory listing by exactly the same rule fc-match output is filtered by —
+// bitmap .pcf/.bdf fonts are the common near-miss.
+export const supported = /\.(ttf|otf|woff|woff2|ttc|dfont)$/i;
 
 const sortedCache = new Map();
+
+// Why fc-match could not be used, remembered so a render loop that catches
+// the error does not respawn a missing binary every frame. The reason string
+// is cached rather than the Error, so each throw still carries its own stack.
+// A process that somehow gains fontconfig mid-run will not notice; nobody
+// installs fontconfig into a running process.
+let unavailable = null;
+
+/**
+ * Did the spawn itself fail, as opposed to fc-match running and being
+ * unhappy? `status` is null only when the child never ran, and these are the
+ * codes that mean "no usable binary at this name" rather than a transient
+ * failure worth reporting verbatim.
+ */
+function isSpawnFailure(err) {
+  return (
+    err.status == null && ['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR'].includes(err.code)
+  );
+}
 
 function patternFor({ family, weight, style }) {
   let fc = family || 'sans-serif';
@@ -51,12 +115,31 @@ export function matchSortedSync(pattern) {
   const fc = patternFor(pattern);
   let list = sortedCache.get(fc);
   if (list) return list;
+  if (unavailable) throw noFontsError(unavailable);
 
-  const out = execFileSync(
-    'fc-match',
-    ['-s', '--format', '%{file}\t%{postscriptname}\t%{charset}\n', fc],
-    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
-  );
+  let out;
+  try {
+    out = execFileSync(
+      'fc-match',
+      ['-s', '--format', '%{file}\t%{postscriptname}\t%{charset}\n', fc],
+      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+    );
+  } catch (err) {
+    if (err.code === 'ERR_NTK_NO_FONTS') throw err; // no child_process at all
+    if (isSpawnFailure(err)) {
+      unavailable = 'the fc-match CLI (fontconfig) is not installed here';
+      throw noFontsError(unavailable, err);
+    }
+    if (err.status != null) {
+      // fontconfig is installed and said no — an image with fontconfig but no
+      // font package answers "No fonts installed on the system" and exits 1.
+      // Not memoized: unlike a missing binary this can depend on the pattern.
+      const stderr = String(err.stderr || '').trim().split('\n')[0];
+      throw noFontsError(`fc-match exited ${err.status}${stderr ? `: ${stderr}` : ''}`, err);
+    }
+    throw err;
+  }
+
   list = [];
   for (const line of out.split('\n')) {
     const [path, postscriptName, charset] = line.split('\t');
@@ -65,7 +148,10 @@ export function matchSortedSync(pattern) {
     }
   }
   if (list.length === 0) {
-    throw new Error(`No usable font found for pattern "${fc}" (need .ttf/.otf/.ttc)`);
+    throw noFontsError(
+      `fontconfig matched no font ntk can parse for "${fc}" (needs ` +
+        '.ttf/.otf/.woff/.woff2/.ttc/.dfont — bitmap .pcf/.bdf fonts are not usable)'
+    );
   }
   sortedCache.set(fc, list);
   return list;
@@ -74,8 +160,9 @@ export function matchSortedSync(pattern) {
 /**
  * Resolve a font pattern ({family, weight, style}) to the best matching font
  * file. Returns { path, postscriptName } or throws if nothing suitable is
- * installed. Requires the fc-match CLI (fontconfig), present on any system
- * running X11.
+ * installed. Requires the fc-match CLI (fontconfig) — usual on a Linux
+ * desktop, absent from slim containers and from stock macOS. Where it is
+ * missing, hand ntk the fonts instead (see docs/fonts.md).
  */
 export function listFontsSync(pattern) {
   const [best] = matchSortedSync(pattern);

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ import FontManager from './text/fontmanager.js';
 import {
   FontconfigFontSource,
   StaticFontSource,
+  createFontSource,
   defaultFontSource,
   setDefaultFontSource
 } from './text/fontsource.js';
@@ -69,7 +70,11 @@ const DEFAULT_BUFFER_REQUESTS = { maxSize: 64 * 1024 };
  *
  * @param {object} [options] passed through to x11.createClient
  *   (e.g. { display: ':1' }); ntk additionally understands
- *   { fontSource } — a pluggable system-font lookup (see docs/fonts.md) —
+ *   { fontSource } — where fonts come from: a FontSource, `'system'` (the
+ *   default, fontconfig via fc-match), or a font spec naming the faces the
+ *   app itself ships — `'/app/fonts'`, `'./Inter.ttf'`, `[bytes]`,
+ *   `{ fonts, alias }` — which is what an environment without fontconfig
+ *   needs, since ntk ships no fonts (see docs/fonts.md) —
  *   { rasterizer, rasterPolicy } — where small fills and strokes are
  *   rasterized, and the thresholds for that choice (see docs/context-2d.md) —
  *   { glxVisual } — a visual id for getContext('opengl') to use instead of
@@ -95,6 +100,14 @@ export function createClient(options, callback) {
   const layout = loadLayout();
 
   const connecting = new Promise((resolve, reject) => {
+    // Resolve the font spec here rather than lazily in `app.fonts`, so a
+    // missing directory is a rejected connect instead of a surprise inside
+    // the first paint. Inside the executor so it rejects rather than throws
+    // synchronously, which keeps the legacy callback form working. The
+    // caller's options object is copied, never mutated.
+    const appOptions = options ? { ...options } : {};
+    if (appOptions.fontSource != null) appOptions.fontSource = createFontSource(appOptions.fontSource);
+
     x11.createClient(x11Options, (error, display) => {
       if (error) return reject(error);
 
@@ -130,7 +143,7 @@ export function createClient(options, callback) {
           });
           updateKeyboardMapping(display.min_keycode, display.max_keycode);
 
-          resolve(new App(display, options || {}));
+          resolve(new App(display, appOptions));
         });
       });
     });
@@ -174,6 +187,7 @@ export {
   FontManager,
   FontconfigFontSource,
   StaticFontSource,
+  createFontSource,
   defaultFontSource,
   setDefaultFontSource,
   CoverageAccumulator,

--- a/lib/text/fontmanager.js
+++ b/lib/text/fontmanager.js
@@ -1,5 +1,10 @@
 import Font from './font.js';
-import { defaultFontSource, detectStyle, numericWeight as numWeight } from './fontsource.js';
+import {
+  createFontSource,
+  defaultFontSource,
+  detectStyle,
+  numericWeight as numWeight
+} from './fontsource.js';
 import { shapeText } from './shape.js';
 import { TextLayout } from './layout.js';
 
@@ -21,11 +26,14 @@ import { TextLayout } from './layout.js';
  *
  * All system lookup goes through a pluggable FontSource (see
  * text/fontsource.js) — pass `{ source }` to use something other than
- * fontconfig, e.g. a StaticFontSource in a browser bundle.
+ * fontconfig, e.g. a StaticFontSource in a browser bundle. `source` also
+ * takes a font spec: a path, a directory of faces, or font bytes.
  */
 export default class FontManager {
   constructor({ source } = {}) {
-    this._source = source ?? null; // resolved lazily so the process-wide default can be set late
+    // coerced here rather than in the getter, which is on the match path;
+    // null stays null so the process-wide default can still be set late
+    this._source = createFontSource(source) ?? null;
     this._fonts = new Map(); // candidate key -> Font
     this._matches = new Map(); // family|weight|style -> Font
     this._fallbacks = new Map(); // family|weight|style -> Map(codepoint -> Font|null)
@@ -146,6 +154,13 @@ export default class FontManager {
    * font doesn't. Registered fonts first, then the source's fallback chain
    * (filtered by the source's coverage data — font files are only opened to
    * confirm). Returns null when nothing on the system covers the codepoint.
+   *
+   * "Nothing covers it" includes "this environment has no system fonts at
+   * all". An app that loaded its own faces still reaches here for the first
+   * character they lack — a bullet, a curly quote — and before this returned
+   * null there, a fontconfig-less box crashed mid-shape on that character,
+   * arbitrarily far from anything about fonts. `shapeText` renders .notdef
+   * for a null, which is the right answer to "no font has this glyph".
    */
   fallbackFor(codepoint, family = 'sans-serif', opts = {}) {
     const cacheKey = `${family}|${numWeight(opts.weight)}|${opts.style || ''}`;
@@ -165,7 +180,15 @@ export default class FontManager {
     }
     if (!found) {
       const source = this.source;
-      const candidates = source.matchSorted({ family, weight: opts.weight, style: opts.style });
+      let candidates;
+      try {
+        candidates = source.matchSorted({ family, weight: opts.weight, style: opts.style });
+      } catch (err) {
+        // no system fonts to fall back to is an answer, not a crash; a source
+        // that failed for any other reason is a real bug and still propagates
+        if (err.code !== 'ERR_NTK_NO_FONTS') throw err;
+        candidates = [];
+      }
       for (const c of candidates) {
         if (source.covers && !source.covers(c, codepoint)) continue;
         try {

--- a/lib/text/fontsource.js
+++ b/lib/text/fontsource.js
@@ -23,7 +23,18 @@
 // The default source shells out to fc-match (fontconfig) — the behavior ntk
 // always had. Swap it per-app (`createClient({ fontSource })`), per-manager
 // (`new FontManager({ source })`) or globally (`setDefaultFontSource()`).
-import { charsetHas, matchSortedSync } from '../fontconfig.js';
+//
+// All three of those also accept a **font spec** — a path, a directory, font
+// bytes, or a list of them — which `createFontSource` turns into a
+// StaticFontSource. That is the whole answer for an environment with no
+// fontconfig: ntk ships no fonts, so the app has to hand over the ones it
+// ships, and the spec is the short way to say so.
+//
+// node:fs is fetched through `getBuiltinModule` inside the path branch rather
+// than imported, because this file is the one the browser bundle keeps — its
+// whole purpose is running the text stack without a filesystem. Do not turn
+// that into a static import (test/packaging.test.js fails if you do).
+import { charsetHas, matchSortedSync, noFontsError, supported } from '../fontconfig.js';
 import Font from './font.js';
 
 const WEIGHTS = { normal: 400, bold: 700 };
@@ -51,6 +62,23 @@ export function detectStyle(font) {
       /italic|oblique/i.test(font.fk.subfamilyName || '')
     )
   };
+}
+
+// A font is monospaced if it says so, or if it draws a period as wide as a W.
+// The probe is the part that carries its weight — `post.isFixedPitch` is 0 on
+// plenty of genuinely fixed-pitch faces.
+const PROBE = ['i', 'M', 'W', '.'].map((c) => c.codePointAt(0));
+
+function isMonospaced(font) {
+  if (font.fk.post?.isFixedPitch) return true;
+  let width = null;
+  for (const cp of PROBE) {
+    if (!font.hasGlyph(cp)) return false;
+    const advance = font.fk.glyphForCodePoint(cp).advanceWidth;
+    if (width === null) width = advance;
+    else if (advance !== width) return false;
+  }
+  return width !== null && width > 0;
 }
 
 /** split a CSS font-family list into normalized lowercase names */
@@ -95,6 +123,8 @@ export class StaticFontSource {
     this._faces = []; // { font, family, weight, italic, candidate }
     this._aliases = new Map(); // 'sans-serif' -> 'dejavu sans'
     this._n = 0;
+    /** files a font spec could not parse: [{ file, error }] */
+    this.skipped = [];
   }
 
   /**
@@ -129,9 +159,55 @@ export class StaticFontSource {
     this._aliases.set(name.toLowerCase(), family.toLowerCase());
   }
 
+  /** what the generic families currently resolve to, for inspection */
+  get aliases() {
+    return Object.fromEntries(this._aliases);
+  }
+
+  /**
+   * Point `sans-serif`, `serif` and `monospace` at added faces.
+   *
+   * This is not cosmetic. Every widget default in the toolkit is
+   * `sans-serif`, and `code`/`pre` ask for `monospace`; with no alias for
+   * them `matchSorted` ranks every face equally and breaks the tie on weight
+   * distance and then insertion order, so `monospace` silently renders in a
+   * proportional face. Inference happens automatically for a source built
+   * from a font spec; a hand-built source calls this when it wants it.
+   *
+   * A generic is only aliased on positive evidence, and a generic with none
+   * is deliberately left out — its absence from `aliases` is the signal to
+   * pass an explicit one. Monospace is decided structurally, because fonts
+   * lie about it: KaTeX_Typewriter reports `isFixedPitch = 0` while every
+   * advance is 525. Sans/serif read the font's own family name, the
+   * convention DejaVu, Noto, Liberation, Source and IBM Plex all follow —
+   * never the filename, which loses on `Inter_18pt-SemiBold.ttf`.
+   *
+   * Explicit aliases are never overridden.
+   */
+  inferGenerics() {
+    const mono = [];
+    const rest = [];
+    for (const face of this._faces) (isMonospaced(face.font) ? mono : rest).push(face);
+
+    // "sans" is checked first and its matches are then excluded, because
+    // "SansSerif" and "Sans Serif" contain "serif" — without that, the one
+    // family named for both wins the generic it is least suited to
+    const sans = rest.filter((f) => /sans/i.test(f.font.familyName || ''));
+    const serif = rest.filter((f) => !sans.includes(f) && /serif/i.test(f.font.familyName || ''));
+    const evidence = {
+      monospace: mono[0]?.family,
+      'sans-serif': sans[0]?.family,
+      serif: serif[0]?.family
+    };
+    for (const [generic, family] of Object.entries(evidence)) {
+      if (family && !this._aliases.has(generic)) this._aliases.set(generic, family);
+    }
+    return this;
+  }
+
   matchSorted(pattern = {}) {
     if (this._faces.length === 0) {
-      throw new Error('StaticFontSource: no fonts added');
+      throw noFontsError('this font source has no fonts added');
     }
     const families = parseFamilies(pattern.family).map((f) => this._aliases.get(f) ?? f);
     const weight = numericWeight(pattern.weight);
@@ -160,6 +236,179 @@ export class StaticFontSource {
   }
 }
 
+// A directory of an app's own faces is a handful of files; a system font
+// tree is hundreds, and every one of them is parsed and then retained for
+// the life of the FontManager (one macOS emoji collection alone is 188 MB).
+// Rather than document that and hope, the walk stops and names the option —
+// an app that really means it says so.
+const MAX_FILES = 64;
+const MAX_DEPTH = 8;
+
+// Said whenever ntk is handed something it cannot read as fonts. It names
+// every accepted shape rather than the one that was wrong, and states the
+// premise — ntk has no fonts of its own — because the spec that brings people
+// here is `'bundled'`, from an issue proposing a font package that does not
+// exist. Naming that value in the matcher would enshrine an API that never
+// shipped; this answers the question without making it real.
+const ACCEPTED =
+  ". Pass 'system', a path to a font file or directory, font bytes, an array of " +
+  'those, { fonts, alias }, or a FontSource. ntk ships no fonts of its own — see ' +
+  'docs/fonts.md';
+
+function fs() {
+  const mod = globalThis.process?.getBuiltinModule?.('node:fs');
+  if (!mod) {
+    throw new Error(
+      'ntk: a font path can only be read in node. In a browser, fetch the font ' +
+        'bytes yourself and pass them: fontSource: [bytes] — see docs/fonts.md'
+    );
+  }
+  return mod;
+}
+
+/** stat a spec'd path, reporting a missing one as the spec mistake it is
+ * rather than as a bare ENOENT from somewhere inside ntk */
+function statOf(path) {
+  try {
+    return fs().statSync(path);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      // A bare word is far more likely a spec someone invented — 'bundled' is
+      // the one the issue asks for — than a path they mistyped. Answer the
+      // question they were actually asking.
+      const guess = /[/\\.]/.test(path) ? '' : ACCEPTED;
+      throw new Error(`ntk: no such font file or directory: "${path}"${guess}`, { cause: err });
+    }
+    throw err;
+  }
+}
+
+/** every font file in a directory, sorted — never readdir order, which would
+ * let the filesystem pick which face `sans-serif` lands on */
+function fontFilesIn(dir, recursive, budget, depth = 0) {
+  const { readdirSync } = fs();
+  const found = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  for (const entry of entries) {
+    const path = `${dir}/${entry.name}`;
+    // isDirectory() is false for a symlink, so this skips linked directories
+    // and with them any chance of a cycle
+    if (entry.isDirectory()) {
+      if (recursive && depth < MAX_DEPTH) found.push(...fontFilesIn(path, true, budget, depth + 1));
+    } else if (supported.test(entry.name)) {
+      found.push(path);
+      if (++budget.count > budget.max) {
+        throw new Error(
+          `ntk: more than ${budget.max} font files under "${budget.root}". That is a font ` +
+            "tree rather than an app's own faces, and every one of them would be parsed and " +
+            'kept in memory for the life of the process. List the faces you want, or raise ' +
+            `the limit deliberately: { fonts: '${budget.root}', maxFiles: N } — see docs/fonts.md`
+        );
+      }
+    }
+  }
+  return found;
+}
+
+/** does this look like a face rather than a typo? */
+function isFace(face) {
+  return (
+    typeof face === 'string' ||
+    ArrayBuffer.isView(face) ||
+    face instanceof ArrayBuffer ||
+    (!!face && typeof face === 'object' && (typeof face.path === 'string' || face.data != null))
+  );
+}
+
+function addFace(source, face, skipped) {
+  try {
+    if (typeof face === 'string') return source.add(Font.loadSync(face));
+    if (ArrayBuffer.isView(face) || face instanceof ArrayBuffer) return source.add(face);
+    const { path, data, ...opts } = face;
+    return source.add(path ? Font.loadSync(path, opts.postscriptName) : data, opts);
+  } catch (err) {
+    // one unparseable file should not take a whole directory down; a spec
+    // that yields no usable face at all still throws, below
+    skipped.push({ file: typeof face === 'string' ? face : face?.path, error: err });
+    return null;
+  }
+}
+
+function describe(value) {
+  if (typeof value === 'string') return `"${value}"`;
+  if (Array.isArray(value)) return 'that array';
+  return value === null ? 'null' : typeof value;
+}
+
+/**
+ * Resolve a **font spec** to a FontSource.
+ *
+ * ```
+ * spec  := FontSource | 'system' | null | undefined
+ *        | faces | { fonts: faces, alias?, recursive?, maxFiles? }
+ * faces := face | face[]
+ * face  := string (path to a font FILE or DIRECTORY)
+ *        | Uint8Array | Buffer | ArrayBuffer
+ *        | { path | data, family?, weight?, style?, postscriptName? }
+ * ```
+ *
+ * Idempotent — a FontSource passes straight through, which is what lets
+ * `createClient`, `FontManager` and `setDefaultFontSource` all coerce
+ * without caring whether someone already did.
+ *
+ * Anything built from faces is a `StaticFontSource`, so there is one
+ * matching implementation to reason about rather than two. Generic families
+ * are inferred (see `inferGenerics`) with an explicit `alias` map winning.
+ *
+ * @param {*} spec
+ * @returns {object|null|undefined} a FontSource
+ */
+export function createFontSource(spec) {
+  if (spec == null) return spec; // preserves setDefaultFontSource(null)'s reset
+  if (typeof spec.matchSorted === 'function') return spec;
+  if (spec === 'system') return new FontconfigFontSource();
+
+  const configured = !Array.isArray(spec) && typeof spec === 'object' && 'fonts' in spec;
+  const { fonts, alias, recursive = false, maxFiles = MAX_FILES } = configured ? spec : { fonts: spec };
+  const list = Array.isArray(fonts) ? fonts : [fonts];
+
+  if (list.length === 0 || !list.every(isFace)) {
+    throw new Error(`ntk: ${describe(spec)} is not a font source${ACCEPTED}`);
+  }
+
+  const source = new StaticFontSource();
+  const skipped = [];
+  const budget = { count: 0, max: maxFiles, root: null };
+  let added = 0;
+  for (const face of list) {
+    if (typeof face === 'string' && statOf(face).isDirectory()) {
+      budget.root = face;
+      const files = fontFilesIn(face, recursive, budget);
+      if (files.length === 0) {
+        throw new Error(
+          `ntk: no font files in "${face}" — looked for .ttf/.otf/.woff/.woff2/.ttc/.dfont` +
+            (recursive ? '' : '. Pass { fonts, recursive: true } to walk subdirectories')
+        );
+      }
+      for (const file of files) if (addFace(source, file, skipped)) added++;
+    } else if (addFace(source, face, skipped)) {
+      added++;
+    }
+  }
+
+  source.skipped = skipped;
+  if (added === 0) {
+    throw new Error(
+      `ntk: none of the ${skipped.length} font file(s) given could be parsed — ` +
+        `${skipped[0]?.file ?? 'the first'}: ${skipped[0]?.error?.message ?? 'unknown error'}`
+    );
+  }
+
+  for (const [generic, family] of Object.entries(alias ?? {})) source.alias(generic, family);
+  return source.inferGenerics();
+}
+
 let _default = null;
 
 /** the process-wide default FontSource (fontconfig unless overridden) */
@@ -173,7 +422,10 @@ export function defaultFontSource() {
  * created afterwards without an explicit source — including the ones
  * widgets create internally. The primary hook for browser playgrounds:
  * call it once with a StaticFontSource before creating any app/window.
+ *
+ * Takes a font spec as well as a source, so pointing the whole process at a
+ * directory is one line. `null` restores the fontconfig default.
  */
 export function setDefaultFontSource(source) {
-  _default = source;
+  _default = createFontSource(source);
 }

--- a/test/fontconfig.test.js
+++ b/test/fontconfig.test.js
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
 
 import { listFontsSync } from '../lib/fontconfig.js';
@@ -9,6 +13,39 @@ try {
   execFileSync('fc-match', ['--version'], { stdio: 'ignore' });
 } catch {
   hasFontconfig = false;
+}
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * Ask a child process to match a font with `fc-match` replaced by `stub`
+ * (or absent entirely), and report the error it got.
+ *
+ * PATH is pointed at an empty directory rather than cleared: with no PATH at
+ * all, execvp falls back to a compiled-in default path and finds the real
+ * fc-match, which would quietly make these tests assert nothing.
+ */
+function matchWithout(stub) {
+  const bin = mkdtempSync(join(tmpdir(), 'ntk-nofc-'));
+  if (stub) {
+    const path = join(bin, 'fc-match');
+    writeFileSync(path, stub);
+    chmodSync(path, 0o755);
+  }
+  const script = join(bin, 'probe.mjs');
+  writeFileSync(
+    script,
+    `import FontManager from ${JSON.stringify(join(root, 'lib/text/fontmanager.js'))};\n` +
+      'try {\n' +
+      "  new FontManager().match('sans-serif');\n" +
+      "  console.log(JSON.stringify({ ok: true }));\n" +
+      '} catch (err) {\n' +
+      '  console.log(JSON.stringify({ code: err.code, message: err.message, cause: err.cause?.code }));\n' +
+      '}\n'
+  );
+  const run = spawnSync(process.execPath, [script], { env: { PATH: bin }, encoding: 'utf8' });
+  assert.equal(run.status, 0, `probe failed: ${run.stderr}`);
+  return JSON.parse(run.stdout);
 }
 
 test('resolves sans-serif to a parseable font file', { skip: !hasFontconfig && 'fc-match not installed' }, () => {
@@ -21,4 +58,41 @@ test('resolves bold and italic patterns', { skip: !hasFontconfig && 'fc-match no
   const italic = listFontsSync({ family: 'sans-serif', style: 'italic', weight: 400 });
   assert.ok(bold.path);
   assert.ok(italic.path);
+});
+
+// The environments issue #121 is about. These run everywhere, with or
+// without fontconfig, because they put a stub on the child's PATH — what
+// used to happen here was a bare `spawnSync fc-match ENOENT` thrown from
+// inside the first text layout, naming neither ntk nor fonts nor a fix.
+
+test('a missing fc-match says what is wrong and how to fix it', () => {
+  const err = matchWithout(null);
+  assert.equal(err.code, 'ERR_NTK_NO_FONTS');
+  assert.equal(err.cause, 'ENOENT', 'the original spawn failure is preserved');
+  assert.match(err.message, /fc-match CLI \(fontconfig\) is not installed/);
+  assert.match(err.message, /fontSource/, 'names the option that fixes it');
+  assert.match(err.message, /apt-get|apk add/, 'and the cheaper fix where there is a package manager');
+  assert.match(err.message, /docs\/fonts\.md#environments-without-fontconfig/);
+});
+
+test('fontconfig installed with no font packages is its own message', () => {
+  // Alpine with fontconfig and no font package: exits 1 on stderr, so the
+  // spawn succeeds and the "not installed" wording would be a lie
+  const err = matchWithout('#!/bin/sh\necho "No fonts installed on the system" >&2\nexit 1\n');
+  assert.equal(err.code, 'ERR_NTK_NO_FONTS');
+  assert.match(err.message, /fc-match exited 1: No fonts installed on the system/);
+});
+
+test('fonts fc-match found but fontkit cannot parse are named as such', () => {
+  // a bitmap-only image: fc-match exits 0 and lists .pcf files
+  const err = matchWithout('#!/bin/sh\nprintf "/usr/share/fonts/misc/fixed.pcf\\tFixed\\t20-7e\\n"\n');
+  assert.equal(err.code, 'ERR_NTK_NO_FONTS');
+  assert.match(err.message, /matched no font ntk can parse/);
+  assert.match(err.message, /bitmap \.pcf\/\.bdf fonts are not usable/);
+});
+
+test('the docs anchor the error points at exists', () => {
+  // nothing else in CI checks a doc anchor referenced from a string literal
+  const docs = readFileSync(join(root, 'docs/fonts.md'), 'utf8');
+  assert.match(docs, /^## Environments without fontconfig$/m);
 });

--- a/test/fontsource.test.js
+++ b/test/fontsource.test.js
@@ -1,15 +1,18 @@
 // The pluggable FontSource seam — fully hermetic: uses the KaTeX .ttf files
 // shipped with the katex dependency, no fontconfig / fc-match required.
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 
 import FontManager from '../lib/text/fontmanager.js';
 import Font from '../lib/text/font.js';
 import {
+  FontconfigFontSource,
   StaticFontSource,
+  createFontSource,
   defaultFontSource,
   setDefaultFontSource
 } from '../lib/text/fontsource.js';
@@ -17,6 +20,13 @@ import {
 const require = createRequire(import.meta.url);
 const fontDir = join(dirname(require.resolve('katex/package.json')), 'dist', 'fonts');
 const bytes = (file) => readFileSync(join(fontDir, file));
+
+/** a directory of faces, the way an app ships its own fonts */
+function fontsDir(files = ['KaTeX_SansSerif-Regular.ttf', 'KaTeX_Typewriter-Regular.ttf']) {
+  const dir = mkdtempSync(join(tmpdir(), 'ntk-fonts-'));
+  for (const file of files) copyFileSync(join(fontDir, file), join(dir, file));
+  return dir;
+}
 
 function staticSource() {
   const source = new StaticFontSource();
@@ -102,4 +112,167 @@ test('setDefaultFontSource affects managers without an explicit source', () => {
   } finally {
     setDefaultFontSource(original);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Font specs — pointing ntk at the faces an app ships, which is the whole
+// answer for an environment with no fontconfig (issue #121)
+// ---------------------------------------------------------------------------
+
+test('a FontSource passes through createFontSource untouched', () => {
+  const source = staticSource();
+  assert.equal(createFontSource(source), source);
+  // duck-typed, so a plain object implementing the contract survives too
+  const plain = { matchSorted: () => [] };
+  assert.equal(createFontSource(plain), plain);
+});
+
+test('null and undefined pass through, so the default can still be reset', () => {
+  assert.equal(createFontSource(null), null);
+  assert.equal(createFontSource(undefined), undefined);
+  const original = defaultFontSource();
+  try {
+    setDefaultFontSource(staticSource());
+    setDefaultFontSource(null);
+    assert.ok(defaultFontSource() instanceof FontconfigFontSource);
+  } finally {
+    setDefaultFontSource(original);
+  }
+});
+
+test("'system' names the default out loud, without spawning anything", () => {
+  assert.ok(createFontSource('system') instanceof FontconfigFontSource);
+});
+
+test('a directory of faces becomes a working source', () => {
+  const dir = fontsDir();
+  const fm = new FontManager({ source: dir });
+  assert.equal(fm.match('sans-serif').postscriptName, 'KaTeX_SansSerif-Regular');
+  assert.equal(fm.match('monospace').postscriptName, 'KaTeX_Typewriter-Regular');
+});
+
+test('directory order is sorted, not readdir order', () => {
+  // the filesystem must never be what decides which face `sans-serif` gets
+  const dir = fontsDir(['KaTeX_Main-Regular.ttf', 'KaTeX_AMS-Regular.ttf', 'KaTeX_Fraktur-Regular.ttf']);
+  const order = () =>
+    createFontSource(dir)
+      .matchSorted({ family: 'nothing-matches' })
+      .map((c) => c.font.postscriptName);
+  assert.deepEqual(order(), order());
+  assert.equal(order()[0], 'KaTeX_AMS-Regular'); // alphabetical, not copy order
+});
+
+test('subdirectories need recursive: true', () => {
+  const dir = fontsDir();
+  mkdirSync(join(dir, 'extra'));
+  copyFileSync(join(fontDir, 'KaTeX_Fraktur-Regular.ttf'), join(dir, 'extra', 'KaTeX_Fraktur-Regular.ttf'));
+  const names = (spec) => createFontSource(spec).matchSorted({}).map((c) => c.font.postscriptName);
+  assert.equal(names(dir).includes('KaTeX_Fraktur-Regular'), false);
+  assert.equal(names({ fonts: dir, recursive: true }).includes('KaTeX_Fraktur-Regular'), true);
+});
+
+test('font files, bytes and descriptors are all faces', () => {
+  const paths = createFontSource([
+    join(fontDir, 'KaTeX_Main-Regular.ttf'),
+    join(fontDir, 'KaTeX_Main-Bold.ttf')
+  ]);
+  assert.equal(new FontManager({ source: paths }).match('KaTeX_Main', { weight: 700 }).postscriptName, 'KaTeX_Main-Bold');
+
+  const buf = bytes('KaTeX_Main-Regular.ttf');
+  for (const data of [buf, new Uint8Array(buf), buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)]) {
+    assert.equal(new FontManager({ source: [data] }).match('x').postscriptName, 'KaTeX_Main-Regular');
+  }
+
+  const described = new FontManager({
+    source: [{ path: join(fontDir, 'KaTeX_Main-Regular.ttf'), family: 'UI', weight: 700 }]
+  });
+  assert.equal(described.match('UI', { weight: 'bold' }).postscriptName, 'KaTeX_Main-Regular');
+});
+
+test('generic families are inferred from the font tables, not the filename', () => {
+  const source = createFontSource(fontsDir([
+    'KaTeX_SansSerif-Regular.ttf',
+    'KaTeX_Typewriter-Regular.ttf',
+    'KaTeX_Main-Regular.ttf'
+  ]));
+  // KaTeX_Typewriter reports isFixedPitch = 0 and is caught by the advance
+  // probe; KaTeX_SansSerif is named, and must not also win `serif` just
+  // because "SansSerif" contains it
+  assert.equal(source.aliases.monospace, 'katex_typewriter');
+  assert.equal(source.aliases['sans-serif'], 'katex_sansserif');
+  assert.equal('serif' in source.aliases, false, 'no evidence for serif, so no guess');
+});
+
+test('an explicit alias survives inference', () => {
+  const source = createFontSource({ fonts: fontsDir(), alias: { serif: 'KaTeX_SansSerif' } });
+  assert.equal(source.aliases.serif, 'katex_sansserif');
+  assert.equal(source.aliases.monospace, 'katex_typewriter'); // still inferred
+});
+
+test('a hand-built source is unchanged unless it asks for inference', () => {
+  const source = new StaticFontSource();
+  source.add(bytes('KaTeX_Typewriter-Regular.ttf'));
+  assert.deepEqual(source.aliases, {});
+  source.inferGenerics();
+  assert.equal(source.aliases.monospace, 'katex_typewriter');
+});
+
+test('one unparseable file does not take the directory down', () => {
+  const dir = fontsDir();
+  writeFileSync(join(dir, 'broken.ttf'), 'not a font');
+  const source = createFontSource(dir);
+  assert.equal(source.skipped.length, 1);
+  assert.match(source.skipped[0].file, /broken\.ttf$/);
+  assert.equal(new FontManager({ source }).match('monospace').postscriptName, 'KaTeX_Typewriter-Regular');
+});
+
+test('a spec mistake is reported as a spec mistake', () => {
+  const dir = fontsDir();
+  // the issue proposes `fonts: 'bundled'`; ntk ships none, so rather than
+  // name a value that could only ever throw, say what is accepted
+  assert.throws(() => createFontSource('bundled'), /not a font source|no such font file/);
+  assert.throws(() => createFontSource('bundled'), /ntk ships no fonts of its own/);
+  for (const bad of [42, {}, [], true]) {
+    assert.throws(() => createFontSource(bad), /is not a font source/);
+  }
+  assert.throws(() => createFontSource('/no/such/dir'), /no such font file or directory/);
+  assert.throws(() => createFontSource(mkdtempSync(join(tmpdir(), 'ntk-empty-'))), /no font files in/);
+  assert.throws(() => createFontSource({ fonts: dir, maxFiles: 1 }), /maxFiles/);
+  // none of these are ERR_NTK_NO_FONTS: the environment is fine, the call is wrong
+  assert.throws(() => createFontSource(42), (err) => err.code !== 'ERR_NTK_NO_FONTS');
+});
+
+test('an empty source reports having no fonts, with the shared code', () => {
+  assert.throws(
+    () => new StaticFontSource().matchSorted({}),
+    (err) => err.code === 'ERR_NTK_NO_FONTS'
+  );
+});
+
+test('no system fonts degrades to .notdef instead of crashing mid-shape', () => {
+  // the environment this issue is about: an app that loaded its own faces
+  // still reaches the source for the first codepoint they lack
+  const empty = {
+    matchSorted() {
+      const err = new Error('nothing here');
+      err.code = 'ERR_NTK_NO_FONTS';
+      throw err;
+    }
+  };
+  const fm = new FontManager({ source: empty });
+  fm.load(bytes('KaTeX_Main-Regular.ttf'), { family: 'ui' });
+  assert.equal(fm.fallbackFor(0x2136, 'ui'), null);
+  const shaped = fm.shape('aℶ', { family: 'ui', size: 16 });
+  assert.deepEqual(shaped.runs.map((r) => r.font.postscriptName), ['KaTeX_Main-Regular']);
+
+  // a source that failed for any other reason is a bug, and still surfaces
+  const broken = new FontManager({
+    source: {
+      matchSorted() {
+        throw new Error('my source is broken');
+      }
+    }
+  });
+  broken.load(bytes('KaTeX_Main-Regular.ttf'), { family: 'ui' });
+  assert.throws(() => broken.fallbackFor(0x2136, 'ui'), /my source is broken/);
 });

--- a/test/packaging.test.js
+++ b/test/packaging.test.js
@@ -36,6 +36,26 @@ test('nothing in lib/ imports the top-level-await yoga entry', () => {
   );
 });
 
+test('nothing in lib/ statically imports a node builtin', () => {
+  // docs/packaging.md and AGENTS.md both promise this: lib/ bundles for the
+  // browser, so a node builtin has to be fetched lazily through
+  // `process.getBuiltinModule` behind a capability check. A static import
+  // breaks the bundle at build time, a long way from whoever added it.
+  // node:events is the one exception — lib/drawable.js extends EventEmitter.
+  const offenders = [];
+  for (const path of sources(libDir)) {
+    const imports = readFileSync(path, 'utf8').matchAll(/from\s+['"](node:[\w/]+)['"]/g);
+    for (const [, mod] of imports) {
+      if (mod !== 'node:events') offenders.push(`${path.slice(libDir.length + 1)}: ${mod}`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    "use globalThis.process?.getBuiltinModule?.('node:…') inside the function that needs it"
+  );
+});
+
 test('importing ntk does not load the layout WebAssembly', async () => {
   // startup cost aside, this is what keeps the graph free of top-level await:
   // the assembly is fetched by createClient(), not by module evaluation


### PR DESCRIPTION
Closes #121.

## The problem, reproduced

ntk resolves every font through the `fc-match` CLI and opens the matches from host paths. With `fc-match` off the PATH, this is what a user gets — thrown from inside the first text layout, naming neither ntk, nor fonts, nor a remedy:

```
Error: spawnSync fc-match ENOENT
    at Object.spawnSync (node:internal/child_process)
    ... at shapeText (lib/text/shape.js:79)
```

That is the whole of issue #121's headline symptom, and it reads as "ntk is broken in Docker".

The issue proposed a bundled font package plus a convenience knob. **The package is out of scope**, so ntk ships zero fonts before and after this change — which makes the question "given that, what is the best possible fix?" Two halves.

## Point ntk at the faces the app ships

`fontSource` accepts a **font spec** as well as a FontSource:

```js
await createClient({ fontSource: '/app/fonts' });      // a directory
await createClient({ fontSource: './Inter.ttf' });     // one file
await createClient({ fontSource: [bytes, more] });     // bytes, no filesystem
await createClient({ fontSource: 'system' });          // today's default, said out loud
await createClient({ fontSource: { fonts: dir, alias: { serif: 'Charter' } } });
```

`createFontSource(spec)` is that resolution, exported and idempotent — a FontSource passes straight through — which is why `FontManager` and `setDefaultFontSource` take a spec too.

**Why widen `fontSource` instead of adding `fonts:`.** `fonts` is already taken twice for something else: `app.fonts` is a FontManager, and `HtmlView` takes `{ fonts: FontManager }`. A second option shadowing a live one needs precedence rules forever, and ~30 files already say `fontSource`. Widening accepted types is not a breaking change; adding a synonym is a migration.

**`'bundled'` is deliberately not a value.** With no package to name it could only throw, and naming it would enshrine an API that never shipped — and invite the obvious follow-up of resolving an optional package at runtime, which is dead inside a SEA, where the module loader reaches built-ins only. Passing it gets the accepted-shapes message instead, so a reader who came from the issue still gets their answer.

Two details that are load-bearing rather than polish:

- **Directory listings are sorted before anything is parsed.** The filesystem must never be what decides which face `sans-serif` lands on — a change whose selling point includes reproducible rendering cannot leave that to `readdir` order.
- **Generic families are inferred from the font tables, never filenames.** `monospace` structurally, because fonts lie about `isFixedPitch` — KaTeX_Typewriter reports 0 with every advance at 525 — and sans/serif from the family name in the `name` table. A generic with no evidence is left unaliased rather than guessed at, and `source.aliases` shows what was chosen. Without this, `monospace` silently renders in a proportional face, since `matchSorted` ranks unaliased families by weight distance and then insertion order.

**Bounded on purpose.** Every file found is parsed and then held for the life of the process. That is right for the handful an app ships and wrong for a system font tree: I measured this Mac's font directories at 372 files, 1.43 s and 218 MB RSS to open them all, and one `Apple Color Emoji.ttc` alone is 188 MB. Past 64 files the walk stops and names `maxFiles`. A cap is an invented number and I would rather not have one, but "the docs steer you away" is not a guard in a memory-capped container, and the error is a one-word fix.

## Say what is wrong when there are none

Every no-fonts path throws one message carrying `code: 'ERR_NTK_NO_FONTS'`:

```
ntk: no fonts available — the fc-match CLI (fontconfig) is not installed here.

ntk ships no font files, so a slim/distroless container, a single-executable
build, a kiosk image or a CI box without font packages has to supply them:

    createClient({ fontSource: '/app/fonts' })   // a directory of .ttf/.otf files
    createClient({ fontSource: [bytes] })        // font bytes — no filesystem needed

Where a package manager is available, installing fontconfig plus a font package
is simpler: Debian/Ubuntu `apt-get install -y --no-install-recommends fontconfig
fonts-dejavu-core`; Alpine `apk add fontconfig font-dejavu`.
```

Three causes, three first lines, because they are three different fixes: `fc-match` absent; `fc-match` present and exiting non-zero, which is the Alpine "fontconfig installed, no font package" state; and `fc-match` matching only formats fontkit cannot parse, which is a bitmap-only image. Each has a test that puts a stub on the child's PATH, so all three run on any machine with or without fontconfig.

Recommending `apt-get` first, ahead of ntk's own option, is deliberate. For most container users it is two Dockerfile lines against any amount of app code, and a library that hides the cheaper fix to advertise its own API is not being helpful.

## One real crash fixed on the way

`fallbackFor` now treats `ERR_NTK_NO_FONTS` as "no fallback exists" instead of propagating it. This is not cosmetic: an app that loaded its own faces **still** consults the source for the first codepoint they lack — a bullet, a curly quote — so on a fontconfig-less box it died mid-shape, arbitrarily far from anything about fonts, on a character rather than at startup. It draws `.notdef` now, which is the right answer to "no font has this glyph". A source that fails for any other reason still propagates, which is what the `code` is for.

This is the only behaviour change for an app that was not already crashing.

## Not built

Directory scanning of *system* font paths as an automatic fallback, which was the tempting third design. It would make a slim image with `fonts-dejavu-core` work with no app change, but on macOS `/usr/bin/fc-match` does not exist and `launchctl getenv PATH` is empty — so the same binary launched from Finder and from a terminal would silently pick different backends, and therefore different typefaces. A loud one-line-diagnosable error beats a quietly different font. Also skipped: an `NTK_FONTS` env var, for the same reason — it would be the first env var in ntk that changes rendering output.

## Testing

629 pass. 20 new in `fontsource.test.js` covering the spec shapes, sort determinism, inference, `skipped`, and each spec mistake; 4 in `fontconfig.test.js` for the three failure modes and the doc anchor the error hardcodes. Plus one in `packaging.test.js` encoding a rule `docs/packaging.md` already claimed but nothing checked: nothing under `lib/` may statically import a node builtin, `node:events` excepted. It passes today, and this change adds lazy `fs` to the file whose whole purpose is browser-safety, so it is worth having.
