### PR TITLE
perf(window): headroom in the backing pixmap, so a drag-resize reallocates O(log) times

### DIFF
--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -294,6 +294,15 @@ class RenderingContext2d {
     this._dropMasks();
   }
 
+  // Undo a rectangular server-side clip. "No clip" has to be stamped as a
+  // rectangle that outlives window growth: the backing pixmap has headroom
+  // past the window and growing into it does not rebind the picture, so a
+  // restore at today's window size would keep clipping tomorrow's pixels.
+  // Coordinates are INT16 — one rect at their maximum covers any drawable.
+  _resetPictureClip() {
+    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, 0x7fff, 0x7fff]);
+  }
+
   /**
    * Release everything this context allocated server-side. Idempotent, and
    * the context must not be drawn with afterwards.
@@ -1211,12 +1220,7 @@ class RenderingContext2d {
         rect.h,
       ]);
       drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
-      R.SetPictureClipRectangles(this.picture.id, 0, 0, [
-        0,
-        0,
-        this.width,
-        this.height,
-      ]);
+      this._resetPictureClip();
       this._markDirty();
       return;
     }
@@ -1293,12 +1297,7 @@ class RenderingContext2d {
         rect.h,
       ]);
       compositeTraps(app, op, src.id, this.picture.id, traps);
-      R.SetPictureClipRectangles(this.picture.id, 0, 0, [
-        0,
-        0,
-        this.width,
-        this.height,
-      ]);
+      this._resetPictureClip();
       this._markDirty();
       return;
     }
@@ -2090,12 +2089,7 @@ class RenderingContext2d {
 
   _endDirectComposite(state) {
     if (!state.clipped) return;
-    this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [
-      0,
-      0,
-      this.width,
-      this.height,
-    ]);
+    this._resetPictureClip();
   }
 
   /** The source colour for a coverage composite, with `globalAlpha` folded
@@ -2259,12 +2253,7 @@ class RenderingContext2d {
         dh,
       );
       if (rect) {
-        R.SetPictureClipRectangles(this.picture.id, 0, 0, [
-          0,
-          0,
-          this.width,
-          this.height,
-        ]);
+        this._resetPictureClip();
       }
     }
 

--- a/lib/window.js
+++ b/lib/window.js
@@ -27,6 +27,19 @@ const MAX_DIRTY_RECTS = 8;
  */
 const SPLIT_SAVING = 0.75;
 
+/**
+ * Backing pixmap dimensions are rounded up to this granularity.
+ *
+ * An interactive enlarge delivers a resize per frame, and an exact grow-only
+ * allocation crosses its previous maximum on every one of them — each frame
+ * paying for a CreatePixmap, a full white clear, a FreePixmap and a picture
+ * rebind. With headroom the reuse check absorbs the intermediate steps and a
+ * continuous drag reallocates O(log) times. The spare pixels are never
+ * presented — every blit is clamped to window ∩ backing — they just sit
+ * white until the window grows into them.
+ */
+const BACKING_GRANULARITY = 128;
+
 function rectArea(r) {
   return Math.max(0, r.w) * Math.max(0, r.h);
 }
@@ -639,12 +652,14 @@ export default class Window extends Drawable {
     });
   }
 
-  // grow-only backing pixmap (re)allocation; new area is cleared to white
+  // grow-only backing pixmap (re)allocation, with headroom (see
+  // BACKING_GRANULARITY); new area is cleared to white
   _allocBacking(w, h) {
     const cur = this._backing;
     if (cur && cur.width >= w && cur.height >= h) return;
-    const newW = Math.max(w, cur ? cur.width : 0);
-    const newH = Math.max(h, cur ? cur.height : 0);
+    const roundUp = (v) => Math.ceil(v / BACKING_GRANULARITY) * BACKING_GRANULARITY;
+    const newW = roundUp(Math.max(w, cur ? cur.width : 0));
+    const newH = roundUp(Math.max(h, cur ? cur.height : 0));
     const pixmap = new Pixmap(this.app, {
       parent: this,
       width: newW,

--- a/test/backing-headroom.test.js
+++ b/test/backing-headroom.test.js
@@ -1,0 +1,93 @@
+// Backing store headroom (sidorares/ntk#179): an interactive enlarge
+// delivers a ConfigureNotify per frame, and an exact grow-only allocation
+// crossed its previous maximum on every one of them — each frame paying for
+// a CreatePixmap, a full white clear, a FreePixmap and a picture rebind.
+// Dimensions round up to BACKING_GRANULARITY so the reuse check absorbs the
+// intermediate steps. Mock X client, the frame-pacing pattern: fences are
+// released by hand to model a server that keeps up with the drag.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import Window from '../lib/window.js';
+
+let nextId = 0xa000;
+
+function makeMockApp() {
+  const calls = { pixmaps: [], freed: 0 };
+  const fences = [];
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    CreateGC() {},
+    CreatePixmap(id, parent, depth, width, height) {
+      calls.pixmaps.push({ id, width, height });
+    },
+    FreePixmap() {
+      calls.freed++;
+    },
+    PolyFillRectangle() {},
+    CopyArea() {},
+    GetInputFocus(cb) {
+      fences.push(cb);
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display }, fences, calls };
+}
+
+const configure = (width, height) => ({ type: 22, width, height, x: 0, y: 0 });
+
+test('a continuous enlarge reallocates the backing O(log) times, not per frame', async () => {
+  const { app, fences, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, frameInterval: 0 });
+  wnd.width = 200;
+  wnd.height = 100;
+  // stands in for what getContext('2d') does on a window
+  wnd._enableBackingStore();
+  assert.equal(calls.pixmaps.length, 1, 'one allocation up front');
+  assert.ok(wnd._backing.width >= 200 && wnd._backing.height >= 100, 'covers the window');
+
+  // a drag enlarge: one ConfigureNotify per frame, each in its own tick so
+  // none of them coalesce, with the fence released between frames
+  for (let i = 1; i <= 10; i++) {
+    wnd.emit('event', configure(200 + i * 8, 100 + i * 8));
+    await tick();
+    while (fences.length) fences.shift()(null);
+    await tick();
+  }
+  const reallocs = calls.pixmaps.length - 1;
+  assert.ok(reallocs <= 2, `10 grow steps caused ${reallocs} reallocations`);
+  assert.ok(wnd._backing.width >= 280 && wnd._backing.height >= 180, 'still covers the window');
+  // every superseded pixmap was freed — headroom trades requests, not memory
+  assert.equal(calls.freed, reallocs);
+
+  wnd.destroy();
+});
+
+test('a grow step inside the headroom leaves the backing pixmap alone', async () => {
+  const { app, fences, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, frameInterval: 0 });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._enableBackingStore();
+  const backing = wnd._backing;
+
+  wnd.emit('event', configure(208, 108));
+  await tick();
+  while (fences.length) fences.shift()(null);
+  await tick();
+
+  assert.equal(wnd._backing, backing, 'same pixmap');
+  assert.equal(calls.pixmaps.length, 1);
+  assert.equal(wnd._backingValid, false, 'the new area still needs a redraw');
+
+  wnd.destroy();
+});


### PR DESCRIPTION
Closes #179. _allocBacking rounds allocation dimensions up to the next multiple of 128, so the existing grow-only reuse check absorbs intermediate grow steps — a continuous drag-resize reallocates a handful of times instead of once per ConfigureNotify frame (each realloc was CreatePixmap + full white fill + full redraw + picture rebinds, GPU-side on glamor). Verification found and fixed a real dependency: the rectangular-clip fast paths restored "no clip" by stamping window-sized rects, correct only while the backing was exactly window-sized — they now use `_resetPictureClip()` ([0,0,0x7fff,0x7fff]), which also fixes a pre-existing stale-clip hazard on shrink-then-regrow. New test: 10×8px grows cause at most 2 reallocations, superseded pixmaps freed. 634/634 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)