### PR TITLE
feat(clipboard): conversion timestamps, and clear() to give a selection back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ lib/keyboard.js            key event -> keysym/codepoint: XKB group from the
                            event state, CapsLock only on cased keys
 lib/clipboard.js           app.clipboard: ICCCM selection/clipboard transfer
                            (CLIPBOARD/PRIMARY, required targets, INCR both
-                           ways, multi-format ownership)
+                           ways, multi-format ownership, acquire/release
+                           and conversion timestamps)
 lib/renderingcontext_2d.js canvas-like context (XRender); CanvasGradient
 lib/path.js                Path2D, SVG path-data parser, affine matrices,
                            adaptive bezier flattening

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,9 +17,9 @@ matching file here (see AGENTS.md).
 - [Window](window.md) — window creation, properties, methods, events,
   keyboard input, frame pacing / event coalescing, `requestAnimationFrame`
 - [Pixmap](pixmap.md) — offscreen drawables
-- [Clipboard](clipboard.md) — `app.clipboard.write()/read()`: transfer over
-  the CLIPBOARD/PRIMARY selections (ICCCM), multi-format ownership, INCR
-  both ways
+- [Clipboard](clipboard.md) — `app.clipboard.write()/read()/clear()`:
+  transfer over the CLIPBOARD/PRIMARY selections (ICCCM), multi-format
+  ownership, INCR both ways
 - [2d rendering context](context-2d.md) — canvas-like drawing API over XRender
 - [Images](images.md) — PNG/JPEG loading (`loadImage`), the `Image` object,
   `drawImage`

--- a/docs/app.md
+++ b/docs/app.md
@@ -56,7 +56,7 @@ const app2 = await createClient({ display: ':1' });
 - `app.X` — the raw node-x11 client, for direct protocol requests
 - `app.fonts` — lazy [FontManager](fonts.md): font matching/loading, shaping
 - `app.clipboard` — lazy [Clipboard](clipboard.md): selection/clipboard
-  transfer (`write()`/`read()`), text or arbitrary targets
+  transfer (`write()`/`read()`/`clear()`), text or arbitrary targets
 - `app.rasterizer` — the Rasterizer small fills and strokes go through;
   writable, `null` sends every drawing to the server
   ([context-2d.md](context-2d.md#swapping-the-rasterizer))

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -7,9 +7,8 @@ X has no clipboard buffer: "copy" means owning a **selection** (the
 `CLIPBOARD` atom for explicit copy/paste, `PRIMARY` for middle-click paste)
 and answering conversion requests from whichever client pastes; "paste"
 means asking the current owner to convert its data into a property and
-reading it back. `app.clipboard` hides that ICCCM dance behind two
-promises, using a hidden 1×1 never-mapped helper window as the selection
-endpoint.
+reading it back. `app.clipboard` hides that ICCCM dance behind promises,
+using a hidden 1×1 never-mapped helper window as the selection endpoint.
 
 ```js
 import { createClient } from 'ntk';
@@ -49,9 +48,10 @@ Takes ownership of a selection and serves `data` to anyone who pastes.
 - Resolves once the server confirms the ownership; rejects if it could not
   be acquired.
 - Ownership (and the data) is held until another client copies — the
-  server's `SelectionClear` then drops it — or the app closes. The data
-  lives in this process: unlike desktops with a clipboard manager, closing
-  the app makes the selection unavailable, which is normal X behavior.
+  server's `SelectionClear` then drops it — until [`clear()`](#appclipboardclearselection--promise)
+  gives it up, or until the app closes. The data lives in this process:
+  unlike desktops with a clipboard manager, closing the app makes the
+  selection unavailable, which is normal X behavior.
 
 Requestors are offered the three targets ICCCM 2.6.2 makes mandatory —
 `TARGETS`, `TIMESTAMP` (the ownership timestamp, as an `INTEGER`) and
@@ -69,6 +69,36 @@ them. This is transparent to both sides — nothing in the API changes with
 size. A requestor that abandons a transfer is dropped after 10 seconds of
 silence.
 
+## `app.clipboard.clear([selection]) → Promise`
+
+Gives a selection back: stops owning it, and stops answering for it.
+
+```js
+await app.clipboard.clear(); // CLIPBOARD
+await app.clipboard.clear('XdndSelection'); // at the end of a drag
+```
+
+The counterpart to `write()`, which otherwise holds a selection until another
+client takes it or the app exits. Two things want it: a drag source, which
+should stop offering its payload once the drag is over — a stale offer
+answered afterwards is what XDND's "throw out extremely old data" rule is
+about — and apps that clear the clipboard deliberately, a password manager
+being the usual example.
+
+- `selection` — selection atom name, default `'CLIPBOARD'`. One selection at
+  a time: clearing `CLIPBOARD` leaves `PRIMARY` alone.
+- Clearing a selection this app does not own does nothing, and in particular
+  **sends nothing**. `SetSelectionOwner(None)` from a non-owner would take
+  the selection away from whichever client legitimately holds it.
+- Released with the timestamp the selection was acquired with, as ICCCM
+  2.3.1 requires — not a fresh one. The server ignores a release whose time
+  is earlier than the selection's current last-change time, so if another
+  client has taken the selection meanwhile this correctly does nothing,
+  where a fresh timestamp would have taken it away from them.
+- A transfer already in flight still completes: an `INCR` transfer holds its
+  own copy of the payload (ICCCM 2.7.2), exactly as when another client takes
+  the selection from us.
+
 ## `app.clipboard.read([options]) → Promise<string>`
 
 Reads the current text of a selection from whoever owns it.
@@ -76,8 +106,15 @@ Reads the current text of a selection from whoever owns it.
 - `options.selection` — as above, default `'CLIPBOARD'`.
 - `options.timeout` — ms to wait for the owner at each protocol step,
   default 2000.
+- `options.time` — the server timestamp of the event that asked for the
+  paste (the `time` field of the key or button event you handled). ICCCM
+  2.4 says to convert with it rather than `CurrentTime`, so that an owner
+  which has replaced its data since can tell the request is for the older
+  value. Omitting it means `CurrentTime`, which every mainstream owner
+  accepts and a strict one may not.
 - Conversion is requested as `UTF8_STRING` first; if the owner refuses
-  (old Xt/Motif apps), it is retried once as latin-1 `STRING`.
+  (old Xt/Motif apps), it is retried once as latin-1 `STRING`. The retry is
+  part of the same paste, so it carries the same timestamp.
 - Incremental (`INCR`) transfers are followed transparently, so pasting
   data larger than the server's single-transfer limit works.
 - Rejects with a descriptive error when the selection has no owner, when
@@ -86,6 +123,20 @@ Reads the current text of a selection from whoever owns it.
 
 Concurrent `read()` calls on one app are serialized internally (they share
 one transfer property on the helper window).
+
+### Reading a specific target
+
+`options.target` reads one named target instead of text, and resolves with a
+`Buffer` — the mirror of offering one to `write()`:
+
+```js
+const png = await app.clipboard.read({ target: 'image/png' });
+const html = await app.clipboard.read({ target: 'text/html' });
+html.toString('utf8');
+```
+
+`INCR` applies here too, so a payload larger than one request reassembles
+transparently. Rejects naming the target when the owner cannot convert to it.
 
 ## `app.clipboard.watch(selection, handler) → Promise<function>`
 
@@ -128,19 +179,6 @@ with `console.warn` and does not cost the other watchers their event.
 Built on XFixes `SelectSelectionInput`. Every X server since about 2004 has
 the extension; on one that does not, `watch()` rejects saying so, rather than
 silently never firing.
-### Reading a specific target
-
-`options.target` reads one named target instead of text, and resolves with a
-`Buffer` — the mirror of offering one to `write()`:
-
-```js
-const png = await app.clipboard.read({ target: 'image/png' });
-const html = await app.clipboard.read({ target: 'text/html' });
-html.toString('utf8');
-```
-
-`INCR` applies here too, so a payload larger than one request reassembles
-transparently. Rejects naming the target when the owner cannot convert to it.
 
 ## `app.clipboard.targets([options]) → Promise<string[]>`
 
@@ -157,6 +195,9 @@ Ask this before `read({ target })`: an owner answers `TARGETS` cheaply, where
 guessing costs a failed conversion per guess. Resolves with `[]` when nothing
 owns the selection.
 
+Takes `options.selection`, `options.timeout` and `options.time`, all with the
+same meaning as in [`read()`](#appclipboardreadoptions--promisestring).
+
 ## Limitations
 
 - Nothing negotiates with a clipboard manager (`SAVE_TARGETS`), so the data
@@ -171,4 +212,5 @@ routes `SetSelectionOwner` / `ConvertSelection` / `SendEvent` since x11
 3.1.0) — see [xserver.md](xserver.md) and `test/clipboard.test.js`, where
 two ntk clients and raw node-x11 clients (a `STRING`-only legacy owner, an
 `INCR` owner, requestors asking for `TARGETS`, `TIMESTAMP`, `MULTIPLE` and
-`INCR` payloads) pass data to each other hermetically.
+`INCR` payloads, and owners that record the timestamp each conversion
+arrives with) pass data to each other hermetically.

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -115,20 +115,76 @@ export default class Clipboard {
   }
 
   /**
+   * Give a selection back: stop owning it, and stop answering for it.
+   *
+   *   await app.clipboard.clear();                 // CLIPBOARD
+   *   await app.clipboard.clear('XdndSelection');  // at the end of a drag
+   *
+   * The counterpart to `write()`, which otherwise holds a selection until
+   * another client takes it or the app exits. Two things want this: a drag
+   * source, which should stop offering its payload once the drag is over
+   * (a stale offer answered later is exactly what XDND's "throw out
+   * extremely old data" rule is about), and apps that clear the clipboard
+   * on purpose — a password manager, say.
+   *
+   * Clearing a selection this app does not own does nothing, and in
+   * particular sends nothing: `SetSelectionOwner(None)` from a non-owner
+   * would take the selection away from whoever legitimately holds it.
+   *
+   * A transfer already in flight still completes — an INCR transfer keeps
+   * its own copy of the payload (ICCCM 2.7.2), the same as when another
+   * client takes the selection from us.
+   *
+   * @param {string} [selection] selection atom name, default 'CLIPBOARD'
+   * @returns {Promise<void>}
+   */
+  async clear(selection = 'CLIPBOARD') {
+    // nothing has ever been written, so nothing can be owned: answer
+    // without interning an atom or creating the helper window
+    if (!this._owned.size) return;
+    const sel = await this._atom(selection);
+    const entry = this._owned.get(sel);
+    if (!entry) return;
+    this._owned.delete(sel);
+    // ICCCM 2.3.1: release with the timestamp the selection was acquired
+    // with, not a fresh one. A SetSelectionOwner is ignored when its time is
+    // earlier than the selection's current last-change time, so the old
+    // stamp is what makes this lose to a client that has taken the selection
+    // since — where a fresh one would take it away from them.
+    this.X.SetSelectionOwner(0, sel, entry.time);
+    // The server answers the release with a SelectionClear addressed to the
+    // helper window; _onXEvent deletes an _owned entry that is already gone,
+    // which is harmless.
+    //
+    // GetSelectionOwner here is a barrier, not a check: requests are
+    // buffered (one socket write per frame) and it is a reply that forces
+    // the flush, so without it the release could still be sitting in our
+    // output buffer when the caller's next await resumes. Whoever owns the
+    // selection afterwards is not our business — we only promised to stop
+    // being the owner.
+    await new Promise((resolve, reject) =>
+      this.X.GetSelectionOwner(sel, (err) => (err ? reject(err) : resolve()))
+    );
+  }
+
+  /**
    * Read the current text of a selection from whoever owns it.
    * Rejects when the selection has no owner, when the owner supports
    * neither UTF8_STRING nor STRING, or when the owner stops responding
    * (`timeout` ms, default 2000).
    *
    * @param {object} [options] { selection: 'CLIPBOARD' | 'PRIMARY' | ...,
-   *   timeout: ms to wait for the owner at each protocol step }
-   * @returns {Promise<string>}
+   *   timeout: ms to wait for the owner at each protocol step;
+   *   target: one named target, returned as bytes, instead of text;
+   *   time: the server timestamp of the event that asked for the paste
+   *   (ICCCM 2.4) — see `targets()` for why it is worth passing }
+   * @returns {Promise<string|Buffer>}
    */
-  read({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT, target } = {}) {
+  read({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT, target, time } = {}) {
     return this._serialize(() =>
       target === undefined
-        ? this._read(selection, timeout)
-        : this._readTarget(selection, target, timeout)
+        ? this._read(selection, timeout, time)
+        : this._readTarget(selection, target, timeout, time)
     );
   }
 
@@ -142,11 +198,18 @@ export default class Clipboard {
    * `TARGETS` cheaply, where guessing costs a failed conversion per guess.
    * Returns `[]` when nothing owns the selection.
    *
-   * @param {object} [options] { selection, timeout }
+   * `time` is the timestamp of the event that asked for the data. ICCCM 2.4
+   * says to pass it rather than CurrentTime, so that an owner which has
+   * since replaced its data can tell that the request is for the older
+   * value; XDND makes it binding, since a drop must convert with the
+   * timestamp from its `XdndDrop` message. Omitting it means CurrentTime,
+   * which every mainstream owner accepts and a strict one may not.
+   *
+   * @param {object} [options] { selection, timeout, time }
    * @returns {Promise<string[]>}
    */
-  targets({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT } = {}) {
-    return this._serialize(() => this._targets(selection, timeout));
+  targets({ selection = 'CLIPBOARD', timeout = DEFAULT_TIMEOUT, time } = {}) {
+    return this._serialize(() => this._targets(selection, timeout, time));
   }
 
   /** Concurrent conversions would share the one transfer property on the
@@ -157,11 +220,11 @@ export default class Clipboard {
     return result;
   }
 
-  async _targets(selection, timeout) {
+  async _targets(selection, timeout, time) {
     await this._ensure();
     const sel = await this._atom(selection);
     const prop = this._transferProp;
-    const notify = await this._convert(sel, this._atoms.TARGETS, prop, selection, timeout);
+    const notify = await this._convert(sel, this._atoms.TARGETS, prop, selection, timeout, time);
     if (notify.property === 0) return [];
     const { data, format } = await this._fetchProperty(prop, selection, timeout);
     // an INCR reassembly reports no format, and a target list is far too
@@ -178,12 +241,12 @@ export default class Clipboard {
    * `write({ 'image/png': buf })` publishes, this is how another ntk app
    * gets it back.
    */
-  async _readTarget(selection, target, timeout) {
+  async _readTarget(selection, target, timeout, time) {
     await this._ensure();
     const sel = await this._atom(selection);
     const atom = await this._atom(target);
     const prop = this._transferProp;
-    const notify = await this._convert(sel, atom, prop, selection, timeout);
+    const notify = await this._convert(sel, atom, prop, selection, timeout, time);
     if (notify.property === 0) {
       const owner = await new Promise((resolve, reject) =>
         this.X.GetSelectionOwner(sel, (err, wid) => (err ? reject(err) : resolve(wid)))
@@ -204,17 +267,18 @@ export default class Clipboard {
     );
   }
 
-  async _read(selection, timeout) {
+  async _read(selection, timeout, time) {
     await this._ensure();
     const X = this.X;
     const sel = await this._atom(selection);
     const prop = this._transferProp;
 
-    let notify = await this._convert(sel, this._atoms.UTF8_STRING, prop, selection, timeout);
+    let notify = await this._convert(sel, this._atoms.UTF8_STRING, prop, selection, timeout, time);
     if (notify.property === 0) {
       // property None: no owner, or the owner refused UTF8_STRING (old
-      // Xt/Motif apps) — ask again for latin-1 STRING before giving up
-      notify = await this._convert(sel, X.atoms.STRING, prop, selection, timeout);
+      // Xt/Motif apps) — ask again for latin-1 STRING before giving up.
+      // Same timestamp: this is a retry of one paste, not a second one.
+      notify = await this._convert(sel, X.atoms.STRING, prop, selection, timeout, time);
     }
     if (notify.property === 0) {
       const owner = await new Promise((resolve, reject) =>
@@ -711,8 +775,11 @@ export default class Clipboard {
 
   // ---- INCR, requestor side ----
 
-  // ConvertSelection and wait for the owner's SelectionNotify answer
-  _convert(sel, target, prop, selectionName, timeout) {
+  // ConvertSelection and wait for the owner's SelectionNotify answer.
+  // `time` is the timestamp of the event that asked for the data; ICCCM 2.4
+  // says to send it rather than CurrentTime. Undefined coerces to 0, which
+  // is CurrentTime — the documented default for callers with no event.
+  _convert(sel, target, prop, selectionName, timeout, time) {
     return new Promise((resolve, reject) => {
       const X = this.X;
       const wid = this._window.id;
@@ -734,7 +801,7 @@ export default class Clipboard {
         X.removeListener('event', onEvent);
       };
       X.on('event', onEvent);
-      X.ConvertSelection(wid, sel, target, prop, 0);
+      X.ConvertSelection(wid, sel, target, prop, time >>> 0);
     });
   }
 

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -614,3 +614,242 @@ test('read({ target }) says which target the owner could not convert', async () 
     /cannot convert to image\/png/
   );
 });
+
+// --- conversion timestamps (ICCCM 2.4) -------------------------------------
+//
+// A requestor should convert with the timestamp of the event that asked for
+// the data, not CurrentTime. The owner sees it on its SelectionRequest, so a
+// raw client playing owner can assert what went over the wire. Note the
+// server substitutes its own clock for a zero time, which is what makes the
+// default distinguishable from an explicit one.
+
+// A raw selection owner that records the timestamp of every request it gets.
+// `serve(ev)` returns { type, data } to answer with, or null to refuse.
+const recordingOwner = (X, wid, serve) => {
+  const requests = [];
+  const onRequest = (ev) => {
+    if (ev.type !== 30 || ev.owner !== wid) return;
+    requests.push({ target: ev.target, time: ev.time });
+    const payload = serve(ev);
+    let property = ev.property;
+    if (payload) {
+      X.ChangeProperty(0, ev.requestor, property, payload.type, 8, payload.data);
+    } else {
+      property = 0;
+    }
+    X.SendEvent(
+      ev.requestor,
+      0,
+      0,
+      selectionNotify(ev.time, ev.requestor, ev.selection, ev.target, property)
+    );
+  };
+  X.on('event', onRequest);
+  return { requests, stop: () => X.removeListener('event', onRequest) };
+};
+
+const PASTE_TIME = 0x3ade68b1; // a timestamp no server clock will coincide with
+
+test('read({ time }) converts with that timestamp, and without one with CurrentTime', async () => {
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [SELECTION, UTF8_STRING] = await Promise.all(
+    ['NTK_TEST_CONVERT_TIME', 'UTF8_STRING'].map((n) => atom(X, n))
+  );
+  const owner = recordingOwner(X, wid, (ev) =>
+    ev.target === UTF8_STRING ? { type: UTF8_STRING, data: Buffer.from('stamped', 'utf8') } : null
+  );
+  X.SetSelectionOwner(wid, SELECTION, 0);
+  try {
+    assert.equal(
+      await reader.clipboard.read({ selection: 'NTK_TEST_CONVERT_TIME', time: PASTE_TIME }),
+      'stamped'
+    );
+    assert.equal(owner.requests.length, 1);
+    assert.equal(owner.requests[0].time, PASTE_TIME, 'the paste timestamp reaches the owner');
+
+    // no time: still CurrentTime, which the server replaces with its own
+    // clock — so the owner sees a real stamp, just not the caller's
+    await reader.clipboard.read({ selection: 'NTK_TEST_CONVERT_TIME' });
+    assert.equal(owner.requests.length, 2);
+    assert.notEqual(owner.requests[1].time, PASTE_TIME, 'the option is what carries it');
+  } finally {
+    owner.stop();
+  }
+});
+
+test('the STRING retry is the same paste, so it reuses its timestamp', async () => {
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [SELECTION, UTF8_STRING] = await Promise.all(
+    ['NTK_TEST_RETRY_TIME', 'UTF8_STRING'].map((n) => atom(X, n))
+  );
+  // a legacy owner: refuses UTF8_STRING, so read() falls back to STRING
+  const owner = recordingOwner(X, wid, (ev) =>
+    ev.target === X.atoms.STRING
+      ? { type: X.atoms.STRING, data: Buffer.from('caf\xe9', 'latin1') }
+      : null
+  );
+  X.SetSelectionOwner(wid, SELECTION, 0);
+  try {
+    assert.equal(
+      await reader.clipboard.read({ selection: 'NTK_TEST_RETRY_TIME', time: PASTE_TIME }),
+      'café'
+    );
+    assert.deepEqual(
+      owner.requests.map((r) => r.target),
+      [UTF8_STRING, X.atoms.STRING],
+      'refused UTF8_STRING, then retried as STRING'
+    );
+    assert.deepEqual(
+      owner.requests.map((r) => r.time),
+      [PASTE_TIME, PASTE_TIME],
+      'both halves of one paste carry its timestamp'
+    );
+  } finally {
+    owner.stop();
+  }
+});
+
+test('targets({ time }) and read({ target, time }) carry it too', async () => {
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const [SELECTION, TARGETS, PNG] = await Promise.all(
+    ['NTK_TEST_TARGETS_TIME', 'TARGETS', 'image/png'].map((n) => atom(X, n))
+  );
+  const owner = recordingOwner(X, wid, (ev) => {
+    if (ev.target === TARGETS) {
+      const list = Buffer.alloc(4);
+      list.writeUInt32LE(PNG, 0);
+      // format 32 for an ATOM list; ChangeProperty's format follows the type
+      X.ChangeProperty(0, ev.requestor, ev.property, X.atoms.ATOM, 32, list);
+      X.SendEvent(
+        ev.requestor,
+        0,
+        0,
+        selectionNotify(ev.time, ev.requestor, ev.selection, ev.target, ev.property)
+      );
+      return undefined; // already answered
+    }
+    return ev.target === PNG ? { type: PNG, data: Buffer.from([0x89, 0x50]) } : null;
+  });
+  X.SetSelectionOwner(wid, SELECTION, 0);
+  try {
+    const offered = await reader.clipboard.targets({
+      selection: 'NTK_TEST_TARGETS_TIME',
+      time: PASTE_TIME
+    });
+    assert.deepEqual(offered, ['image/png']);
+    await reader.clipboard.read({
+      selection: 'NTK_TEST_TARGETS_TIME',
+      target: 'image/png',
+      time: PASTE_TIME
+    });
+    assert.deepEqual(
+      owner.requests.map((r) => r.time),
+      [PASTE_TIME, PASTE_TIME]
+    );
+  } finally {
+    owner.stop();
+  }
+});
+
+// --- giving a selection back (ICCCM 2.3.1) ---------------------------------
+
+test('clear() releases the selection, and a paste then finds no owner', async () => {
+  await writer.clipboard.write('temporary');
+  assert.equal(await reader.clipboard.read(), 'temporary');
+
+  await writer.clipboard.clear();
+  await assert.rejects(() => reader.clipboard.read(), /no owner/);
+  const sel = await atom(writer.X, 'CLIPBOARD');
+  assert.equal(writer.clipboard._owned.has(sel), false, 'and it stops answering for it');
+});
+
+test('clear() gives up one selection, not every selection', async () => {
+  await writer.clipboard.write('for ctrl-v');
+  await writer.clipboard.write('for middle click', { selection: 'PRIMARY' });
+
+  await writer.clipboard.clear();
+
+  await assert.rejects(() => reader.clipboard.read(), /no owner/);
+  assert.equal(await reader.clipboard.read({ selection: 'PRIMARY' }), 'for middle click');
+});
+
+test('clear() releases with the timestamp the selection was acquired with', async () => {
+  const clipboard = writer.clipboard;
+  await clipboard.write('stamped');
+  const sel = await atom(writer.X, 'CLIPBOARD');
+  const acquired = clipboard._owned.get(sel).time;
+  assert.notEqual(acquired, 0);
+
+  const calls = [];
+  const real = clipboard.X.SetSelectionOwner.bind(clipboard.X);
+  clipboard.X.SetSelectionOwner = (owner, selection, time) => {
+    calls.push({ owner, selection, time });
+    return real(owner, selection, time);
+  };
+  try {
+    await clipboard.clear();
+  } finally {
+    clipboard.X.SetSelectionOwner = real;
+  }
+  // ICCCM 2.3.1: owner None, and the acquisition timestamp — not a fresh
+  // one, and not CurrentTime, either of which a real server may reject
+  assert.deepEqual(calls, [{ owner: 0, selection: sel, time: acquired }]);
+});
+
+test('clear() on a selection we do not own sends nothing', async () => {
+  const X = raw.client;
+  const wid = rawWindow(raw);
+  const SELECTION = await atom(X, 'NTK_TEST_FOREIGN');
+  X.SetSelectionOwner(wid, SELECTION, 0);
+  // something else is owned, so this exercises the per-selection check
+  // rather than the "never wrote anything" shortcut
+  await writer.clipboard.write('unrelated');
+
+  await writer.clipboard.clear('NTK_TEST_FOREIGN');
+
+  const owner = await new Promise((resolve, reject) =>
+    writer.X.GetSelectionOwner(SELECTION, (err, id) => (err ? reject(err) : resolve(id)))
+  );
+  assert.equal(owner, wid, 'the real owner keeps the selection');
+});
+
+test('clear() on a clipboard that never wrote anything touches the server at all', async () => {
+  const fresh = await connect();
+  try {
+    await fresh.clipboard.clear();
+    assert.equal(fresh.clipboard._window, null, 'no helper window created for a no-op');
+  } finally {
+    await fresh.close();
+  }
+});
+
+test('a transfer already in flight survives the release', async () => {
+  const clipboard = writer.clipboard;
+  const X = raw.client;
+  const wid = rawWindow(raw, x11.eventMask.PropertyChange);
+  const [CLIPBOARD, UTF8_STRING, INCR, PROP] = await Promise.all(
+    ['CLIPBOARD', 'UTF8_STRING', 'INCR', 'NTK_TEST_CLEAR_INCR'].map((n) => atom(X, n))
+  );
+  const text = `${'a'.repeat(4000)}κόσμε${'b'.repeat(4000)}`;
+  const payload = Buffer.from(text, 'utf8');
+  clipboard._transferLimit = 64;
+  try {
+    await clipboard.write(text);
+    const reply = await rawConvert(X, wid, CLIPBOARD, UTF8_STRING, PROP);
+    assert.equal(reply.property, PROP);
+
+    const collecting = rawIncrRead(X, wid, PROP);
+    const first = await getProperty(X, wid, PROP); // delete=1 starts the chunks
+    assert.equal(first.type, INCR);
+    // give the selection up mid-transfer: ICCCM 2.7.2 says the transfer
+    // still has to finish, and it does because it holds its own copy
+    await clipboard.clear();
+    assert.equal(clipboard._owned.has(CLIPBOARD), false, 'ownership is gone immediately');
+    assert.deepEqual(await collecting, payload, 'every byte still arrives');
+  } finally {
+    clipboard._transferLimit = null;
+  }
+});


### PR DESCRIPTION
Two gaps left by 5.3.0's selection work. Both have a consumer waiting in
react-x11's XDND code, which is where they were found.

Closes #168. Closes #169.

## A time option for read and targets

Every ConvertSelection went out with CurrentTime, because `_convert`
hardcoded the time argument. ICCCM 2.4 says to convert with the timestamp of
the event that asked for the data, and XDND makes that binding rather than
advisory: a drop must convert with the timestamp from its XdndDrop message.
react-x11's merged drop target carries that value to a parameter it could
not use, with a comment saying so.

```js
const text = await app.clipboard.read({ time: ev.time });
const offered = await app.clipboard.targets({ time: ev.time });
```

Undefined coerces to 0, so callers with no event keep exactly today's
behaviour. The UTF8_STRING to STRING retry reuses the stamp, being one paste
rather than two.

Deliberately no server-time fallback here, unlike write. Acquiring with
CurrentTime is forbidden outright by ICCCM 2.1, which is what justified the
extra round trip in write; for conversion it is only discouraged, every
toolkit sends CurrentTime when no event is at hand, and taxing every paste
with a round trip would buy no interop.

## clear

Ownership could previously end only when another client copied or the app
exited. A drag source needs to stop offering its payload once the drag is
over — a stale offer answered afterwards is what XDND's "throw out extremely
old data" rule is about — and clearing the clipboard is an ordinary app
feature besides.

```js
await app.clipboard.clear();
await app.clipboard.clear('XdndSelection');
```

Release follows ICCCM 2.3.1: owner None, with the timestamp the selection was
acquired with. The server ignores a release whose time is earlier than the
selection's last-change time, so the old stamp is exactly what makes this
lose to a client that has taken the selection since; a fresh one would take
it away from them.

Three details worth naming:

- **Clearing a selection this app does not own sends nothing at all.**
  SetSelectionOwner None from a non-owner would clobber the real owner.
- **The GetSelectionOwner after the release is a flush barrier, not a
  check.** Requests are buffered since 5.0.0 and a reply is what forces the
  write, so without it the release could still sit in the output buffer when
  the caller's next await resumes. This is a refinement of what #169
  proposed, which assumed no round trip was needed; the semantics are
  unchanged, in that a lost race is still not an error.
- **A transfer already in flight still completes**, because an INCR transfer
  holds its own copy of the payload, the same as when another client takes
  the selection from us.

## Tests

Eight new hermetic tests, 614 pass. A raw node-x11 owner that records the
timestamp of every SelectionRequest is how the wire value is asserted —
including that the default is distinguishable, since the server substitutes
its own clock for a zero time.

The release timestamp is pinned with a spy instead. Worth explaining: the
in-process server does not implement the last-change check, so a release with
CurrentTime passes every functional test. I confirmed that by mutating the
code both ways — dropping the threaded time fails exactly the three timestamp
tests, and releasing with 0 fails only the spy test.

The INCR-survives-release case is covered end to end: a transfer is started,
the selection is given up mid-transfer, and every byte still arrives.

## Also

Moves the "Reading a specific target" subsection back under read in
docs/clipboard.md. It had ended up inside the watch section, where it
documented options belonging to a different method — presumably where the two
5.3.0 branches met.
