### PR TITLE
perf: solid paints are one CreateSolidFill, cached per connection

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -129,7 +129,8 @@ to the anchor point, but glyphs are not rotated/scaled — size text via
   clip the clip goes to the server directly, rather than through a
   full-surface mask
 - `ctx.destroy()` / `Symbol.dispose` — release the context's server-side
-  resources: its GCs, its Picture, its masks and its solid-colour pictures.
+  resources: its GCs, its Picture and its masks. Solid-colour sources are
+  cached on the `App`, shared across contexts, and freed with `app.close()`.
   Needed only for contexts created dynamically, such as one per
   [`Surface`](surface.md); a context on a window lives as long as the window.
   A context dropped without it still releases its GCs through a finalizer,

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -83,11 +83,13 @@ cache of rendered things can satisfy it without ntk knowing the type.
 
 ## Context lifetime
 
-Contexts are not free: each one holds a GC, a Picture, and a 1x1 pixmap per
-fill colour it has seen. A context bound to a window normally lives as long
-as the window, so this rarely mattered — but creating them per surface makes
-it matter, which is why `RenderingContext2d` now has `destroy()` (and
-`Symbol.dispose`). `Surface.render()` calls it for you.
+Contexts are not free: each one holds a GC and a Picture (fill colours are
+cached on the `App` and shared by every context on the connection, so a
+colour costs its one server object no matter how many contexts use it). A
+context bound to a window normally lives as long as the window, so this
+rarely mattered — but creating them per surface makes it matter, which is
+why `RenderingContext2d` now has `destroy()` (and `Symbol.dispose`).
+`Surface.render()` calls it for you.
 
 ```js
 using ctx = surface.getContext('2d'); // or ctx.destroy() when done

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,6 +1,7 @@
 import Clipboard from './clipboard.js';
 import { CursorCache } from './cursor.js';
 import { chooseGLXConfig } from './glx.js';
+import Picture from './picture.js';
 import Pixmap from './pixmap.js';
 import { DEFAULT_RASTER_POLICY, defaultRasterizer } from './rasterize.js';
 import FontManager from './text/fontmanager.js';
@@ -42,6 +43,7 @@ export default class App {
     this._fonts = null;
     this._clipboard = null;
     this._cursors = null;
+    this._solidPictures = new Map();
     this._rasterizer = undefined;
     // node-x11 emits X errors it cannot route to a request callback as
     // 'error' on the client — from inside its packet parser. With no
@@ -167,12 +169,56 @@ export default class App {
     return new Pixmap(this, args);
   }
 
+  /**
+   * A repeating source Picture of one colour, for compositing. Components
+   * are 0..1 floats, premultiplied by alpha.
+   *
+   * Cached per connection, not per context: colours a context uses are the
+   * app's palette, and `Surface.render` builds a context per call — a
+   * per-context cache made every render recreate its fill colours
+   * server-side. Nothing evicts; a solid is a few dozen bytes on the server
+   * and an app cycles through few colours. Freed in `close()`.
+   *
+   * On RENDER >= 0.10 a solid is one CreateSolidFill request; an older
+   * server (or a hand-built App that skipped the version handshake in
+   * `createClient`) gets a 1x1 repeat pixmap, which composites identically.
+   */
+  solidPicture(r, g, b, a) {
+    const key = `${r}|${g}|${b}|${a}`;
+    let p = this._solidPictures.get(key);
+    if (p) return p;
+
+    const Render = this.display.Render;
+    const [major, minor] = Render.version || [0, 0];
+    if (major > 0 || minor >= 10) {
+      const pid = this.X.AllocID();
+      Render.CreateSolidFill(pid, r, g, b, a);
+      p = new Picture(this, { id: pid });
+    } else {
+      const pixmap = this.createPixmap({ depth: 32, width: 1, height: 1 });
+      const pid = this.X.AllocID();
+      Render.CreatePicture(pid, pixmap.id, Render.rgba32, { repeat: 1 });
+      Render.FillRectangles(Render.PictOp.Src, pid, [r, g, b, a], [0, 0, 1, 1]);
+      p = new Picture(this, { id: pid });
+      p._sourcePixmap = pixmap; // keep the 1x1 pixmap alive alongside the picture
+    }
+    this._solidPictures.set(key, p);
+    return p;
+  }
+
   // flush pending requests and close the connection
   close() {
     if (this._cursors) {
       this._cursors.dispose();
       this._cursors = null;
     }
+    // shared by every context that ever asked (see solidPicture), so their
+    // lifetime is the connection's — context teardown must not free them
+    for (const picture of this._solidPictures.values()) {
+      picture.destroy();
+      picture._sourcePixmap?.destroy();
+    }
+    this._solidPictures.clear();
     return new Promise((resolve) => this.X.close(resolve));
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,26 +124,35 @@ export function createClient(options, callback) {
           // rendering too bright.
           if (process.env.NTK_STRICT_COLORS) Render.strictColors = true;
           display.GLX = glxError ? null : GLX;
-          const X = display.client;
-          X.keycode2keysyms = {};
 
-          function updateKeyboardMapping(min, max) {
-            if (max <= min) return;
-            X.GetKeyboardMapping(min, max - min, (err, list) => {
-              if (err) return;
-              for (let i = 0; i < list.length; ++i) X.keycode2keysyms[i + min] = list[i].slice();
-            });
-          }
+          // RENDER requires the client to declare its version before using
+          // requests beyond 0.0, and the reply is what gates them afterwards
+          // — CreateSolidFill needs 0.10 (see App#solidPicture). 0.11 is the
+          // last published protocol revision.
+          Render.QueryVersion(0, 11, (versionError, version) => {
+            Render.version = versionError ? [0, 0] : version;
 
-          X.on('event', (ev) => {
-            // MappingNotify
-            if (ev.type === 34) {
-              updateKeyboardMapping(ev.firstKeyCode, ev.firstKeyCode + ev.count);
+            const X = display.client;
+            X.keycode2keysyms = {};
+
+            function updateKeyboardMapping(min, max) {
+              if (max <= min) return;
+              X.GetKeyboardMapping(min, max - min, (err, list) => {
+                if (err) return;
+                for (let i = 0; i < list.length; ++i) X.keycode2keysyms[i + min] = list[i].slice();
+              });
             }
-          });
-          updateKeyboardMapping(display.min_keycode, display.max_keycode);
 
-          resolve(new App(display, appOptions));
+            X.on('event', (ev) => {
+              // MappingNotify
+              if (ev.type === 34) {
+                updateKeyboardMapping(ev.firstKeyCode, ev.firstKeyCode + ev.count);
+              }
+            });
+            updateKeyboardMapping(display.min_keycode, display.max_keycode);
+
+            resolve(new App(display, appOptions));
+          });
         });
       });
     });

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -234,7 +234,6 @@ class RenderingContext2d {
       });
     }
 
-    this._solidPictures = new Map();
     this.fillMask = null;
     this.fillMaskDrawable = null;
     this.clipMask = null;
@@ -302,10 +301,11 @@ class RenderingContext2d {
    * connection outlives both, which is why this went missing for so long (see
    * issue #156). It matters as soon as contexts are created *dynamically* —
    * one per offscreen `Surface`, say — because without it each one
-   * permanently costs a GC, a Picture, and a 1x1 pixmap per fill colour used.
+   * permanently costs a GC and a Picture.
    *
    * `_backgroundPicture` and `_glyphSource` are deliberately not freed here:
-   * both are either aliases into `_solidPictures`, already freed below, or a
+   * both are either solids owned by the app (`App#solidPicture` — shared
+   * with every other context, freed with the connection) or a
    * `Picture`/`CanvasGradient` the caller passed in through `fillStyle`,
    * which is not ours to free.
    */
@@ -326,11 +326,6 @@ class RenderingContext2d {
     this._gc = this._fillMaskGC = null;
     this._gcs.length = 0;
 
-    for (const picture of this._solidPictures.values()) {
-      picture.destroy();
-      picture._sourcePixmap?.destroy();
-    }
-    this._solidPictures.clear();
     this._backgroundPicture = this._glyphSource = null;
 
     if (this.picture) {
@@ -401,26 +396,10 @@ class RenderingContext2d {
     return this._gco;
   }
 
+  // solids live on the app, not the context: contexts can be as short-lived
+  // as one Surface.render call, and the colours outlive all of them
   createSolidPicture(r, g, b, a) {
-    const key = [r, g, b, a].join("|");
-    let p = this._solidPictures.get(key);
-    if (p) return p;
-
-    // TODO: use window.createPixmap
-    const pixmap = new Pixmap(this.window.app, {
-      depth: 32,
-      width: 1,
-      height: 1,
-    });
-    const pictSolidPix = this.window.X.AllocID();
-    this.Render.CreatePicture(pictSolidPix, pixmap.id, this.Render.rgba32, {
-      repeat: 1,
-    });
-    this.Render.FillRectangles(1, pictSolidPix, [r, g, b, a], [0, 0, 100, 100]);
-    p = new Picture(this.window.app, { id: pictSolidPix });
-    p._sourcePixmap = pixmap; // keep the 1x1 pixmap alive alongside the picture
-    this._solidPictures.set(key, p);
-    return p;
+    return this.window.app.solidPicture(r, g, b, a);
   }
 
   _stylePicture(value) {

--- a/test/surface.test.js
+++ b/test/surface.test.js
@@ -321,6 +321,25 @@ describe('server resources are not leaked', () => {
     assert.equal(counts.FreePixmap, 5, 'and every one of them freed again');
   });
 
+  test('solid fill colours are cached on the app, not rebuilt per context', () => {
+    // render() builds a context per call, so per-context solids used to make
+    // every render recreate its colours server-side (pixmap + fill + picture
+    // each). They now live on the app, one CreateSolidFill per colour ever.
+    const surface = new Surface(app, { width: 8, height: 8 });
+    const paint = (colour) => (ctx) => {
+      ctx.fillStyle = colour;
+      ctx.fillRect(0, 0, 8, 8);
+    };
+    surface.render(paint('#8090a0')); // primes the colour and the defaults
+    const counts = countRender(['CreateSolidFill'], () => {
+      surface.render(paint('#8090a0'));
+      surface.render(paint('#8090a0'));
+    });
+    assert.equal(counts.CreateSolidFill, 0, 'renders after the first create no solids');
+    const fresh = countRender(['CreateSolidFill'], () => surface.render(paint('#8191a1')));
+    assert.equal(fresh.CreateSolidFill, 1, 'a colour not seen before costs one request');
+  });
+
   test('destroy() frees the GCs it allocated', () => {
     const pixmap = app.createPixmap({ width: 8, height: 8, depth: 32 });
     const ctx = pixmap.getContext('2d');


### PR DESCRIPTION
Closes #183. createClient now negotiates RENDER (QueryVersion 0.11 stored as display.Render.version); on ≥0.10 solid sources are one CreateSolidFill instead of CreatePixmap+fill+repeat-Picture, and the solid cache moved from per-context to per-App — Surface.render's short-lived contexts stop rebuilding and re-freeing the palette every render. Pixmap fallback kept for older servers / hand-built Apps; both paths verified pixel-identical (the in-process xserver implements CreateSolidFill, so tests exercise the new path). App-level pictures are freed in App.close(), not context teardown. New test: repeat renders issue zero CreateSolidFill, a fresh colour exactly one. 636/636 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)