### PR TITLE
perf: rect-only clip stacks never materialize the a8 mask

### DIFF
--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -1,11 +1,16 @@
-import parseFontStyle from 'canvas-fontstyle';
-import extrudePolyline from 'extrude-polyline';
+import parseFontStyle from "canvas-fontstyle";
+import extrudePolyline from "extrude-polyline";
 
-import { safeRelease } from './cleanup.js';
-import { cssColor } from './color.js';
-import Drawable from './drawable.js';
-import { Image } from './image.js';
-import { ImageData, fromStraightRgba, pixelLayout, toStraightRgba } from './imagedata.js';
+import { safeRelease } from "./cleanup.js";
+import { cssColor } from "./color.js";
+import Drawable from "./drawable.js";
+import { Image } from "./image.js";
+import {
+  ImageData,
+  fromStraightRgba,
+  pixelLayout,
+  toStraightRgba,
+} from "./imagedata.js";
 import {
   Path2D,
   flattenPath,
@@ -15,17 +20,27 @@ import {
   matApply,
   matInvert,
   matIsIdentity,
-  matMultiply
-} from './path.js';
-import Picture from './picture.js';
-import Pixmap from './pixmap.js';
-import { routeRaster } from './rasterize.js';
-import { compositeTraps, drawGlyphRuns } from './text/glyphs.js';
-import { TextLayout } from './text/layout.js';
-import { reorderRuns } from './text/shape.js';
-import { trapezoidize } from './trapezoid.js';
+  matMultiply,
+} from "./path.js";
+import Picture from "./picture.js";
+import Pixmap from "./pixmap.js";
+import { routeRaster } from "./rasterize.js";
+import { compositeTraps, drawGlyphRuns } from "./text/glyphs.js";
+import { TextLayout } from "./text/layout.js";
+import { reorderRuns } from "./text/shape.js";
+import { trapezoidize } from "./trapezoid.js";
 
-const DEFAULT_FONT = '20px sans-serif';
+/** The overlap of two {x, y, w, h} boxes, or null when they have none. */
+function intersectBox(a, b) {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.w, b.x + b.w);
+  const bottom = Math.min(a.y + a.h, b.y + b.h);
+  if (right <= x || bottom <= y) return null;
+  return { x, y, w: right - x, h: bottom - y };
+}
+
+const DEFAULT_FONT = "20px sans-serif";
 
 /**
  * Fallback for a context dropped without `destroy()`, matching Pixmap,
@@ -56,14 +71,14 @@ const gcRegistry = new FinalizationRegistry(({ X, gcs }) => {
 /** a fillStyle with a single colour behind it, as opposed to a gradient or a
  * caller-supplied Picture */
 function isPlainColor(style) {
-  return typeof style === 'string' || Array.isArray(style);
+  return typeof style === "string" || Array.isArray(style);
 }
 
 function isPictureSource(image) {
   return (
     image instanceof Image ||
     (image != null &&
-      typeof image.picture === 'function' &&
+      typeof image.picture === "function" &&
       Number.isFinite(image.width) &&
       Number.isFinite(image.height))
   );
@@ -73,24 +88,24 @@ function isPictureSource(image) {
 // map directly; with a clip/shape mask active the op only applies inside
 // the mask coverage (outside pixels are left untouched).
 const GCO_TO_PICTOP = {
-  'source-over': 'Over',
-  copy: 'Src',
-  'destination-over': 'OverReverse',
-  'source-in': 'In',
-  'destination-in': 'InReverse',
-  'source-out': 'Out',
-  'destination-out': 'OutReverse',
-  'source-atop': 'Atop',
-  'destination-atop': 'AtopReverse',
-  xor: 'Xor',
-  lighter: 'Add'
+  "source-over": "Over",
+  copy: "Src",
+  "destination-over": "OverReverse",
+  "source-in": "In",
+  "destination-in": "InReverse",
+  "source-out": "Out",
+  "destination-out": "OutReverse",
+  "source-atop": "Atop",
+  "destination-atop": "AtopReverse",
+  xor: "Xor",
+  lighter: "Add",
 };
 
 // extrude-polyline has no round caps/joins: 'round' extrudes as butt/bevel
 // and the missing coverage is unioned in afterwards as triangle-fan disks
 // (see _strokePolys)
-const LINE_CAP = { butt: 'butt', square: 'square', round: 'butt' };
-const LINE_JOIN = { miter: 'miter', bevel: 'bevel', round: 'bevel' };
+const LINE_CAP = { butt: "butt", square: "square", round: "butt" };
+const LINE_JOIN = { miter: "miter", bevel: "bevel", round: "bevel" };
 
 /**
  * Split a device-space polyline into dash "on" runs by arc length.
@@ -206,12 +221,12 @@ class RenderingContext2d {
     this._gc = null;
     this.picture = null;
     this._bindTarget();
-    if (typeof window.on === 'function') {
-      window.on('_backing', () => this._bindTarget());
+    if (typeof window.on === "function") {
+      window.on("_backing", () => this._bindTarget());
       // masks are sized to the drawable — recreate them after a resize
-      window.on('resize', () => this._dropMasks());
+      window.on("resize", () => this._dropMasks());
       // window-backed pictures are freed server-side with the window
-      window.on('_destroyed', () => {
+      window.on("_destroyed", () => {
         if (this.picture && this._target === this.window) {
           this.picture.forget();
           this.picture = null;
@@ -226,23 +241,23 @@ class RenderingContext2d {
     this.clipMaskDrawable = null;
     this._textStyle = null;
     this._lastFontString = null;
-    this.textAlign = 'start';
-    this.textBaseline = 'alphabetic';
+    this.textAlign = "start";
+    this.textBaseline = "alphabetic";
 
     this._path = new Path2D();
     this._m = [1, 0, 0, 1, 0, 0];
     this._stack = [];
     this._clips = []; // [{ polys, rule }] in device space, already stacked
-    this._gco = 'source-over';
+    this._gco = "source-over";
     this.globalAlpha = 1;
-    this.lineCap = 'butt';
-    this.lineJoin = 'miter';
+    this.lineCap = "butt";
+    this.lineJoin = "miter";
     this.miterLimit = 10;
     this._lineDash = [];
     this._lineDashOffset = 0;
 
-    this.fillStyle = 'white';
-    this.strokeStyle = 'black';
+    this.fillStyle = "white";
+    this.strokeStyle = "black";
     this.lineWidth = 1;
   }
 
@@ -274,7 +289,7 @@ class RenderingContext2d {
       drawable: target,
       format,
       polyEdge: 1,
-      polyMode: 1
+      polyMode: 1,
     });
     this._dropMasks();
   }
@@ -351,7 +366,7 @@ class RenderingContext2d {
 
   // notify a double-buffered window that its backing content changed
   _markDirty() {
-    if (typeof this.window._markDirty !== 'function') return;
+    if (typeof this.window._markDirty !== "function") return;
     // The clip bounds everything this operation could have touched, so it is
     // also the region the window has to blit. Reporting it lets the present
     // copy the part of the backing store that changed instead of all of it —
@@ -375,7 +390,7 @@ class RenderingContext2d {
   }
 
   _op() {
-    return this.Render.PictOp[GCO_TO_PICTOP[this._gco] || 'Over'];
+    return this.Render.PictOp[GCO_TO_PICTOP[this._gco] || "Over"];
   }
 
   set globalCompositeOperation(value) {
@@ -387,14 +402,20 @@ class RenderingContext2d {
   }
 
   createSolidPicture(r, g, b, a) {
-    const key = [r, g, b, a].join('|');
+    const key = [r, g, b, a].join("|");
     let p = this._solidPictures.get(key);
     if (p) return p;
 
     // TODO: use window.createPixmap
-    const pixmap = new Pixmap(this.window.app, { depth: 32, width: 1, height: 1 });
+    const pixmap = new Pixmap(this.window.app, {
+      depth: 32,
+      width: 1,
+      height: 1,
+    });
     const pictSolidPix = this.window.X.AllocID();
-    this.Render.CreatePicture(pictSolidPix, pixmap.id, this.Render.rgba32, { repeat: 1 });
+    this.Render.CreatePicture(pictSolidPix, pixmap.id, this.Render.rgba32, {
+      repeat: 1,
+    });
     this.Render.FillRectangles(1, pictSolidPix, [r, g, b, a], [0, 0, 100, 100]);
     p = new Picture(this.window.app, { id: pictSolidPix });
     p._sourcePixmap = pixmap; // keep the 1x1 pixmap alive alongside the picture
@@ -403,14 +424,14 @@ class RenderingContext2d {
   }
 
   _stylePicture(value) {
-    if (typeof value === 'string' || Array.isArray(value)) {
+    if (typeof value === "string" || Array.isArray(value)) {
       const c = parseColor(value);
       return this.createSolidPicture(c[0], c[1], c[2], c[3]);
     }
     if (value instanceof Picture || value instanceof CanvasGradient) {
       return value;
     }
-    throw new Error('Unknown fill style');
+    throw new Error("Unknown fill style");
   }
 
   set fillStyle(value) {
@@ -476,7 +497,7 @@ class RenderingContext2d {
       textAlign: this.textAlign,
       textBaseline: this.textBaseline,
       m: this._m.slice(),
-      clips: this._clips
+      clips: this._clips,
     });
   }
 
@@ -526,9 +547,11 @@ class RenderingContext2d {
   }
 
   setTransform(a, b, c, d, e, f) {
-    if (typeof a === 'object' && a !== null) {
+    if (typeof a === "object" && a !== null) {
       const m = a;
-      this._m = Array.isArray(m) ? m.slice(0, 6) : [m.a, m.b, m.c, m.d, m.e, m.f];
+      this._m = Array.isArray(m)
+        ? m.slice(0, 6)
+        : [m.a, m.b, m.c, m.d, m.e, m.f];
       return;
     }
     if (a === undefined) return this.resetTransform();
@@ -587,13 +610,35 @@ class RenderingContext2d {
   }
 
   arc(x, y, r, startAngle, endAngle, counterclockwise = false) {
-    if (r < 0) throw new RangeError('arc: negative radius');
-    this._appendUserSegments(ellipseSegments(x, y, r, r, 0, startAngle, endAngle, counterclockwise));
+    if (r < 0) throw new RangeError("arc: negative radius");
+    this._appendUserSegments(
+      ellipseSegments(x, y, r, r, 0, startAngle, endAngle, counterclockwise),
+    );
   }
 
-  ellipse(x, y, rx, ry, rotation, startAngle, endAngle, counterclockwise = false) {
-    if (rx < 0 || ry < 0) throw new RangeError('ellipse: negative radius');
-    this._appendUserSegments(ellipseSegments(x, y, rx, ry, rotation, startAngle, endAngle, counterclockwise));
+  ellipse(
+    x,
+    y,
+    rx,
+    ry,
+    rotation,
+    startAngle,
+    endAngle,
+    counterclockwise = false,
+  ) {
+    if (rx < 0 || ry < 0) throw new RangeError("ellipse: negative radius");
+    this._appendUserSegments(
+      ellipseSegments(
+        x,
+        y,
+        rx,
+        ry,
+        rotation,
+        startAngle,
+        endAngle,
+        counterclockwise,
+      ),
+    );
   }
 
   arcTo(x1, y1, x2, y2, r) {
@@ -625,12 +670,12 @@ class RenderingContext2d {
     if (args[0] instanceof Path2D) {
       return {
         polys: flattenPath(args[0]._cmds, this._m),
-        rule: args[1] === 'evenodd' ? 'evenodd' : 'nonzero'
+        rule: args[1] === "evenodd" ? "evenodd" : "nonzero",
       };
     }
     return {
       polys: flattenPath(this._path._cmds, null),
-      rule: args[0] === 'evenodd' ? 'evenodd' : 'nonzero'
+      rule: args[0] === "evenodd" ? "evenodd" : "nonzero",
     };
   }
 
@@ -642,11 +687,11 @@ class RenderingContext2d {
     this.fillMaskDrawable = new Pixmap(this.window.app, {
       depth: 8,
       width: this.width,
-      height: this.height
+      height: this.height,
     });
     this.fillMask = new Picture(this.window.app, {
       drawable: this.fillMaskDrawable,
-      format: this.Render.a8
+      format: this.Render.a8,
     });
   }
 
@@ -655,19 +700,19 @@ class RenderingContext2d {
     this.clipMaskDrawable = new Pixmap(this.window.app, {
       depth: 8,
       width: this.width,
-      height: this.height
+      height: this.height,
     });
     this.clipMask = new Picture(this.window.app, {
       drawable: this.clipMaskDrawable,
-      format: this.Render.a8
+      format: this.Render.a8,
     });
   }
 
-  _rasterizePolys(picture, polys, rule) {
+  _rasterizePolys(picture, polys, rule, dx = 0, dy = 0) {
     const flat = [];
     for (const p of polys) if (p.pts.length >= 6) flat.push(p.pts);
     if (!flat.length) return;
-    const traps = trapezoidize(flat, 0, 0, [], rule);
+    const traps = trapezoidize(flat, dx, dy, [], rule);
     // stay under the server's maximum request size
     const chunk = 4000 * 6;
     for (let i = 0; i < traps.length; i += chunk) {
@@ -699,7 +744,8 @@ class RenderingContext2d {
   _uploadCoverage(job, b, edges) {
     const rasterizer = this.window.app.rasterizer;
     if (!rasterizer) return false;
-    if (routeRaster(b.w, b.h, edges, this.window.app.rasterPolicy) !== 'local') return false;
+    if (routeRaster(b.w, b.h, edges, this.window.app.rasterPolicy) !== "local")
+      return false;
 
     const coverage = rasterizer.rasterize({ ...job, width: b.w, height: b.h });
     if (!coverage) return false;
@@ -717,10 +763,24 @@ class RenderingContext2d {
     } else {
       data = Buffer.alloc(stride * b.h);
       for (let y = 0; y < b.h; ++y) {
-        Buffer.from(coverage.buffer, coverage.byteOffset + y * b.w, b.w).copy(data, y * stride);
+        Buffer.from(coverage.buffer, coverage.byteOffset + y * b.w, b.w).copy(
+          data,
+          y * stride,
+        );
       }
     }
-    this.X.PutImage(2, this.fillMaskDrawable.id, this._maskGC(), b.w, b.h, b.x, b.y, 0, 8, data);
+    this.X.PutImage(
+      2,
+      this.fillMaskDrawable.id,
+      this._maskGC(),
+      b.w,
+      b.h,
+      b.x,
+      b.y,
+      0,
+      8,
+      data,
+    );
     return true;
   }
 
@@ -802,22 +862,74 @@ class RenderingContext2d {
       flat.push(p.pts);
       edges += p.pts.length / 2;
     }
-    if (!this._uploadCoverage({ polys: flat, rule, dx: -b.x, dy: -b.y }, b, edges)) {
-      R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [b.x, b.y, b.w, b.h]);
+    if (
+      !this._uploadCoverage({ polys: flat, rule, dx: -b.x, dy: -b.y }, b, edges)
+    ) {
+      R.FillRectangles(
+        R.PictOp.Src,
+        this.fillMask.id,
+        [0, 0, 0, 0],
+        [b.x, b.y, b.w, b.h],
+      );
       this._rasterizePolys(this.fillMask, polys, rule);
     }
 
+    // a rectangular clip narrows where the coverage is *composited*; the
+    // mask content outside it is stale by the same argument as outside `b`.
+    // A stack whose mask was dropped by restore() may still hold a poly —
+    // _clipRect says null then, and the mask comes back on demand.
+    let out = b;
+    if (this._clips.length && !this.clipMask) {
+      const cr = this._clipRect();
+      if (cr) {
+        out = intersectBox(b, cr);
+        if (!out) return;
+      } else {
+        this._requireClipMask();
+      }
+    }
     if (alpha < 1) {
       // In with a constant color scales the a8 coverage by that alpha
-      R.FillRectangles(R.PictOp.In, this.fillMask.id, [0, 0, 0, alpha], [b.x, b.y, b.w, b.h]);
+      R.FillRectangles(
+        R.PictOp.In,
+        this.fillMask.id,
+        [0, 0, 0, alpha],
+        [out.x, out.y, out.w, out.h],
+      );
     }
     if (this.clipMask) {
       // clipMask is surface-aligned, so it is sampled at the same offset
-      R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, b.x, b.y, 0, 0, b.x, b.y, b.w, b.h);
+      R.Composite(
+        R.PictOp.In,
+        this.clipMask.id,
+        0,
+        this.fillMask.id,
+        out.x,
+        out.y,
+        0,
+        0,
+        out.x,
+        out.y,
+        out.w,
+        out.h,
+      );
     }
     // src is either a 1x1 repeating solid (offset irrelevant) or a
     // surface-aligned gradient, so it is sampled at the same offset too
-    R.Composite(op, src.id, this.fillMask.id, this.picture.id, b.x, b.y, b.x, b.y, b.x, b.y, b.w, b.h);
+    R.Composite(
+      op,
+      src.id,
+      this.fillMask.id,
+      this.picture.id,
+      out.x,
+      out.y,
+      out.x,
+      out.y,
+      out.x,
+      out.y,
+      out.w,
+      out.h,
+    );
     this._markDirty();
   }
 
@@ -828,16 +940,18 @@ class RenderingContext2d {
     const det = this._m[0] * this._m[3] - this._m[1] * this._m[2];
     const scale = Math.sqrt(Math.abs(det)) || 1;
     const thickness = this.lineWidth * scale;
-    const roundCap = this.lineCap === 'round';
-    const roundJoin = this.lineJoin === 'round';
+    const roundCap = this.lineCap === "round";
+    const roundJoin = this.lineJoin === "round";
     const stroke = extrudePolyline({
       thickness,
-      cap: LINE_CAP[this.lineCap] || 'butt',
-      join: LINE_JOIN[this.lineJoin] || 'miter',
-      miterLimit: this.miterLimit
+      cap: LINE_CAP[this.lineCap] || "butt",
+      join: LINE_JOIN[this.lineJoin] || "miter",
+      miterLimit: this.miterLimit,
     });
     // dash distances are user-space lengths; scale them like the line width
-    const dash = this._lineDash.length ? this._lineDash.map((d) => d * scale) : null;
+    const dash = this._lineDash.length
+      ? this._lineDash.map((d) => d * scale)
+      : null;
     const dashOffset = this._lineDashOffset * scale;
 
     const tris = [];
@@ -867,7 +981,9 @@ class RenderingContext2d {
       const l1 = Math.hypot(b[0] - a[0], b[1] - a[1]);
       const l2 = Math.hypot(c[0] - b[0], c[1] - b[1]);
       if (!l1 || !l2) return;
-      let dot = ((b[0] - a[0]) * (c[0] - b[0]) + (b[1] - a[1]) * (c[1] - b[1])) / (l1 * l2);
+      let dot =
+        ((b[0] - a[0]) * (c[0] - b[0]) + (b[1] - a[1]) * (c[1] - b[1])) /
+        (l1 * l2);
       dot = Math.max(-1, Math.min(1, dot));
       // bevel-to-arc gap depth for turn angle θ: r * (1 - cos(θ/2))
       if (r * (1 - Math.sqrt((1 + dot) / 2)) > 0.05) addDisk(b[0], b[1]);
@@ -888,9 +1004,11 @@ class RenderingContext2d {
         }
       }
       if (roundJoin) {
-        for (let i = 1; i < pts.length - 1; i++) maybeJoinDisk(pts[i - 1], pts[i], pts[i + 1]);
+        for (let i = 1; i < pts.length - 1; i++)
+          maybeJoinDisk(pts[i - 1], pts[i], pts[i + 1]);
         // the seam of a closed loop is a join too (pts[0] === pts[last])
-        if (closed && pts.length > 2) maybeJoinDisk(pts[pts.length - 2], pts[0], pts[1]);
+        if (closed && pts.length > 2)
+          maybeJoinDisk(pts[pts.length - 2], pts[0], pts[1]);
       }
       if (roundCap && !closed) {
         addDisk(pts[0][0], pts[0][1]);
@@ -903,7 +1021,8 @@ class RenderingContext2d {
       for (let i = 1; i < run.length; i++) {
         const p = run[i];
         const q = out[out.length - 1];
-        if (Math.abs(p[0] - q[0]) > 1e-6 || Math.abs(p[1] - q[1]) > 1e-6) out.push(p);
+        if (Math.abs(p[0] - q[0]) > 1e-6 || Math.abs(p[1] - q[1]) > 1e-6)
+          out.push(p);
       }
       return out;
     };
@@ -924,7 +1043,8 @@ class RenderingContext2d {
       }
       if (pts.length >= 2 && poly.closed) {
         const [fx, fy] = pts[0];
-        if (Math.abs(fx - lx) > 1e-6 || Math.abs(fy - ly) > 1e-6) pts.push([fx, fy]);
+        if (Math.abs(fx - lx) > 1e-6 || Math.abs(fy - ly) > 1e-6)
+          pts.push([fx, fy]);
       }
       if (pts.length < 2) continue;
 
@@ -947,11 +1067,23 @@ class RenderingContext2d {
     // round-cap/join disks overlap the stroke body; overlapping coverage
     // must accumulate in the clamped a8 mask (single composite) or a
     // semi-transparent stroke style would double-blend at the overlaps
-    const direct = !hasRound && this.globalAlpha >= 1 && !this.clipMask && op === this.Render.PictOp.Over;
+    const direct =
+      !hasRound &&
+      this.globalAlpha >= 1 &&
+      !this._clips.length &&
+      op === this.Render.PictOp.Over;
     const chunk = 4000 * 6;
     if (direct) {
       for (let i = 0; i < tris.length; i += chunk) {
-        this.Render.Triangles(op, src.id, 0, 0, this.picture.id, this.Render.a8, tris.slice(i, i + chunk));
+        this.Render.Triangles(
+          op,
+          src.id,
+          0,
+          0,
+          this.picture.id,
+          this.Render.a8,
+          tris.slice(i, i + chunk),
+        );
       }
       this._markDirty();
       return;
@@ -970,20 +1102,80 @@ class RenderingContext2d {
     this._ensureFillMask();
     const b = this._trisBBox(tris);
     if (!b) return;
-    if (!this._uploadCoverage({ triangles: tris, dx: -b.x, dy: -b.y }, b, tris.length / 2)) {
-      this.Render.FillRectangles(this.Render.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [b.x, b.y, b.w, b.h]);
+    if (
+      !this._uploadCoverage(
+        { triangles: tris, dx: -b.x, dy: -b.y },
+        b,
+        tris.length / 2,
+      )
+    ) {
+      this.Render.FillRectangles(
+        this.Render.PictOp.Src,
+        this.fillMask.id,
+        [0, 0, 0, 0],
+        [b.x, b.y, b.w, b.h],
+      );
       const opaque = this.createSolidPicture(0, 0, 0, 1);
       for (let i = 0; i < tris.length; i += chunk) {
-        this.Render.Triangles(this.Render.PictOp.Add, opaque.id, 0, 0, this.fillMask.id, this.Render.a8, tris.slice(i, i + chunk));
+        this.Render.Triangles(
+          this.Render.PictOp.Add,
+          opaque.id,
+          0,
+          0,
+          this.fillMask.id,
+          this.Render.a8,
+          tris.slice(i, i + chunk),
+        );
+      }
+    }
+    let out = b;
+    if (this._clips.length && !this.clipMask) {
+      const cr = this._clipRect();
+      if (cr) {
+        out = intersectBox(b, cr);
+        if (!out) return;
+      } else {
+        this._requireClipMask();
       }
     }
     if (this.globalAlpha < 1) {
-      this.Render.FillRectangles(this.Render.PictOp.In, this.fillMask.id, [0, 0, 0, this.globalAlpha], [b.x, b.y, b.w, b.h]);
+      this.Render.FillRectangles(
+        this.Render.PictOp.In,
+        this.fillMask.id,
+        [0, 0, 0, this.globalAlpha],
+        [out.x, out.y, out.w, out.h],
+      );
     }
     if (this.clipMask) {
-      this.Render.Composite(this.Render.PictOp.In, this.clipMask.id, 0, this.fillMask.id, b.x, b.y, 0, 0, b.x, b.y, b.w, b.h);
+      this.Render.Composite(
+        this.Render.PictOp.In,
+        this.clipMask.id,
+        0,
+        this.fillMask.id,
+        out.x,
+        out.y,
+        0,
+        0,
+        out.x,
+        out.y,
+        out.w,
+        out.h,
+      );
     }
-    this.Render.Composite(op, src.id, this.fillMask.id, this.picture.id, b.x, b.y, b.x, b.y, b.x, b.y, b.w, b.h);
+    this.Render.Composite(
+      op,
+      src.id,
+      this.fillMask.id,
+      this.picture.id,
+      out.x,
+      out.y,
+      out.x,
+      out.y,
+      out.x,
+      out.y,
+      out.w,
+      out.h,
+    );
     this._markDirty();
   }
 
@@ -1000,7 +1192,7 @@ class RenderingContext2d {
   drawGlyphs(op, src, positioned) {
     const app = this.window.app;
     const R = this.Render;
-    if (!this.clipMask) {
+    if (!this._clips.length) {
       drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
       this._markDirty();
       return;
@@ -1012,19 +1204,67 @@ class RenderingContext2d {
     const rect = this._clipRect();
     if (rect) {
       if (rect.w === 0 || rect.h === 0) return;
-      R.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+        rect.x,
+        rect.y,
+        rect.w,
+        rect.h,
+      ]);
       drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
-      R.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+        0,
+        0,
+        this.width,
+        this.height,
+      ]);
       this._markDirty();
       return;
     }
+    const clipMask = this._requireClipMask();
     this._ensureFillMask();
     this._glyphSource ??= this.createSolidPicture(1, 1, 1, 1);
-    R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
+    R.FillRectangles(
+      R.PictOp.Src,
+      this.fillMask.id,
+      [0, 0, 0, 0],
+      [0, 0, this.width, this.height],
+    );
     // solid white through the glyphs leaves their coverage in the a8 mask
-    drawGlyphRuns(app, R.PictOp.Over, this._glyphSource.id, this.fillMask.id, positioned);
-    R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
-    R.Composite(op, src.id, this.fillMask.id, this.picture.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    drawGlyphRuns(
+      app,
+      R.PictOp.Over,
+      this._glyphSource.id,
+      this.fillMask.id,
+      positioned,
+    );
+    R.Composite(
+      R.PictOp.In,
+      clipMask.id,
+      0,
+      this.fillMask.id,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      this.width,
+      this.height,
+    );
+    R.Composite(
+      op,
+      src.id,
+      this.fillMask.id,
+      this.picture.id,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      this.width,
+      this.height,
+    );
     this._markDirty();
   }
 
@@ -1038,7 +1278,7 @@ class RenderingContext2d {
     if (!traps.length) return;
     const app = this.window.app;
     const R = this.Render;
-    if (!this.clipMask) {
+    if (!this._clips.length) {
       compositeTraps(app, op, src.id, this.picture.id, traps);
       this._markDirty();
       return;
@@ -1046,29 +1286,98 @@ class RenderingContext2d {
     const rect = this._clipRect();
     if (rect) {
       if (rect.w === 0 || rect.h === 0) return;
-      R.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+        rect.x,
+        rect.y,
+        rect.w,
+        rect.h,
+      ]);
       compositeTraps(app, op, src.id, this.picture.id, traps);
-      R.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+      R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+        0,
+        0,
+        this.width,
+        this.height,
+      ]);
       this._markDirty();
       return;
     }
+    const clipMask = this._requireClipMask();
     this._ensureFillMask();
     this._glyphSource ??= this.createSolidPicture(1, 1, 1, 1);
-    R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
-    compositeTraps(app, R.PictOp.Over, this._glyphSource.id, this.fillMask.id, traps);
-    R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
-    R.Composite(op, src.id, this.fillMask.id, this.picture.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    R.FillRectangles(
+      R.PictOp.Src,
+      this.fillMask.id,
+      [0, 0, 0, 0],
+      [0, 0, this.width, this.height],
+    );
+    compositeTraps(
+      app,
+      R.PictOp.Over,
+      this._glyphSource.id,
+      this.fillMask.id,
+      traps,
+    );
+    R.Composite(
+      R.PictOp.In,
+      clipMask.id,
+      0,
+      this.fillMask.id,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      this.width,
+      this.height,
+    );
+    R.Composite(
+      op,
+      src.id,
+      this.fillMask.id,
+      this.picture.id,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      this.width,
+      this.height,
+    );
     this._markDirty();
   }
 
   // combined clip ∩ globalAlpha mask for direct composites (rect/image
   // fast paths); returns a picture id or 0. Reuses the fill scratch mask.
   _compositeMask() {
-    if (this.globalAlpha >= 1) return this.clipMask ? this.clipMask.id : 0;
+    // reached only when the clip is not a rectangle (those went through the
+    // SetPictureClipRectangles path), so a clip here always means the mask
+    const clipMask = this._clips.length ? this._requireClipMask() : null;
+    if (this.globalAlpha >= 1) return clipMask ? clipMask.id : 0;
     this._ensureFillMask();
-    this.Render.FillRectangles(this.Render.PictOp.Src, this.fillMask.id, [0, 0, 0, this.globalAlpha], [0, 0, this.width, this.height]);
-    if (this.clipMask) {
-      this.Render.Composite(this.Render.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    this.Render.FillRectangles(
+      this.Render.PictOp.Src,
+      this.fillMask.id,
+      [0, 0, 0, this.globalAlpha],
+      [0, 0, this.width, this.height],
+    );
+    if (clipMask) {
+      this.Render.Composite(
+        this.Render.PictOp.In,
+        clipMask.id,
+        0,
+        this.fillMask.id,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        this.width,
+        this.height,
+      );
     }
     return this.fillMask.id;
   }
@@ -1077,8 +1386,13 @@ class RenderingContext2d {
   // drawing
 
   clearRect(x, y, w, h) {
-    if (matIsIdentity(this._m) && !this.clipMask) {
-      this.Render.FillRectangles(this.Render.PictOp.Src, this.picture.id, [1, 1, 1, 1], [x, y, w, h]);
+    if (matIsIdentity(this._m) && !this._clips.length) {
+      this.Render.FillRectangles(
+        this.Render.PictOp.Src,
+        this.picture.id,
+        [1, 1, 1, 1],
+        [x, y, w, h],
+      );
       this._markDirty();
       return;
     }
@@ -1086,10 +1400,10 @@ class RenderingContext2d {
     tmp.rect(x, y, w, h);
     // clear = opaque white, ignoring alpha and the composite op (but
     // honoring the clip), matching the identity fast path above
-    this._fillPolys(flattenPath(tmp._cmds, this._m), 'nonzero', {
+    this._fillPolys(flattenPath(tmp._cmds, this._m), "nonzero", {
       src: this.createSolidPicture(1, 1, 1, 1),
       op: this.Render.PictOp.Over,
-      alpha: 1
+      alpha: 1,
     });
   }
 
@@ -1101,17 +1415,21 @@ class RenderingContext2d {
         this._backgroundPicture.id,
         mask,
         this.picture.id,
-        x, y,
-        x, y,
-        x, y,
-        w, h
+        x,
+        y,
+        x,
+        y,
+        x,
+        y,
+        w,
+        h,
       );
       this._markDirty();
       return;
     }
     const tmp = new Path2D();
     tmp.rect(x, y, w, h);
-    this._fillPolys(flattenPath(tmp._cmds, this._m), 'nonzero');
+    this._fillPolys(flattenPath(tmp._cmds, this._m), "nonzero");
   }
 
   strokeRect(x, y, w, h) {
@@ -1166,7 +1484,12 @@ class RenderingContext2d {
     // rather than quietly changing what they look like.
     const integral = (v) => Math.abs(v - Math.round(v)) < 1e-6;
     if (![x, y, w, h].every(integral)) return null;
-    return { x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h) };
+    return {
+      x: Math.round(x),
+      y: Math.round(y),
+      w: Math.round(w),
+      h: Math.round(h),
+    };
   }
 
   /** Intersection of the whole clip stack, or null if any part is not a
@@ -1201,13 +1524,64 @@ class RenderingContext2d {
     // copy-on-write: earlier save() snapshots keep their own clip list
     this._clips = this._clips.concat([entry]);
 
-    if (this._clips.length === 1) {
-      this._ensureClipMask();
-      this.Render.FillRectangles(this.Render.PictOp.Src, this.clipMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
-      this._rasterizePolys(this.clipMask, polys, rule);
+    // A stack of rectangles stays virtual: consumers apply the intersected
+    // rectangle server-side (SetPictureClipRectangles, bounded composites),
+    // and no a8 mask — no window-sized pixmap, no AddTraps — ever exists.
+    // That is the common case by a wide margin: a renderer clipping to a
+    // damage rect, a viewport and a cell nests rectangles three deep before
+    // the first rounded corner appears. The mask materializes on the first
+    // entry that is not a rectangle, and stays in sync from then on.
+    if (!this.clipMask) {
+      if (entry.rect) return;
+      this._materializeClipMask();
       return;
     }
     this._intersectClip(entry);
+  }
+
+  /**
+   * Build the a8 mask from the whole clip stack, on first demand. Rect
+   * entries are plain fills; only genuinely non-rectangular entries
+   * rasterize, and those through `_applyPolyClip`, which keeps the
+   * trapezoid work off the window-sized mask itself.
+   */
+  _materializeClipMask() {
+    const R = this.Render;
+    this._ensureClipMask();
+    R.FillRectangles(
+      R.PictOp.Src,
+      this.clipMask.id,
+      [0, 0, 0, 0],
+      [0, 0, this.width, this.height],
+    );
+    const first = this._clips[0];
+    if (first.rect) {
+      const r = first.rect;
+      const x = Math.max(0, Math.min(r.x, this.width));
+      const y = Math.max(0, Math.min(r.y, this.height));
+      const right = Math.max(x, Math.min(r.x + r.w, this.width));
+      const bottom = Math.max(y, Math.min(r.y + r.h, this.height));
+      if (right > x && bottom > y) {
+        R.FillRectangles(
+          R.PictOp.Src,
+          this.clipMask.id,
+          [0, 0, 0, 1],
+          [x, y, right - x, bottom - y],
+        );
+      }
+    } else {
+      this._applyPolyClip(first, R.PictOp.Src);
+    }
+    for (let i = 1; i < this._clips.length; i++)
+      this._intersectClip(this._clips[i]);
+  }
+
+  /** The live mask, built if the stack has not needed one yet. Callers on
+   * the rectangle fast paths never get here; a rect-only stack only
+   * materializes when a consumer genuinely has no cheaper way in. */
+  _requireClipMask() {
+    if (!this.clipMask) this._materializeClipMask();
+    return this.clipMask;
   }
 
   // rasterize one clip entry into a temp a8 and In-composite it onto the mask
@@ -1236,32 +1610,97 @@ class RenderingContext2d {
         outside.push(right, y, this.width - right, bottom - y);
       }
       if (outside.length) {
-        this.Render.FillRectangles(this.Render.PictOp.Src, this.clipMask.id, [0, 0, 0, 0], outside);
+        this.Render.FillRectangles(
+          this.Render.PictOp.Src,
+          this.clipMask.id,
+          [0, 0, 0, 0],
+          outside,
+        );
       }
       return;
     }
-    const tmpPixmap = new Pixmap(this.window.app, { depth: 8, width: this.width, height: this.height });
-    const tmpMask = new Picture(this.window.app, { drawable: tmpPixmap, format: this.Render.a8 });
-    this.Render.FillRectangles(this.Render.PictOp.Src, tmpMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
-    this._rasterizePolys(tmpMask, entry.polys, entry.rule);
-    this.Render.Composite(this.Render.PictOp.In, tmpMask.id, 0, this.clipMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+    this._applyPolyClip(entry, this.Render.PictOp.In);
+  }
+
+  /**
+   * Rasterize one non-rectangular clip entry and combine it onto the mask:
+   * `Src` writes a fresh mask (everything outside was just cleared), `In`
+   * intersects a live one. The trapezoids land in a temp sized to the
+   * entry's bounding box, never on the window-sized mask — on glamor an
+   * AddTraps is a software fallback that maps its whole target pixmap, so
+   * the target's size *is* the cost. Everything outside the box is cleared
+   * with plain fills: outside the entry the mask is zero by definition.
+   */
+  _applyPolyClip(entry, op) {
+    const R = this.Render;
+    const bb = this._polysBBox(entry.polys);
+    if (!bb || bb.w <= 0 || bb.h <= 0) {
+      R.FillRectangles(
+        R.PictOp.Src,
+        this.clipMask.id,
+        [0, 0, 0, 0],
+        [0, 0, this.width, this.height],
+      );
+      return;
+    }
+    if (op === R.PictOp.In) {
+      const outside = [];
+      if (bb.y > 0) outside.push(0, 0, this.width, bb.y);
+      if (bb.y + bb.h < this.height) {
+        outside.push(0, bb.y + bb.h, this.width, this.height - (bb.y + bb.h));
+      }
+      if (bb.x > 0) outside.push(0, bb.y, bb.x, bb.h);
+      if (bb.x + bb.w < this.width) {
+        outside.push(bb.x + bb.w, bb.y, this.width - (bb.x + bb.w), bb.h);
+      }
+      if (outside.length) {
+        R.FillRectangles(R.PictOp.Src, this.clipMask.id, [0, 0, 0, 0], outside);
+      }
+    }
+    const tmpPixmap = new Pixmap(this.window.app, {
+      depth: 8,
+      width: bb.w,
+      height: bb.h,
+    });
+    const tmpMask = new Picture(this.window.app, {
+      drawable: tmpPixmap,
+      format: R.a8,
+    });
+    R.FillRectangles(
+      R.PictOp.Src,
+      tmpMask.id,
+      [0, 0, 0, 0],
+      [0, 0, bb.w, bb.h],
+    );
+    this._rasterizePolys(tmpMask, entry.polys, entry.rule, -bb.x, -bb.y);
+    R.Composite(
+      op,
+      tmpMask.id,
+      0,
+      this.clipMask.id,
+      0,
+      0,
+      0,
+      0,
+      bb.x,
+      bb.y,
+      bb.w,
+      bb.h,
+    );
     tmpMask.destroy();
     tmpPixmap.destroy();
   }
 
   _rebuildClipMask() {
-    if (!this._clips.length) {
-      if (this.clipMask) {
-        this.clipMask.destroy();
-        this.clipMaskDrawable.destroy();
-        this.clipMask = this.clipMaskDrawable = null;
-      }
-      return;
+    // The stack changed shape (restore, resize): drop the mask rather than
+    // rebuild it eagerly. A stack that went back to rectangles never needs
+    // one again, and one that still holds a poly rebuilds on first demand
+    // through _requireClipMask — same work, paid only if something draws.
+    if (this.clipMask) {
+      this.clipMask.destroy();
+      this.clipMaskDrawable.destroy();
+      this.clipMask = this.clipMaskDrawable = null;
     }
-    this._ensureClipMask();
-    this.Render.FillRectangles(this.Render.PictOp.Src, this.clipMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
-    this._rasterizePolys(this.clipMask, this._clips[0].polys, this._clips[0].rule);
-    for (let i = 1; i < this._clips.length; i++) this._intersectClip(this._clips[i]);
   }
 
   isPointInPath(...args) {
@@ -1272,8 +1711,15 @@ class RenderingContext2d {
       rest = args.slice(1);
     }
     const [x, y, rule] = rest;
-    const polys = path ? flattenPath(path._cmds, this._m) : flattenPath(this._path._cmds, null);
-    return polysContain(polys, x, y, rule === 'evenodd' ? 'evenodd' : 'nonzero');
+    const polys = path
+      ? flattenPath(path._cmds, this._m)
+      : flattenPath(this._path._cmds, null);
+    return polysContain(
+      polys,
+      x,
+      y,
+      rule === "evenodd" ? "evenodd" : "nonzero",
+    );
   }
 
   // ------------------------------------------------------------------
@@ -1287,24 +1733,24 @@ class RenderingContext2d {
   // horizontal offset of the alignment point, given the shaped width
   _alignOffset(shaped) {
     let align = this.textAlign;
-    if (align === 'start') align = shaped.baseLevel & 1 ? 'right' : 'left';
-    if (align === 'end') align = shaped.baseLevel & 1 ? 'left' : 'right';
-    if (align === 'center') return -shaped.width / 2;
-    if (align === 'right') return -shaped.width;
+    if (align === "start") align = shaped.baseLevel & 1 ? "right" : "left";
+    if (align === "end") align = shaped.baseLevel & 1 ? "left" : "right";
+    if (align === "center") return -shaped.width / 2;
+    if (align === "right") return -shaped.width;
     return 0;
   }
 
   // vertical distance from the requested y to the baseline
   _baselineOffset(metrics) {
     switch (this.textBaseline) {
-      case 'top':
+      case "top":
         return metrics.ascent;
-      case 'hanging':
+      case "hanging":
         return metrics.ascent * 0.8;
-      case 'middle':
+      case "middle":
         return (metrics.ascent - metrics.descent) / 2;
-      case 'bottom':
-      case 'ideographic':
+      case "bottom":
+      case "ideographic":
         return -metrics.descent;
       default:
         // 'alphabetic'
@@ -1323,7 +1769,7 @@ class RenderingContext2d {
    * font via `ctx.font` instead).
    */
   fillText(text, x, y) {
-    text = String(text ?? '');
+    text = String(text ?? "");
     if (!text) return;
     const style = this._resolvedTextStyle();
     const app = this.window.app;
@@ -1338,7 +1784,11 @@ class RenderingContext2d {
       positioned.push({ run, x: cursor, y: oy });
       cursor += run.width;
     }
-    this.drawGlyphs(this.Render.PictOp.Over, this._backgroundPicture, positioned);
+    this.drawGlyphs(
+      this.Render.PictOp.Over,
+      this._backgroundPicture,
+      positioned,
+    );
   }
 
   /**
@@ -1348,7 +1798,7 @@ class RenderingContext2d {
    */
   measureText(text) {
     const style = this._resolvedTextStyle();
-    const shaped = this.window.app.fonts.shape(String(text ?? ''), style);
+    const shaped = this.window.app.fonts.shape(String(text ?? ""), style);
     let minX = 0;
     let maxX = 0;
     let minY = 0;
@@ -1378,7 +1828,7 @@ class RenderingContext2d {
       emHeightAscent: m.ascent,
       emHeightDescent: m.descent,
       // legacy ntk field: ink height
-      height: maxY - minY
+      height: maxY - minY,
     };
   }
 
@@ -1402,14 +1852,14 @@ class RenderingContext2d {
    * `app.fonts.load()` win over system (fontconfig) lookup.
    */
   set font(val) {
-    if (!val || typeof val !== 'string') return;
+    if (!val || typeof val !== "string") return;
     const parsed = parseFontStyle(val);
     if (!parsed) return;
     const style = {
       family: parsed.family,
       weight: parsed.weight,
       style: parsed.style,
-      size: parsed.size
+      size: parsed.size,
     };
     style.font = this.window.app.fonts.match(style.family, style);
     this._lastFontString = val;
@@ -1424,20 +1874,23 @@ class RenderingContext2d {
   // gradients / images
 
   createLinearGradient(x0, y0, x1, y1) {
-    return new CanvasGradient('linear', this, x0, y0, x1, y1);
+    return new CanvasGradient("linear", this, x0, y0, x1, y1);
   }
 
   createRadialGradient(x0, y0, r0, x1, y1, r1) {
-    return new CanvasGradient('radial', this, x0, y0, x1, y1, r0, r1);
+    return new CanvasGradient("radial", this, x0, y0, x1, y1, r0, r1);
   }
 
   createConicalGradient(x0, y0, angle) {
-    return new CanvasGradient('conical', this, x0, y0, angle);
+    return new CanvasGradient("conical", this, x0, y0, angle);
   }
 
   /** the pixel layout of whatever this context currently draws into */
   get _layout() {
-    const depth = this._target.depth ?? this.window.depth ?? this.display.screen[0].root_depth;
+    const depth =
+      this._target.depth ??
+      this.window.depth ??
+      this.display.screen[0].root_depth;
     if (!this._layoutCache || this._layoutCache.depth !== depth) {
       this._layoutCache = pixelLayout(this.display, depth);
     }
@@ -1451,9 +1904,12 @@ class RenderingContext2d {
    *   createImageData(imagedata)
    */
   createImageData(a, b) {
-    if (typeof a === 'number') return new ImageData(a, b);
-    if (a && typeof a.width === 'number' && a.data) return new ImageData(a.width, a.height);
-    throw new TypeError('createImageData: pass (width, height) or an ImageData');
+    if (typeof a === "number") return new ImageData(a, b);
+    if (a && typeof a.width === "number" && a.data)
+      return new ImageData(a.width, a.height);
+    throw new TypeError(
+      "createImageData: pass (width, height) or an ImageData",
+    );
   }
 
   /**
@@ -1469,14 +1925,20 @@ class RenderingContext2d {
     const src = data.data;
     if (!src || src.length !== width * height * 4) {
       throw new Error(
-        `putImageData: data must be ${width * height * 4} RGBA bytes for ${width}x${height}`
+        `putImageData: data must be ${width * height * 4} RGBA bytes for ${width}x${height}`,
       );
     }
     dirtyWidth ??= width;
     dirtyHeight ??= height;
     // the spec normalises negative extents by moving the origin
-    if (dirtyWidth < 0) { dirtyX += dirtyWidth; dirtyWidth = -dirtyWidth; }
-    if (dirtyHeight < 0) { dirtyY += dirtyHeight; dirtyHeight = -dirtyHeight; }
+    if (dirtyWidth < 0) {
+      dirtyX += dirtyWidth;
+      dirtyWidth = -dirtyWidth;
+    }
+    if (dirtyHeight < 0) {
+      dirtyY += dirtyHeight;
+      dirtyHeight = -dirtyHeight;
+    }
     const sx = Math.max(0, dirtyX);
     const sy = Math.max(0, dirtyY);
     const sw = Math.min(width, dirtyX + dirtyWidth) - sx;
@@ -1488,8 +1950,11 @@ class RenderingContext2d {
       const cropped = new Uint8ClampedArray(sw * sh * 4);
       for (let row = 0; row < sh; row++) {
         cropped.set(
-          src.subarray((sy + row) * width * 4 + sx * 4, (sy + row) * width * 4 + (sx + sw) * 4),
-          row * sw * 4
+          src.subarray(
+            (sy + row) * width * 4 + sx * 4,
+            (sy + row) * width * 4 + (sx + sw) * 4,
+          ),
+          row * sw * 4,
         );
       }
       rgba = cropped;
@@ -1507,11 +1972,13 @@ class RenderingContext2d {
         2, // ZPixmap
         this._target.id,
         this._gc,
-        sw, rows,
-        x + sx, y + sy + row,
+        sw,
+        rows,
+        x + sx,
+        y + sy + row,
         0,
         layout.depth,
-        bytes.subarray(row * stride, (row + rows) * stride)
+        bytes.subarray(row * stride, (row + rows) * stride),
       );
     }
     this._markDirty();
@@ -1531,9 +1998,9 @@ class RenderingContext2d {
    */
   getImageData(x, y, w, h, cb) {
     const promise = this.readPixels(x, y, w, h).then(
-      (raw) => new ImageData(toStraightRgba(raw.data, raw.layout, w, h), w, h)
+      (raw) => new ImageData(toStraightRgba(raw.data, raw.layout, w, h), w, h),
     );
-    if (typeof cb === 'function') {
+    if (typeof cb === "function") {
       promise.then((data) => cb(null, data), cb);
       return undefined;
     }
@@ -1561,10 +2028,19 @@ class RenderingContext2d {
   readPixels(x, y, w, h) {
     const layout = this._layout;
     return new Promise((resolve, reject) => {
-      this.X.GetImage(2, this._target.id, x, y, w, h, 0xffffffff, (err, img) => {
-        if (err) return reject(err);
-        resolve({ width: w, height: h, data: img.data, layout, ...layout });
-      });
+      this.X.GetImage(
+        2,
+        this._target.id,
+        x,
+        y,
+        w,
+        h,
+        0xffffffff,
+        (err, img) => {
+          if (err) return reject(err);
+          resolve({ width: w, height: h, data: img.data, layout, ...layout });
+        },
+      );
     });
   }
 
@@ -1594,18 +2070,32 @@ class RenderingContext2d {
    * picture is the same thing to the server, with no pixel work at all.
    */
   _beginDirectComposite() {
-    const rect = this.clipMask ? this._clipRect() : null;
-    if (!rect) return { mask: this._compositeMask(), clipped: false, empty: false };
-    if (rect.w === 0 || rect.h === 0) return { mask: 0, clipped: false, empty: true };
-    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+    const rect = this._clips.length ? this._clipRect() : null;
+    if (!rect)
+      return { mask: this._compositeMask(), clipped: false, empty: false };
+    if (rect.w === 0 || rect.h === 0)
+      return { mask: 0, clipped: false, empty: true };
+    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [
+      rect.x,
+      rect.y,
+      rect.w,
+      rect.h,
+    ]);
     const mask =
-      this.globalAlpha >= 1 ? 0 : this.createSolidPicture(0, 0, 0, this.globalAlpha).id;
+      this.globalAlpha >= 1
+        ? 0
+        : this.createSolidPicture(0, 0, 0, this.globalAlpha).id;
     return { mask, clipped: true, empty: false };
   }
 
   _endDirectComposite(state) {
     if (!state.clipped) return;
-    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [
+      0,
+      0,
+      this.width,
+      this.height,
+    ]);
   }
 
   /** The source colour for a coverage composite, with `globalAlpha` folded
@@ -1615,7 +2105,8 @@ class RenderingContext2d {
    * colour to fold into; `_drawCoverage` routes those through the scratch. */
   _coverageSource() {
     const style = this._fillStyle;
-    if (this.globalAlpha >= 1 || !isPlainColor(style)) return this._backgroundPicture;
+    if (this.globalAlpha >= 1 || !isPlainColor(style))
+      return this._backgroundPicture;
     const c = parseColor(style);
     return this.createSolidPicture(c[0], c[1], c[2], c[3] * this.globalAlpha);
   }
@@ -1633,69 +2124,154 @@ class RenderingContext2d {
     const R = this.Render;
     const scaled = dw !== sw || dh !== sh;
     if (scaled) {
-      R.SetPictureTransform(picture.id, [sw / dw, 0, sx, 0, sh / dh, sy, 0, 0, 1]);
-      picture.setFilter('bilinear');
+      R.SetPictureTransform(picture.id, [
+        sw / dw,
+        0,
+        sx,
+        0,
+        sh / dh,
+        sy,
+        0,
+        0,
+        1,
+      ]);
+      picture.setFilter("bilinear");
     }
     // with a transform in place the mask is already sampled from (sx, sy)
     const mx = scaled ? 0 : sx;
     const my = scaled ? 0 : sy;
 
-    const rect = this.clipMask ? this._clipRect() : null;
+    const rect = this._clips.length ? this._clipRect() : null;
     // the mask slot can hold exactly one picture, so anything that cannot be
     // folded into the colour or handed to the server as a clip rectangle has
     // to be intersected into the scratch mask first
     const scratch =
-      (this.clipMask && !rect) || (this.globalAlpha < 1 && !isPlainColor(this._fillStyle));
+      (this._clips.length && !rect) ||
+      (this.globalAlpha < 1 && !isPlainColor(this._fillStyle));
 
     if (scratch) {
       this._ensureFillMask();
-      R.FillRectangles(R.PictOp.Src, this.fillMask.id, [0, 0, 0, 0], [0, 0, this.width, this.height]);
-      R.Composite(R.PictOp.Src, picture.id, 0, this.fillMask.id, mx, my, 0, 0, dx, dy, dw, dh);
+      R.FillRectangles(
+        R.PictOp.Src,
+        this.fillMask.id,
+        [0, 0, 0, 0],
+        [0, 0, this.width, this.height],
+      );
+      R.Composite(
+        R.PictOp.Src,
+        picture.id,
+        0,
+        this.fillMask.id,
+        mx,
+        my,
+        0,
+        0,
+        dx,
+        dy,
+        dw,
+        dh,
+      );
       if (this.globalAlpha < 1) {
         R.Composite(
           R.PictOp.InReverse,
           this.createSolidPicture(0, 0, 0, this.globalAlpha).id,
           0,
           this.fillMask.id,
-          0, 0, 0, 0, 0, 0,
-          this.width, this.height
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          this.width,
+          this.height,
         );
       }
-      if (this.clipMask) {
-        R.Composite(R.PictOp.In, this.clipMask.id, 0, this.fillMask.id, 0, 0, 0, 0, 0, 0, this.width, this.height);
+      if (this._clips.length && !rect) {
+        const clipMask = this._requireClipMask();
+        R.Composite(
+          R.PictOp.In,
+          clipMask.id,
+          0,
+          this.fillMask.id,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          this.width,
+          this.height,
+        );
+      } else if (rect) {
+        // scratch was forced by alpha-over-gradient, not by the clip: the
+        // rectangle still applies, server-side, around the final composite
+        R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+          rect.x,
+          rect.y,
+          rect.w,
+          rect.h,
+        ]);
       }
       R.Composite(
         op,
         this._backgroundPicture.id,
         this.fillMask.id,
         this.picture.id,
-        0, 0, 0, 0,
-        dx, dy,
-        dw, dh
+        0,
+        0,
+        0,
+        0,
+        dx,
+        dy,
+        dw,
+        dh,
       );
+      if (rect) {
+        R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+          0,
+          0,
+          this.width,
+          this.height,
+        ]);
+      }
     } else if (!rect || (rect.w > 0 && rect.h > 0)) {
       if (rect) {
-        R.SetPictureClipRectangles(this.picture.id, 0, 0, [rect.x, rect.y, rect.w, rect.h]);
+        R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+          rect.x,
+          rect.y,
+          rect.w,
+          rect.h,
+        ]);
       }
       R.Composite(
         op,
         this._coverageSource().id,
         picture.id,
         this.picture.id,
-        0, 0,
-        mx, my,
-        dx, dy,
-        dw, dh
+        0,
+        0,
+        mx,
+        my,
+        dx,
+        dy,
+        dw,
+        dh,
       );
       if (rect) {
-        R.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, this.width, this.height]);
+        R.SetPictureClipRectangles(this.picture.id, 0, 0, [
+          0,
+          0,
+          this.width,
+          this.height,
+        ]);
       }
     }
 
     if (scaled) {
       // restore defaults so the cached surface stays reusable as-is
       R.SetPictureTransform(picture.id, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
-      picture.setFilter('nearest');
+      picture.setFilter("nearest");
     }
     this._markDirty();
   }
@@ -1729,7 +2305,7 @@ class RenderingContext2d {
         return;
       }
 
-      if (image.format === 'a8') {
+      if (image.format === "a8") {
         this._drawCoverage(picture, sx, sy, sw, sh, dx, dy, dw, dh, op);
         return;
       }
@@ -1741,31 +2317,52 @@ class RenderingContext2d {
       if (scaled) {
         // the picture transform maps composite coordinates into source
         // samples: dest pixel (i, j) reads (sx + i*sw/dw, sy + j*sh/dh)
-        this.Render.SetPictureTransform(picture.id, [sw / dw, 0, sx, 0, sh / dh, sy, 0, 0, 1]);
-        picture.setFilter('bilinear');
+        this.Render.SetPictureTransform(picture.id, [
+          sw / dw,
+          0,
+          sx,
+          0,
+          sh / dh,
+          sy,
+          0,
+          0,
+          1,
+        ]);
+        picture.setFilter("bilinear");
         this.Render.Composite(
           op,
           picture.id,
           mask,
           this.picture.id,
-          0, 0,
-          dx, dy,
-          dx, dy,
-          dw, dh
+          0,
+          0,
+          dx,
+          dy,
+          dx,
+          dy,
+          dw,
+          dh,
         );
         // restore defaults so the cached upload can be reused as-is
-        this.Render.SetPictureTransform(picture.id, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
-        picture.setFilter('nearest');
+        this.Render.SetPictureTransform(
+          picture.id,
+          [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        );
+        picture.setFilter("nearest");
       } else {
         this.Render.Composite(
           op,
           picture.id,
           mask,
           this.picture.id,
-          sx, sy,
-          dx, dy,
-          dx, dy,
-          dw, dh
+          sx,
+          sy,
+          dx,
+          dy,
+          dx,
+          dy,
+          dw,
+          dh,
         );
       }
       this._endDirectComposite(state);
@@ -1788,12 +2385,21 @@ class RenderingContext2d {
         image.picture.id,
         this._compositeMask(),
         this.picture.id,
-        0, 0, 0, 0, 0, 0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
         this.width,
-        this.height
+        this.height,
       );
       this._markDirty();
-    } else if (image && image.context && typeof image.context.getImageData === 'function') {
+    } else if (
+      image &&
+      image.context &&
+      typeof image.context.getImageData === "function"
+    ) {
       // node-canvas Canvas ( or any ctx with ctx.canvas.getImageData returning pixels)
       const imageData = image.context.getImageData(sx, sy, sWidth, sHeight);
       // node-canvas hands over straight RGBA, and the rgba32 picture below is
@@ -1803,7 +2409,7 @@ class RenderingContext2d {
         imageData.data,
         pixelLayout(this.display, 32),
         sWidth,
-        sHeight
+        sHeight,
       );
 
       // One upload GC per app rather than one per call, the same sharing
@@ -1812,8 +2418,15 @@ class RenderingContext2d {
       // time and free none of them, so drawing a node-canvas source in an
       // animation loop leaked three server resources per frame.
       const app = this.window.app;
-      const pixmap = new Pixmap(app, { depth: 32, width: sWidth, height: sHeight });
-      const picture = new Picture(app, { drawable: pixmap, format: this.Render.rgba32 });
+      const pixmap = new Pixmap(app, {
+        depth: 32,
+        width: sWidth,
+        height: sHeight,
+      });
+      const picture = new Picture(app, {
+        drawable: pixmap,
+        format: this.Render.rgba32,
+      });
       try {
         let gc = app._imageUploadGC;
         if (!gc) {
@@ -1829,9 +2442,14 @@ class RenderingContext2d {
           picture.id,
           this._compositeMask(),
           this.picture.id,
-          0, 0, 0, 0, 0, 0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
           this.width,
-          this.height
+          this.height,
         );
         this._markDirty();
       } finally {
@@ -1856,22 +2474,51 @@ class RenderingContext2d {
       matApply(this._m, dx, dy),
       matApply(this._m, dx + dw, dy),
       matApply(this._m, dx, dy + dh),
-      matApply(this._m, dx + dw, dy + dh)
+      matApply(this._m, dx + dw, dy + dh),
     ];
     const x0 = Math.max(0, Math.floor(Math.min(...corners.map((c) => c[0]))));
     const y0 = Math.max(0, Math.floor(Math.min(...corners.map((c) => c[1]))));
-    const x1 = Math.min(this.width, Math.ceil(Math.max(...corners.map((c) => c[0]))));
-    const y1 = Math.min(this.height, Math.ceil(Math.max(...corners.map((c) => c[1]))));
+    const x1 = Math.min(
+      this.width,
+      Math.ceil(Math.max(...corners.map((c) => c[0]))),
+    );
+    const y1 = Math.min(
+      this.height,
+      Math.ceil(Math.max(...corners.map((c) => c[1]))),
+    );
     if (x1 <= x0 || y1 <= y0) return;
 
     // device -> source sample (adding the source-rect origin)
     const srcM = [inv[0], inv[1], inv[2], inv[3], inv[4] + sx, inv[5] + sy];
-    this.Render.SetPictureTransform(picture.id, [srcM[0], srcM[2], srcM[4], srcM[1], srcM[3], srcM[5], 0, 0, 1]);
-    picture.setFilter('bilinear');
+    this.Render.SetPictureTransform(picture.id, [
+      srcM[0],
+      srcM[2],
+      srcM[4],
+      srcM[1],
+      srcM[3],
+      srcM[5],
+      0,
+      0,
+      1,
+    ]);
+    picture.setFilter("bilinear");
     const mask = this._compositeMask();
-    this.Render.Composite(op, picture.id, mask, this.picture.id, x0, y0, x0, y0, x0, y0, x1 - x0, y1 - y0);
+    this.Render.Composite(
+      op,
+      picture.id,
+      mask,
+      this.picture.id,
+      x0,
+      y0,
+      x0,
+      y0,
+      x0,
+      y0,
+      x1 - x0,
+      y1 - y0,
+    );
     this.Render.SetPictureTransform(picture.id, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
-    picture.setFilter('nearest');
+    picture.setFilter("nearest");
     this._markDirty();
   }
 }
@@ -1886,7 +2533,7 @@ class CanvasGradient {
 
     this.x0 = p0;
     this.y0 = p1;
-    if (type === 'linear' || type === 'radial') {
+    if (type === "linear" || type === "radial") {
       this.x1 = p2;
       this.y1 = p3;
       this.r0 = p4;
@@ -1911,17 +2558,34 @@ class CanvasGradient {
 
     this._id = X.AllocID();
     switch (this.type) {
-      case 'linear':
-        Render.LinearGradient(this._id, [this.x0, this.y0], [this.x1, this.y1], this.stops);
+      case "linear":
+        Render.LinearGradient(
+          this._id,
+          [this.x0, this.y0],
+          [this.x1, this.y1],
+          this.stops,
+        );
         break;
-      case 'radial':
-        Render.RadialGradient(this._id, [this.x0, this.y0], [this.x1, this.y1], this.r0, this.r1, this.stops);
+      case "radial":
+        Render.RadialGradient(
+          this._id,
+          [this.x0, this.y0],
+          [this.x1, this.y1],
+          this.r0,
+          this.r1,
+          this.stops,
+        );
         break;
-      case 'conical':
-        Render.ConicalGradient(this._id, [this.x0, this.y0], this.angle, this.stops);
+      case "conical":
+        Render.ConicalGradient(
+          this._id,
+          [this.x0, this.y0],
+          this.angle,
+          this.stops,
+        );
         break;
       default:
-        throw new Error('unknown gradient type');
+        throw new Error("unknown gradient type");
     }
     // wrap with picture so FreePicture is invoked on gc via FinalizationRegistry
     this._picture = new Picture(this.ctx.window.app, { id: this._id });
@@ -1930,7 +2594,8 @@ class CanvasGradient {
 }
 
 // register context
-Drawable.renderingContextFactory['2d'] = (window) => new RenderingContext2d(window);
+Drawable.renderingContextFactory["2d"] = (window) =>
+  new RenderingContext2d(window);
 
 export default RenderingContext2d;
 export { CanvasGradient };

--- a/test/clip-lazy.test.js
+++ b/test/clip-lazy.test.js
@@ -1,0 +1,131 @@
+// Rectangular clip stacks are virtual: no a8 mask, no AddTraps, no
+// window-sized pixmap — consumers apply the intersected rectangle
+// server-side. The mask exists only while the stack holds something
+// genuinely non-rectangular, and its trapezoid work happens in temps
+// sized to the entry's bounding box, never on the mask itself.
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import xserver from "x11/lib/xserver/index.js";
+
+import { createClient, StaticFontSource } from "../lib/index.js";
+
+let app = null;
+const W = 120;
+const H = 120;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+  });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext("2d");
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+const read = (ctx) => ctx.getImageData(0, 0, W, H);
+const at = (img, x, y) => {
+  const i = (y * W + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2]];
+};
+const isWhite = (p) => p[0] > 240 && p[1] > 240 && p[2] > 240;
+
+/** Count AddTraps requests issued while `fn` runs. */
+function countingTraps(ctx, fn) {
+  const R = ctx.Render;
+  const original = R.AddTraps;
+  let count = 0;
+  R.AddTraps = function (...args) {
+    count += 1;
+    return original.apply(this, args);
+  };
+  try {
+    fn();
+  } finally {
+    R.AddTraps = original;
+  }
+  return count;
+}
+
+test("nested rectangular clips never build a mask or send trapezoids", async () => {
+  const ctx = freshCtx();
+  const traps = countingTraps(ctx, () => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(10, 10, 80, 80);
+    ctx.clip();
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(20, 20, 40, 40);
+    ctx.clip();
+    ctx.fillStyle = "red";
+    ctx.fillRect(0, 0, W, H);
+    ctx.restore();
+    ctx.restore();
+  });
+  assert.equal(traps, 0, "a rect-only stack must not rasterize anything");
+  assert.equal(ctx.clipMask, null, "no mask for a rect-only stack");
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 30, 30), [255, 0, 0], "inside both clips filled");
+  assert.ok(isWhite(at(img, 15, 15)), "inside outer, outside inner: clipped");
+  assert.ok(isWhite(at(img, 95, 95)), "outside both: clipped");
+});
+
+test("a rounded clip still masks, and pixels honor the corner", async () => {
+  const ctx = freshCtx();
+  ctx.save();
+  ctx.beginPath();
+  ctx.roundRect(10, 10, 80, 80, 24);
+  ctx.clip();
+  assert.ok(ctx.clipMask, "a non-rectangular clip materializes the mask");
+  ctx.fillStyle = "red";
+  ctx.fillRect(0, 0, W, H);
+  ctx.restore();
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 50, 50), [255, 0, 0], "center filled");
+  assert.ok(isWhite(at(img, 12, 12)), "the corner the radius cuts off");
+  assert.ok(isWhite(at(img, 95, 95)), "outside the clip");
+});
+
+test("restore drops the mask and later rect clips stay virtual", async () => {
+  const ctx = freshCtx();
+  ctx.save();
+  ctx.beginPath();
+  ctx.roundRect(10, 10, 80, 80, 24);
+  ctx.clip();
+  ctx.restore();
+  assert.equal(ctx.clipMask, null, "restore past the poly drops the mask");
+
+  const traps = countingTraps(ctx, () => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(40, 40, 30, 30);
+    ctx.clip();
+    ctx.fillStyle = "blue";
+    ctx.fillRect(0, 0, W, H);
+    ctx.restore();
+  });
+  assert.equal(traps, 0, "back to rectangles, back to no mask");
+  assert.equal(ctx.clipMask, null);
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 50, 50), [0, 0, 255], "inside the rect clip");
+  assert.ok(isWhite(at(img, 20, 20)), "outside it");
+});


### PR DESCRIPTION
Closes #176.

## What

- `clip()` with a rectangular entry on a mask-less stack just records it. Consumers (fills, strokes, glyphs, traps, image composites, `clearRect`) gate on `_clips` instead of `clipMask` and use the rectangle paths they already had; fills and strokes additionally intersect their composite bbox with the clip rect (a shape outside the clip now costs nothing).
- The mask materializes on the first non-rectangular entry (`_requireClipMask`), and `restore()`/resize simply drop it — a stack that went back to rectangles never rebuilds it.
- Poly entries rasterize into a **bbox-sized temp** composited onto the mask (`_applyPolyClip`), with the outside cleared by plain fills. AddTraps never touches the window-sized mask again — on glamor `glamor_add_traps` does `prepare_access(RW)` on its whole target, so target size *is* the cost.

## Why it matters

Measured from react-x11 on Xorg/glamor/virgl: a single AddTraps per frame moved ntk's frame fence (server drain) from 0.38ms avg / 0.7ms p95 to 4.5ms avg / 17ms p95. A renderer clipping to a damage rect + viewport + cell nests three rectangles deep before any rounded corner appears — the common case was paying for the rare one on every frame. react-x11's protocol bench has a `clips: 40 nested rect clips with text` scenario (277 requests today) that should collapse when it picks this up.

## Verification

- 635 tests pass (632 existing + 3 new in `test/clip-lazy.test.js`): rect-only stacks issue zero AddTraps and keep `clipMask === null` with pixel-correct clipping; a rounded clip still materializes and honors the corner; restore past a poly drops the mask and later rect clips stay virtual.
- The existing `glyph-clip`, `fill-bbox`, and `icon` pixel suites cover the consumer paths under both clip kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)