### PR TITLE
perf(fonts): prewarm fc-match for the default pattern off the event loop

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -38,7 +38,11 @@ ctx.fillText('Hello', 10, 50);
 Requires `fc-match` on the system and font files for it to find. A Linux
 desktop has both; a slim container, a single-file build and stock macOS do
 not — see [Environments without fontconfig](#environments-without-fontconfig).
-Matches are cached.
+Matches are cached, and the match for the default pattern (`sans-serif`,
+regular weight) is prewarmed with a non-blocking `fc-match` while
+`createClient` connects, so the first text layout does not stall on the
+spawn. Other patterns still pay one synchronous `fc-match` (~50ms) the
+first time they are used.
 
 ## Loading a font file directly
 

--- a/lib/fontconfig.js
+++ b/lib/fontconfig.js
@@ -1,8 +1,12 @@
 // node:child_process is fetched lazily (not via static import) so that
 // browser bundles of the package never try to resolve it; in non-node
 // environments use a custom FontSource instead (see text/fontsource.js).
+function childProcess() {
+  return globalThis.process?.getBuiltinModule?.('node:child_process');
+}
+
 function execFileSync(...args) {
-  const cp = globalThis.process?.getBuiltinModule?.('node:child_process');
+  const cp = childProcess();
   if (!cp) {
     throw noFontsError(
       'fontconfig matching needs node (the fc-match CLI) and this is not a node environment'
@@ -101,6 +105,69 @@ function patternFor({ family, weight, style }) {
   return fc;
 }
 
+// One command shared by the sync and async paths, so a prewarmed cache entry
+// is byte-for-byte what the sync call would have computed.
+const fcMatchArgs = ['-s', '--format', '%{file}\t%{postscriptname}\t%{charset}\n'];
+const fcMatchOpts = { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 };
+
+/** fc-match -s output -> candidates, filtered to formats fontkit can parse */
+function parseMatches(out) {
+  const list = [];
+  for (const line of out.split('\n')) {
+    const [path, postscriptName, charset] = line.split('\t');
+    if (path && supported.test(path)) {
+      list.push({ path, postscriptName, charset: charset || '', _ranges: null });
+    }
+  }
+  return list;
+}
+
+const prewarming = new Map();
+
+/**
+ * Seed the match cache for a pattern ahead of time, off the event loop.
+ *
+ * matchSortedSync is deliberately synchronous — it answers from inside text
+ * layout — so the first layout for a pattern pays the fc-match spawn (~50ms)
+ * as a first-paint stall. Starting the same command here with a non-blocking
+ * execFile, while the X connection is still being set up, moves that cost off
+ * the critical path (issue #182).
+ *
+ * Never rejects and never reports: a prewarm is an optimization, and an app
+ * that never renders text must not crash — or even warn — over a missing
+ * fc-match. An app that does render text reaches the sync path, which
+ * diagnoses the failure properly. For the same reason nothing here touches
+ * `unavailable`: the first sync throw keeps its original spawn error as
+ * `cause`.
+ *
+ * A sync call racing this one wins — the child's result is discarded
+ * whenever the pattern is already cached by the time it exits.
+ *
+ * @returns {Promise<void>} resolves once the cache is seeded or the attempt
+ *   abandoned
+ */
+export function prewarm(pattern = {}) {
+  const fc = patternFor(pattern);
+  if (sortedCache.has(fc) || unavailable) return Promise.resolve();
+  const inflight = prewarming.get(fc);
+  if (inflight) return inflight;
+  const cp = childProcess();
+  if (!cp) return Promise.resolve();
+
+  const promise = new Promise((resolve) => {
+    cp.execFile('fc-match', [...fcMatchArgs, fc], fcMatchOpts, (err, out) => {
+      prewarming.delete(fc);
+      if (!err && !sortedCache.has(fc)) {
+        const list = parseMatches(out);
+        if (list.length > 0) sortedCache.set(fc, list);
+      }
+      resolve();
+    });
+  });
+  prewarming.set(fc, promise);
+  return promise;
+}
+
 /**
  * Full fontconfig match list for a pattern, best match first — this is the
  * system's font fallback chain. Each candidate carries the unicode coverage
@@ -119,11 +186,7 @@ export function matchSortedSync(pattern) {
 
   let out;
   try {
-    out = execFileSync(
-      'fc-match',
-      ['-s', '--format', '%{file}\t%{postscriptname}\t%{charset}\n', fc],
-      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
-    );
+    out = execFileSync('fc-match', [...fcMatchArgs, fc], fcMatchOpts);
   } catch (err) {
     if (err.code === 'ERR_NTK_NO_FONTS') throw err; // no child_process at all
     if (isSpawnFailure(err)) {
@@ -140,13 +203,7 @@ export function matchSortedSync(pattern) {
     throw err;
   }
 
-  list = [];
-  for (const line of out.split('\n')) {
-    const [path, postscriptName, charset] = line.split('\t');
-    if (path && supported.test(path)) {
-      list.push({ path, postscriptName, charset: charset || '', _ranges: null });
-    }
-  }
+  list = parseMatches(out);
   if (list.length === 0) {
     throw noFontsError(
       `fontconfig matched no font ntk can parse for "${fc}" (needs ` +

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,16 @@ export function createClient(options, callback) {
     // synchronously, which keeps the legacy callback form working. The
     // caller's options object is copied, never mutated.
     const appOptions = options ? { ...options } : {};
-    if (appOptions.fontSource != null) appOptions.fontSource = createFontSource(appOptions.fontSource);
+    if (appOptions.fontSource != null) {
+      appOptions.fontSource = createFontSource(appOptions.fontSource);
+    } else {
+      // An app without a fontSource of its own resolves the process default
+      // lazily, at first text layout — too late for the fontconfig source's
+      // async fc-match prewarm to hide the ~50ms spawn (issue #182). Touch
+      // the default now, while the connection handshake runs; only touch,
+      // so a later setDefaultFontSource still takes effect.
+      defaultFontSource();
+    }
 
     x11.createClient(x11Options, (error, display) => {
       if (error) return reject(error);

--- a/lib/text/fontsource.js
+++ b/lib/text/fontsource.js
@@ -34,7 +34,7 @@
 // than imported, because this file is the one the browser bundle keeps — its
 // whole purpose is running the text stack without a filesystem. Do not turn
 // that into a static import (test/packaging.test.js fails if you do).
-import { charsetHas, matchSortedSync, noFontsError, supported } from '../fontconfig.js';
+import { charsetHas, matchSortedSync, noFontsError, prewarm, supported } from '../fontconfig.js';
 import Font from './font.js';
 
 const WEIGHTS = { normal: 400, bold: 700 };
@@ -95,6 +95,17 @@ export function parseFamilies(family) {
  * self-contained alternative.
  */
 export class FontconfigFontSource {
+  constructor() {
+    // Construction is the moment fontconfig is chosen as the lookup path, so
+    // the fc-match spawn for the pattern every widget default resolves to —
+    // sans-serif at regular weight, exactly as FontManager.match normalizes
+    // it — starts here, asynchronously, instead of stalling the first text
+    // layout for ~50ms. Fire-and-forget: prewarm never rejects, and a source
+    // constructed where fc-match is missing stays silent until (unless) text
+    // is actually rendered.
+    prewarm({ family: 'sans-serif', weight: 400, style: 'normal' });
+  }
+
   matchSorted(pattern) {
     return matchSortedSync(pattern);
   }

--- a/test/fontconfig.test.js
+++ b/test/fontconfig.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -89,6 +89,140 @@ test('fonts fc-match found but fontkit cannot parse are named as such', () => {
   assert.equal(err.code, 'ERR_NTK_NO_FONTS');
   assert.match(err.message, /matched no font ntk can parse/);
   assert.match(err.message, /bitmap \.pcf\/\.bdf fonts are not usable/);
+});
+
+// The prewarm (issue #182): the fc-match spawn for the default pattern runs
+// asynchronously when the fontconfig source is chosen, so the first text
+// layout finds the match cache already seeded instead of blocking first
+// paint on a child process. These run everywhere, fc-match or not: each
+// probe puts a stub on its child's PATH, and — because both exec paths read
+// process.env at spawn time — swaps PATH mid-script to tell the async spawn
+// apart from the sync one.
+
+/**
+ * Run a probe script in a child process. `stubs` maps a name to an fc-match
+ * script body; each becomes its own PATH directory, exposed to the probe as
+ * BIN.<name>. EMPTY is a directory with no fc-match at all (the child starts
+ * there), and PATTERN is the pattern FontManager.match('sans-serif') asks
+ * fontconfig for — the one the prewarm must seed for a first paint to hit it.
+ */
+function prewarmProbe(body, stubs = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'ntk-prewarm-'));
+  const bins = {};
+  for (const [name, stub] of Object.entries(stubs)) {
+    const bin = join(dir, name);
+    mkdirSync(bin);
+    writeFileSync(join(bin, 'fc-match'), stub);
+    chmodSync(join(bin, 'fc-match'), 0o755);
+    bins[name] = bin;
+  }
+  const empty = join(dir, 'empty');
+  mkdirSync(empty);
+  const script = join(dir, 'probe.mjs');
+  writeFileSync(
+    script,
+    `import { matchSortedSync, prewarm } from ${JSON.stringify(join(root, 'lib/fontconfig.js'))};\n` +
+      `import { FontconfigFontSource } from ${JSON.stringify(join(root, 'lib/text/fontsource.js'))};\n` +
+      `const BIN = ${JSON.stringify(bins)};\n` +
+      `const EMPTY = ${JSON.stringify(empty)};\n` +
+      "const PATTERN = { family: 'sans-serif', weight: 400, style: 'normal' };\n" +
+      body
+  );
+  const run = spawnSync(process.execPath, [script], { env: { PATH: empty }, encoding: 'utf8' });
+  assert.equal(run.status, 0, `probe failed: ${run.stderr}`);
+  return JSON.parse(run.stdout);
+}
+
+// prints one match and counts its invocations next to itself, so a probe can
+// assert a spawn did not happen rather than merely not crash. $0 stands in
+// for dirname: the probe's PATH holds only stub directories, no coreutils.
+const counting = (path) =>
+  '#!/bin/sh\n' + 'echo x >> "$0.spawns"\n' + `printf "${path}\\tStub\\t20-7e\\n"\n`;
+
+test('prewarm seeds the cache the sync path reads', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.warm;\n' +
+      'await prewarm(PATTERN);\n' +
+      'process.env.PATH = EMPTY; // any spawn after this point would throw ENOENT\n' +
+      'const [best] = matchSortedSync(PATTERN);\n' +
+      'console.log(JSON.stringify({ path: best.path }));\n',
+    { warm: counting('/warmed/A.ttf') }
+  );
+  assert.equal(out.path, '/warmed/A.ttf');
+});
+
+test('a sync call racing the prewarm wins; the late async result is discarded', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.slow;\n' +
+      'const warmed = prewarm(PATTERN); // spawns now, answers in ~300ms\n' +
+      'process.env.PATH = BIN.fast;\n' +
+      'const [duringRace] = matchSortedSync(PATTERN);\n' +
+      'await warmed;\n' +
+      'const [after] = matchSortedSync(PATTERN);\n' +
+      'console.log(JSON.stringify({ duringRace: duringRace.path, after: after.path }));\n',
+    {
+      // sleep by absolute path — the stub's PATH has no coreutils. Best
+      // effort: even an unslept child's exit callback cannot run before the
+      // probe's synchronous block finishes, so the assertion holds either way
+      slow:
+        '#!/bin/sh\n' +
+        '{ /bin/sleep 0.3 || /usr/bin/sleep 0.3; } 2>/dev/null\n' +
+        'printf "/async/LATE.ttf\\tLate\\t20-7e\\n"\n',
+      fast: '#!/bin/sh\nprintf "/sync/WINNER.ttf\\tWinner\\t20-7e\\n"\n'
+    }
+  );
+  assert.equal(out.duringRace, '/sync/WINNER.ttf');
+  assert.equal(out.after, '/sync/WINNER.ttf', 'the async result must not evict the sync one');
+});
+
+test('prewarm for an already-cached pattern spawns nothing', () => {
+  const out = prewarmProbe(
+    "import { readFileSync } from 'node:fs';\n" +
+      "import { join } from 'node:path';\n" +
+      'process.env.PATH = BIN.count;\n' +
+      'matchSortedSync(PATTERN);\n' +
+      'await prewarm(PATTERN);\n' +
+      "const spawns = readFileSync(join(BIN.count, 'fc-match.spawns'), 'utf8').trim().split('\\n').length;\n" +
+      'console.log(JSON.stringify({ spawns }));\n',
+    { count: counting('/counted/A.ttf') }
+  );
+  assert.equal(out.spawns, 1, 'only the sync call may spawn');
+});
+
+test('a missing fc-match leaves prewarm silent and the sync diagnosis intact', () => {
+  const out = prewarmProbe(
+    'await prewarm(PATTERN); // PATH is still EMPTY: the spawn fails with ENOENT\n' +
+      'let result;\n' +
+      'try {\n' +
+      '  matchSortedSync(PATTERN);\n' +
+      '  result = { ok: true };\n' +
+      '} catch (err) {\n' +
+      '  result = { code: err.code, cause: err.cause?.code };\n' +
+      '}\n' +
+      'console.log(JSON.stringify(result));\n'
+  );
+  assert.equal(out.code, 'ERR_NTK_NO_FONTS');
+  assert.equal(out.cause, 'ENOENT', 'the sync throw still carries its own spawn failure');
+});
+
+test('constructing FontconfigFontSource starts the prewarm', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.warm;\n' +
+      'new FontconfigFontSource();\n' +
+      'process.env.PATH = EMPTY;\n' +
+      '// fire-and-forget from the constructor, so poll for the seeded cache\n' +
+      'let path = null;\n' +
+      'for (let i = 0; i < 200 && !path; i++) {\n' +
+      '  try {\n' +
+      '    path = matchSortedSync(PATTERN)[0].path;\n' +
+      '  } catch {\n' +
+      '    await new Promise((r) => setTimeout(r, 25));\n' +
+      '  }\n' +
+      '}\n' +
+      'console.log(JSON.stringify({ path }));\n',
+    { warm: counting('/constructed/A.ttf') }
+  );
+  assert.equal(out.path, '/constructed/A.ttf');
 });
 
 test('the docs anchor the error points at exists', () => {


### PR DESCRIPTION
Closes #182. `matchSortedSync`'s ~50ms execFileSync per pattern ran lazily inside the first text layout. A new `prewarm(pattern)` runs the identical command via non-blocking execFile and seeds the same cache (sync always wins any race; in-flight spawns dedupe; failures are swallowed and never clobber the sync path's diagnostics). The fontconfig source prewarm-fires the normalized sans-serif pattern at construction, and createClient touches the default source during the handshake — StaticFontSource users never spawn anything. Measured: first sync match 0.04ms after prewarm vs ~16ms cold. 5 new tests (stubbed fc-match, no binary needed); 640/640 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)