### PR TITLE
feat(window): tag 'resize' with what actually changed (#184)

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -132,7 +132,9 @@ While a frame is pending, noisy events **coalesce** instead of queueing:
   kept in `ev.coalesced` (oldest first, like the DOM's
   `getCoalescedEvents()`), for e.g. freehand drawing that wants the full
   pointer trail. `wnd.width/height/x/y` always track the newest
-  `ConfigureNotify` immediately, even before the event is delivered.
+  `ConfigureNotify` immediately, even before the event is delivered. A
+  delivered `resize` also says what the merged burst actually changed —
+  see [`resize` fires for moves](#resize-fires-for-moves).
 - `expose` — damage accumulates: `ev.x/y/width/height` is the bounding box
   of all merged rectangles and `ev.rects` lists each one.
 
@@ -815,7 +817,7 @@ constructor arg) automatically extends the window's X event mask.
 | `focus` / `blur` | FocusIn/FocusOut | keyboard focus arrived at or left this window — usually because the window manager moved it. `ev.detail`/`ev.mode` carry the X notify detail and mode |
 | `expose` | Expose | `ev.x/y/width/height` of the damaged area, coalesced per frame (bounding box; rect list in `ev.rects`); on double-buffered windows only emitted when a real repaint is needed (see above) |
 | `draw` | — | synthetic repaint request on double-buffered windows (same payload as the accompanying `expose`) |
-| `resize` | ConfigureNotify | coalesced per frame (last state wins); updates `wnd.width/height/x/y` first |
+| `resize` | ConfigureNotify | **fires for moves too** — check `ev.resized` / `ev.moved`, see [below](#resize-fires-for-moves). Coalesced per frame (last state wins); updates `wnd.width/height/x/y` first |
 | `map` / `unmap` | Map/UnmapNotify | |
 | `destroy` | DestroyNotify | wrapper is removed from the cache |
 | `map_request`, `configure_request` | SubstructureRedirect | for window managers |
@@ -824,6 +826,43 @@ constructor arg) automatically extends the window's X event mask.
 | `property`, `reparent`, `message`, `selection*` | | |
 
 Every event object gets `ev.window` and `ev.target` set to the `Window`.
+
+### `resize` fires for moves
+
+`resize` is X's `ConfigureNotify`, and X reports *any* geometry change with
+it: a pure move, a reparent by the window manager, or a restatement of
+geometry that did not change at all. Under an opaque-move window manager
+(Compiz, KWin, Mutter, …) dragging a window by its title bar delivers one
+per pointer step, all of them the same size.
+
+So a handler that re-lays-out or reallocates on every `resize` does that
+work per step of a drag. The event says which change it was:
+
+| | |
+|---|---|
+| `ev.resized` | the size differs from the last delivered `resize` |
+| `ev.moved` | the position does |
+| `ev.previous` | that event's `{x, y, width, height}` — `null` on an adopted window whose geometry is not known yet, where both flags read `true` because nothing can be ruled out |
+
+```js
+wnd.on('resize', (ev) => {
+  if (ev.resized) relayout(ev.width, ev.height); // not on a drag
+  if (ev.moved) repositionPopups();
+});
+```
+
+The flags compare against the last **delivered** event, not the last raw
+one, so coalescing cannot hide a change: a frame that merges two moves and a
+resize reports both. For the same reason the merged raw events in
+`ev.coalesced` are not tagged — the flags describe the delivery.
+
+Position is compared as reported. A reparenting window manager sends real
+`ConfigureNotify` in frame coordinates and synthetic ones in root
+coordinates (ICCCM 4.2.3), so the frame's own offset can read as a move on
+the first event after the switch — spurious work, never missed work. The
+alternative is a `TranslateCoordinates` round trip per event, which is the
+cost these flags exist to avoid; ask for one explicitly if you need the true
+screen origin.
 
 ## Keyboard input
 

--- a/lib/widgets/htmlview.js
+++ b/lib/widgets/htmlview.js
@@ -105,8 +105,10 @@ export default class HtmlView {
     if (this.window) {
       this._ctx = this.window.getContext('2d');
       this.window.on('expose', () => this.render());
-      this.window.on('resize', () => {
-        this._layoutWidth = -1;
+      // a move is a ConfigureNotify too; re-laying out a document per step
+      // of a window drag is exactly what ev.resized is for
+      this.window.on('resize', (ev) => {
+        if (ev.resized) this._layoutWidth = -1;
       });
       this.window.on('mousedown', (ev) => {
         if (ev.keycode === 4 || ev.keycode === 5) {

--- a/lib/widgets/markdownview.js
+++ b/lib/widgets/markdownview.js
@@ -74,8 +74,10 @@ export default class MarkdownView {
     if (this.window) {
       this._ctx = this.window.getContext('2d');
       this.window.on('expose', () => this.render());
-      this.window.on('resize', () => {
-        this._layoutWidth = -1; // invalidate
+      // a move is a ConfigureNotify too; re-laying out a document per step
+      // of a window drag is exactly what ev.resized is for
+      this.window.on('resize', (ev) => {
+        if (ev.resized) this._layoutWidth = -1; // invalidate
       });
       this.window.on('mousedown', (ev) => {
         if (ev.keycode !== 1 || !this.onLink) return; // left button only

--- a/lib/window.js
+++ b/lib/window.js
@@ -386,6 +386,10 @@ export default class Window extends Drawable {
       this.height = args.height ?? 800;
       this.x = args.x ?? 0;
       this.y = args.y ?? 0;
+      // the baseline 'resize' compares against (see _tagResize): what the
+      // window was asked to be, so the window manager's first ConfigureNotify
+      // reports only what it actually overrode
+      this._deliveredGeom = { x: this.x, y: this.y, width: this.width, height: this.height };
       const values = {
         // NorthWest bit gravity: keep the old content anchored during
         // resize instead of discarding it (less flicker between the resize
@@ -419,6 +423,8 @@ export default class Window extends Drawable {
       this.eventMask = 0;
       this.visual = 0;
       this.depth = 0;
+      // an adopted window's geometry is not known until GetGeometry replies
+      this._deliveredGeom = null;
       // populate width and height
       X.GetGeometry(this.id, (err, res) => {
         if (!err) {
@@ -427,6 +433,10 @@ export default class Window extends Drawable {
           this.x = res.xPos;
           this.y = res.yPos;
           this.depth = res.depth;
+          // nothing was known about this window until now, so until this
+          // reply lands a 'resize' reports both moved and resized (see
+          // _tagResize) rather than guessing
+          this._deliveredGeom ??= { x: this.x, y: this.y, width: this.width, height: this.height };
         }
         this._readyPromiseResolve();
       });
@@ -523,6 +533,7 @@ export default class Window extends Drawable {
       // deliver buffered state events before a discrete one so handlers see
       // them in the order they happened (a drag sees the move, then the up)
       this._flushCoalesced();
+      if (eventName === 'resize') this._tagResize(ntkev);
       this.emit(eventName, ntkev);
       // a WM_DELETE_WINDOW ClientMessage is the window manager *asking*, and
       // 'close' is that question in a form an application can answer
@@ -628,8 +639,6 @@ export default class Window extends Drawable {
     this._dirty = false;
     this._backingValid = false;
     this._presentScheduled = false;
-    this._backedW = this.width;
-    this._backedH = this.height;
 
     this._presentGc = this.X.AllocID();
     this.X.CreateGC(this._presentGc, this.id, { graphicsExposures: 0 });
@@ -642,10 +651,11 @@ export default class Window extends Drawable {
       this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask }, () => {});
     }
 
+    // a pure move is a ConfigureNotify too, and reallocating a backing
+    // pixmap per step of a window drag is the bug this flag exists to spare
+    // everyone (see _tagResize)
     this.on('resize', (ev) => {
-      if (ev.width === this._backedW && ev.height === this._backedH) return;
-      this._backedW = ev.width;
-      this._backedH = ev.height;
+      if (!ev.resized) return;
       this._allocBacking(ev.width, ev.height);
       this._backingValid = false;
       this._requestRedraw();
@@ -875,6 +885,46 @@ export default class Window extends Drawable {
     this._scheduleFrame();
   }
 
+  /**
+   * Say what a 'resize' actually changed.
+   *
+   * 'resize' is ConfigureNotify, which fires for pure moves and for
+   * reparents as much as for size changes — under an opaque-move window
+   * manager a window drag is one per pointer step. Every consumer used to
+   * rediscover that by keeping its own copy of the last size (this library
+   * included, in the backing-store listener), and one that didn't paid a
+   * full relayout per step of a drag.
+   *
+   * So the delivered event says which it was:
+   *
+   *   - `ev.resized` — the size differs from the last delivered event's
+   *   - `ev.moved` — the position does
+   *   - `ev.previous` — that event's `{x, y, width, height}`, for a delta;
+   *     null on an adopted window whose geometry is not known yet, where
+   *     both flags read true because nothing can be ruled out
+   *
+   * Measured against the last *delivered* event, not the last raw one, so
+   * that coalescing cannot swallow a change: a frame that merges two moves
+   * and a resize reports both, where per-hop flags would report only the
+   * final hop. The merged raw events in `ev.coalesced` are not tagged for
+   * that reason — the flags are a property of the delivery.
+   *
+   * Position is compared as reported. A reparenting window manager sends
+   * real ConfigureNotify in frame coordinates and synthetic ones in root
+   * coordinates (ICCCM 4.2.3), so a frame's own offset can read as a move
+   * on the first event after the switch. That is the safe direction —
+   * spurious work, never missed work — and the alternative is a
+   * TranslateCoordinates round trip per event, which is the cost this flag
+   * exists to avoid.
+   */
+  _tagResize(ev) {
+    const prev = this._deliveredGeom;
+    ev.previous = prev;
+    ev.moved = !prev || ev.x !== prev.x || ev.y !== prev.y;
+    ev.resized = !prev || ev.width !== prev.width || ev.height !== prev.height;
+    this._deliveredGeom = { x: ev.x, y: ev.y, width: ev.width, height: ev.height };
+  }
+
   _flushCoalesced() {
     const pending = this._frame.pending;
     if (!pending.size) return;
@@ -884,6 +934,7 @@ export default class Window extends Drawable {
       const ev = pending.get(name);
       if (ev) {
         pending.delete(name);
+        if (name === 'resize') this._tagResize(ev);
         this.emit(name, ev);
       }
     }

--- a/test/resize-moved.test.js
+++ b/test/resize-moved.test.js
@@ -1,0 +1,219 @@
+// 'resize' is ConfigureNotify, which fires for pure moves and reparents as
+// much as for size changes (sidorares/ntk#184). The delivered event says
+// which it was — ev.moved / ev.resized / ev.previous — so a consumer does
+// not have to keep its own copy of the last geometry to find out, which is
+// the mistake that cost react-x11 a full relayout per step of a window drag
+// (sidorares/react-x11#183).
+//
+// Measured against the last *delivered* event, not the last raw one: a
+// frame that coalesces two moves and a resize has to report both.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import Window from '../lib/window.js';
+
+let nextId = 0xa000;
+
+function makeMockApp() {
+  const calls = { pixmaps: [], freed: 0 };
+  const fences = [];
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    CreateGC() {},
+    CreatePixmap(id, parent, depth, width, height) {
+      calls.pixmaps.push({ id, width, height });
+    },
+    FreePixmap() {
+      calls.freed++;
+    },
+    PolyFillRectangle() {},
+    CopyArea() {},
+    GetGeometry(id, cb) {
+      calls.getGeometry = cb;
+    },
+    GetInputFocus(cb) {
+      fences.push(cb);
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display }, fences, calls };
+}
+
+const configure = (width, height, x = 0, y = 0) => ({ type: 22, width, height, x, y });
+
+/** Deliver one ConfigureNotify and let its frame run. */
+async function send(wnd, fences, ev) {
+  wnd.emit('event', ev);
+  await tick();
+  while (fences.length) fences.shift()(null);
+  await tick();
+}
+
+test('a pure move is tagged moved, not resized', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, x: 10, y: 20, frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  await send(wnd, fences, configure(200, 100, 60, 70));
+
+  assert.equal(got.length, 1);
+  assert.equal(got[0].moved, true, 'the position changed');
+  assert.equal(got[0].resized, false, 'the size did not');
+  assert.deepEqual(got[0].previous, { x: 10, y: 20, width: 200, height: 100 });
+  wnd.destroy();
+});
+
+test('a pure resize is tagged resized, not moved', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, x: 10, y: 20, frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  await send(wnd, fences, configure(640, 480, 10, 20));
+
+  assert.equal(got[0].moved, false);
+  assert.equal(got[0].resized, true);
+  wnd.destroy();
+});
+
+test('a move-and-resize is tagged as both', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, x: 10, y: 20, frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  await send(wnd, fences, configure(640, 480, 60, 70));
+
+  assert.equal(got[0].moved, true);
+  assert.equal(got[0].resized, true);
+  wnd.destroy();
+});
+
+test('a ConfigureNotify that changed nothing is tagged as neither', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, x: 10, y: 20, frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  // a reparent, or a WM restating the geometry it already gave us
+  await send(wnd, fences, configure(200, 100, 10, 20));
+
+  assert.equal(got.length, 1, 'still delivered — the event happened');
+  assert.equal(got[0].moved, false);
+  assert.equal(got[0].resized, false);
+  wnd.destroy();
+});
+
+test('the baseline is the last delivered event, so coalescing cannot swallow a change', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, x: 0, y: 0, frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  // one frame's worth: two moves and then a resize. Per-hop flags would
+  // report the last hop only — resized, not moved — and a listener that
+  // re-anchors on moves would never hear about the 40px the window travelled.
+  wnd.emit('event', configure(200, 100, 20, 0));
+  wnd.emit('event', configure(200, 100, 40, 0));
+  wnd.emit('event', configure(300, 100, 40, 0));
+  await tick();
+  while (fences.length) fences.shift()(null);
+
+  assert.equal(got.length, 1, 'one delivery for the frame');
+  assert.equal(got[0].coalesced.length, 3);
+  assert.equal(got[0].moved, true, 'the net move across the frame');
+  assert.equal(got[0].resized, true, 'and the net resize');
+  assert.deepEqual(got[0].previous, { x: 0, y: 0, width: 200, height: 100 });
+  wnd.destroy();
+});
+
+test('flags follow each delivery, so a drag reports move-only every frame', async () => {
+  const { app, fences } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, x: 0, y: 0, frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  for (let i = 1; i <= 5; i++) await send(wnd, fences, configure(200, 100, i * 10, 0));
+
+  assert.equal(got.length, 5);
+  assert.ok(
+    got.every((ev) => ev.moved && !ev.resized),
+    'every step of an opaque-move drag is a move'
+  );
+  assert.deepEqual(got.at(-1).previous, { x: 40, y: 0, width: 200, height: 100 });
+  wnd.destroy();
+});
+
+test('without coalescing the flags are the same', async () => {
+  const { app } = makeMockApp();
+  const wnd = new Window(app, {
+    width: 200,
+    height: 100,
+    x: 0,
+    y: 0,
+    coalesceEvents: false,
+    frameSync: false
+  });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  wnd.emit('event', configure(200, 100, 30, 0));
+  wnd.emit('event', configure(260, 100, 30, 0));
+
+  assert.deepEqual(
+    got.map((ev) => [ev.moved, ev.resized]),
+    [
+      [true, false],
+      [false, true]
+    ]
+  );
+  wnd.destroy();
+});
+
+test('an adopted window reports both until its geometry is known', async () => {
+  const { app, calls, fences } = makeMockApp();
+  const wnd = new Window(app, { id: 0xbeef, frameInterval: 0 });
+  const got = [];
+  wnd.on('resize', (ev) => got.push(ev));
+
+  assert.equal(wnd._deliveredGeom, null, 'nothing known before GetGeometry replies');
+  await send(wnd, fences, configure(300, 200, 5, 5));
+  assert.equal(got[0].moved, true, 'nothing can be ruled out');
+  assert.equal(got[0].resized, true);
+  assert.equal(got[0].previous, null);
+
+  // the reply lands late; the event stream has already established a
+  // baseline, so it must not overwrite one
+  calls.getGeometry(null, { width: 300, height: 200, xPos: 5, yPos: 5, depth: 24 });
+  await send(wnd, fences, configure(300, 200, 5, 5));
+  assert.equal(got[1].moved, false, 'the baseline came from the events, not the reply');
+  assert.equal(got[1].resized, false);
+  wnd.destroy();
+});
+
+test('the backing store ignores moves and still follows resizes', async () => {
+  const { app, fences, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, x: 0, y: 0, frameInterval: 0 });
+  wnd._enableBackingStore();
+  assert.equal(calls.pixmaps.length, 1, 'one allocation up front');
+
+  // an opaque-move drag: 20 ConfigureNotify, no size change
+  for (let i = 1; i <= 20; i++) await send(wnd, fences, configure(200, 100, i * 5, 0));
+  assert.equal(calls.pixmaps.length, 1, 'a drag reallocates nothing');
+  assert.equal(wnd._backingValid, false, 'and does not invalidate what is drawn');
+
+  // a real enlarge past the headroom still reallocates
+  await send(wnd, fences, configure(900, 700, 100, 0));
+  assert.equal(calls.pixmaps.length, 2, 'a resize still grows the backing');
+  wnd.destroy();
+});


### PR DESCRIPTION
Closes #184.

## What

`resize` is `ConfigureNotify`, and X reports any geometry change with it: a pure move, a reparent, or a restatement of geometry that did not change at all. Under an opaque-move window manager, dragging a window by its title bar delivers one per pointer step — all the same size.

Every consumer had to rediscover that and keep its own copy of the last geometry to find out. One that didn't paid a full relayout and a full-window repaint per step of a drag, which is sidorares/react-x11#183.

The delivered event now says which it was:

| | |
|---|---|
| `ev.resized` | the size differs from the last delivered `resize` |
| `ev.moved` | the position does |
| `ev.previous` | that event's geometry, for a delta — `null` on an adopted window whose geometry is not known yet, where both flags read `true` because nothing can be ruled out |

## Measured against the last *delivered* event

Not against the last raw one, which is the part that matters under coalescing. A frame that merges two moves and then a resize reports both; per-hop flags would report only the final hop, and a listener that re-anchors on moves would never hear about the distance the window travelled. There is a test for exactly that.

For the same reason the raw events in `ev.coalesced` are not tagged — the flags are a property of the delivery, not of a packet.

## ntk uses them itself

Which is the proof that they are right, and removes the duplicated state the issue points at:

- the backing store no longer keeps `_backedW`/`_backedH` to guard reallocation — it reads `ev.resized`. A 20-step drag now reallocates nothing and invalidates nothing, pinned by a test.
- `HtmlView` and `MarkdownView` no longer throw away their document layout on every step of a window drag.

## Position is compared as reported

A reparenting window manager sends real `ConfigureNotify` in frame coordinates and synthetic ones in root coordinates, per ICCCM 4.2.3, so the frame's own offset can read as a move on the first event after the switch. That is the safe direction — spurious work, never missed work — and the alternative is a `TranslateCoordinates` round trip per event, which is the cost these flags exist to avoid. Documented in `docs/window.md`, together with the line the issue asked for: `resize` fires for moves.

## Verification

`test/resize-moved.test.js`, 9 cases: pure move, pure resize, both, neither, the coalescing case above, a five-step drag, the uncoalesced path, an adopted window before and after its `GetGeometry` reply, and the backing store ignoring a drag while still following a real enlarge. Full suite: 654 pass.

## Downstream

sidorares/react-x11 has a PR ready against this: it drops a `TranslateCoordinates` round trip per frame of a resize drag. It is feature-detected, so it does not have to wait for this release.
