### PR TITLE
perf(text): LRU-evict the shaping memo and route fillText through it

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -83,7 +83,10 @@ XRender glyph ids are client-assigned, and ntk exploits that:
   budget is exceeded, the least-recently-drawn (face, size) page is freed
   server-side with `FreeGlyphSet`, so transient sizes don't accumulate.
 - `TextLayout` memoizes shaping per word, so re-wrapping on window resize
-  re-uses shaped glyphs and sends only composition requests.
+  re-uses shaped glyphs and sends only composition requests. `ctx.fillText`
+  draws through the same memo, so repainting a label shapes it once, not
+  once per frame. The memo is LRU-bounded (4000 entries): on overflow the
+  least-recently-used half is dropped, so what is on screen stays shaped.
 
 For scale: a 60-character line of 16px Latin text is ~70 bytes of
 `CompositeGlyphs` after warm-up. The one-time glyph upload for a full

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -1773,7 +1773,9 @@ class RenderingContext2d {
     if (!text) return;
     const style = this._resolvedTextStyle();
     const app = this.window.app;
-    const shaped = app.fonts.shape(text, style);
+    // through the shaping memo TextLayout uses: a label repainted every
+    // frame shapes once, not once per frame
+    const shaped = app.fonts._shapeCachedWhole(text, style);
     const [tx, ty] = matApply(this._m, x, y);
     const ox = tx + this._alignOffset(shaped);
     const oy = ty + this._baselineOffset(style.font.metrics(style.size));

--- a/lib/text/fontmanager.js
+++ b/lib/text/fontmanager.js
@@ -5,7 +5,7 @@ import {
   detectStyle,
   numericWeight as numWeight
 } from './fontsource.js';
-import { shapeText } from './shape.js';
+import { embeddingLevels, normalizedLevels, shapeText } from './shape.js';
 import { TextLayout } from './layout.js';
 
 /**
@@ -38,7 +38,7 @@ export default class FontManager {
     this._matches = new Map(); // family|weight|style -> Font
     this._fallbacks = new Map(); // family|weight|style -> Map(codepoint -> Font|null)
     this._registered = []; // { font, family (lowercase), weight, italic }
-    this._shapeCache = new Map(); // word-level shaping memo (bounded)
+    this._shapeCache = new Map(); // word-level shaping memo (bounded, LRU)
   }
 
   /** the FontSource in effect (explicit, else the process-wide default) */
@@ -232,25 +232,63 @@ export default class FontManager {
   }
 
   /**
-   * Memoized shaping used by TextLayout (bounded cache). `levelsKey` is a
-   * compact embedding-levels encoding: a single number when uniform for the
-   * whole fragment (the common case), else comma-separated per-char levels.
+   * Memoized shaping used by TextLayout and the canvas text path (bounded
+   * LRU). `levelsKey` is a compact embedding-levels encoding: a single
+   * number when uniform for the whole fragment (the common case), else
+   * comma-separated per-char levels.
    */
   _shapeCached(text, style, levelsKey = '0') {
     const font = style.font;
     const key = `${font ? font.key : style.family}|${style.size}|${style.weight}|${style.style}|${levelsKey}|${text}`;
     let shaped = this._shapeCache.get(key);
-    if (!shaped) {
-      let levels;
-      if (levelsKey.includes(',')) {
-        levels = levelsKey.split(',').map(Number);
-      } else {
-        levels = new Uint8Array(text.length).fill(Number(levelsKey));
-      }
-      shaped = shapeText(this, text, style, levels);
-      if (this._shapeCache.size > 4000) this._shapeCache.clear();
+    if (shaped) {
+      // Map iterates in insertion order: re-inserting a hit moves it to the
+      // tail, so the eviction sweep below walks least-recently-used first
+      this._shapeCache.delete(key);
       this._shapeCache.set(key, shaped);
+      return shaped;
     }
+    let levels;
+    if (levelsKey.includes(',')) {
+      levels = levelsKey.split(',').map(Number);
+    } else {
+      levels = new Uint8Array(text.length).fill(Number(levelsKey));
+    }
+    shaped = shapeText(this, text, style, levels);
+    if (this._shapeCache.size > 4000) {
+      // drop the stale half in one sweep rather than one entry per insert —
+      // a live UI's working set sits at the recent end and survives, where
+      // the old wholesale clear() re-shaped everything on screen
+      let drop = this._shapeCache.size >> 1;
+      for (const k of this._shapeCache.keys()) {
+        if (drop-- <= 0) break;
+        this._shapeCache.delete(k);
+      }
+    }
+    this._shapeCache.set(key, shaped);
     return shaped;
+  }
+
+  /**
+   * Memoized whole-string shaping — what `ctx.fillText` draws through, so
+   * repainting the same label hits the same entries TextLayout populates
+   * instead of re-running bidi + OpenType shaping every frame.
+   *
+   * Bidi is resolved here because the memo key needs the embedding levels;
+   * the paragraph level rides back on the result separately, since per-char
+   * levels cannot recover it (RTL text in an RTL paragraph carries level 1,
+   * which reads as an even base) and start/end alignment depends on it.
+   *
+   * `features` and `language` change shaped output but are not part of the
+   * memo key (styles reaching it via TextLayout never carry them into the
+   * key either), so a style with either shapes uncached rather than
+   * poisoning entries other callers share.
+   */
+  _shapeCachedWhole(text, style) {
+    if (style.features || style.language) return shapeText(this, text, style);
+    const emb = embeddingLevels(text, style.direction);
+    const baseLevel = emb.paragraphs.length ? emb.paragraphs[0].level : 0;
+    const shaped = this._shapeCached(text, style, normalizedLevels(emb.levels, 0, text.length));
+    return shaped.baseLevel === baseLevel ? shaped : { ...shaped, baseLevel };
   }
 }

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -1,7 +1,7 @@
 import LineBreaker from 'linebreak';
 
 import { drawGlyphRuns } from './glyphs.js';
-import { embeddingLevels, reorderRuns } from './shape.js';
+import { embeddingLevels, normalizedLevels, reorderRuns } from './shape.js';
 
 const WS = new Set([0x20, 0x09, 0xa0]);
 const HARD_BREAKS = /[\n\r\u2028\u2029]+$/;
@@ -855,17 +855,4 @@ function sliceLevels(key, start, end) {
   if (key === undefined) return '0';
   if (!key.includes(',')) return key;
   return key.split(',').slice(start, end).join(',');
-}
-
-// compact levels key for the shaping cache: single char when uniform
-function normalizedLevels(levels, start, end) {
-  let uniform = true;
-  for (let i = start + 1; i < end; i++) {
-    if (levels[i] !== levels[start]) {
-      uniform = false;
-      break;
-    }
-  }
-  if (uniform) return String(levels[start] ?? 0);
-  return Array.prototype.slice.call(levels, start, end).join(',');
 }

--- a/lib/text/shape.js
+++ b/lib/text/shape.js
@@ -29,6 +29,23 @@ export function embeddingLevels(text, direction = 'auto') {
 }
 
 /**
+ * Compact embedding-levels encoding for the shaping memo key: a single
+ * number when uniform over [start, end) — the common case — else
+ * comma-separated per-char levels.
+ */
+export function normalizedLevels(levels, start, end) {
+  let uniform = true;
+  for (let i = start + 1; i < end; i++) {
+    if (levels[i] !== levels[start]) {
+      uniform = false;
+      break;
+    }
+  }
+  if (uniform) return String(levels[start] ?? 0);
+  return Array.prototype.slice.call(levels, start, end).join(',');
+}
+
+/**
  * Shape a string through the full pipeline:
  *
  *   1. bidi resolution (UAX#9, bidi-js) — unless precomputed `levels` are

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -549,6 +549,39 @@ test('shaping cache reuses results across layouts', needsFonts, () => {
   assert.equal(fonts._shapeCache.size, cacheSize, 'relayout added no new shaping work');
 });
 
+test('shaping cache evicts its stale half on overflow, not everything', () => {
+  const fonts = fixedFonts();
+  const style = { font: fonts.match('sans-serif'), family: 'sans-serif', size: 16 };
+  const keep = fonts._shapeCached('keep', style);
+  const drop = fonts._shapeCached('drop', style);
+  // fill to the bound with distinct entries, then refresh 'keep' so it sits
+  // at the recently-used end when the sweep runs
+  let i = 0;
+  while (fonts._shapeCache.size <= 4000) fonts._shapeCached(`w${i++}`, style);
+  assert.equal(fonts._shapeCached('keep', style), keep, 'hit before overflow');
+  const before = fonts._shapeCache.size;
+  fonts._shapeCached('straw', style); // one past the bound: triggers the sweep
+  assert.ok(fonts._shapeCache.size < before, 'the sweep ran');
+  assert.ok(fonts._shapeCache.size > before / 4, 'and kept the recent half');
+  assert.equal(fonts._shapeCached('keep', style), keep, 'recently-used entry survived');
+  assert.notEqual(fonts._shapeCached('drop', style), drop, 'stale entries were evicted');
+});
+
+test('fillText-path shaping reuses the memo and keeps the paragraph level', () => {
+  const fonts = fixedFonts();
+  const style = { font: fonts.match('sans-serif'), family: 'sans-serif', size: 16 };
+  const first = fonts._shapeCachedWhole('hello', style);
+  assert.equal(fonts._shapeCachedWhole('hello', style), first, 'ltr string shapes once');
+  // rtl: the memoed entry alone reads back as an even base level, and
+  // start/end alignment flips for rtl strings if the paragraph level is lost
+  const rtl = fonts._shapeCachedWhole('שלום', style);
+  const direct = shapeText(fonts, 'שלום', style);
+  assert.equal(rtl.baseLevel & 1, 1, 'rtl paragraph level preserved');
+  assert.equal(rtl.baseLevel, direct.baseLevel);
+  assert.equal(rtl.width, direct.width);
+  assert.equal(fonts._shapeCachedWhole('שלום', style).runs, rtl.runs, 'rtl shaping still cached');
+});
+
 // ---------- markdown parser ----------
 
 test('parseMarkdown: blocks', () => {


### PR DESCRIPTION
Closes #181. `_shapeCached` is a true LRU now (Map re-insertion on hit; overflow evicts the oldest half instead of clear()), so a document crossing 4000 shaped fragments no longer re-shapes everything. `fillText` goes through the same memo via a new `_shapeCachedWhole` (bidi levels resolved with the identical key; paragraph level restored on a shallow copy for RTL start/end alignment; styles carrying features/language bypass with a comment). Tests assert recency survival across overflow and fillText memo hits incl. RTL. 634/634 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)