### PR TITLE
perf: pace discrete-event blits with a minimum inter-blit interval

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -55,9 +55,9 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 - `coalesceEvents: false` — deliver every noisy event individually (see
   [Frames, coalescing and slow connections](#frames-coalescing-and-slow-connections))
 - `frameSync: false` — don't pace frames with a server round-trip fence
-- `frameInterval: ms` — minimum time between paced frames (default `16`,
-  ~60 fps; `0` disables the timer gate). Also writable later as
-  `wnd.frameInterval`.
+- `frameInterval: ms` — minimum time between paced frames, and the minimum
+  time between blits (default `16`, ~60 fps; `0` disables both gates). Also
+  writable later as `wnd.frameInterval`.
 
 ## Double buffering (backing store)
 
@@ -114,7 +114,7 @@ arrives as bursts of `Expose` rectangles. Reacting to each one queues more
 drawing than the connection can drain, and the window plays back a trail of
 stale intermediate states — most visibly over ssh-forwarded / networked
 displays. ntk therefore delivers noisy events and repaints in **paced
-frames**, gated by two independent mechanisms:
+frames**, gated by three independent mechanisms:
 
 - **a fence** — after each frame the library sends a cheap request with a
   reply (`GetInputFocus`). X processes requests strictly in order, so the
@@ -125,6 +125,15 @@ frames**, gated by two independent mechanisms:
   backlog builds up. Disable with `frameSync: false`.
 - **a timer** — at most one paced frame per `frameInterval` ms (default 16),
   so a local server isn't asked to redraw at input-device rate.
+- **a minimum inter-blit interval** — also `frameInterval`. Blits that are
+  *not* part of a paced frame (the one at the end of a discrete event's
+  handler, below) skip the timer for latency, and used to be bounded only by
+  the fence: on a local server that answers in a few hundred microseconds, a
+  stream of discrete events blitted several hundred times a second, and under
+  a compositor every blit is a texture-from-pixmap recomposite. The first blit
+  after a quiet moment is still immediate; any that follow within
+  `frameInterval` are held back and coalesce into one. `frameInterval: 0`
+  turns this off with the timer gate.
 
 While a frame is pending, noisy events **coalesce** instead of queueing:
 
@@ -139,7 +148,13 @@ While a frame is pending, noisy events **coalesce** instead of queueing:
 Discrete events (`mousedown`, `keydown`, …) are never coalesced and are
 delivered immediately — any buffered noisy events are flushed first so
 handlers observe them in the order they happened. Blits of an already-drawn
-backing store still respect the fence, but skip the timer for latency.
+backing store skip the frame timer for latency, so the response to a discrete
+input goes out with the handler's own requests; they are still bounded by the
+fence and by the minimum inter-blit interval above. A discrete input arriving
+out of the blue is always more than `frameInterval` after the last blit, so
+the interval never taxes the case that latency matters for — it only stops a
+*burst* (a spun wheel sends a press and a release per notch) from blitting
+faster than the display can show.
 
 A toolkit that schedules its own painting can go one better and draw a
 discrete input's response *inside* the handler, so the pixels leave with the
@@ -148,9 +163,10 @@ handler's own requests rather than on the next paced frame — a click's
 frame interval for it buys nothing. `wnd.frameInFlight()` is the gate to
 make that decision with: `false` means the server is caught up and drawing
 now costs nothing extra, `true` means a frame is already on its way and the
-present would only be deferred and coalesced with it. Gating on it is what
-keeps a burst sane — the first wheel notch paints immediately, the rest fold
-into one catch-up frame.
+present would only be deferred and coalesced with it. Gating on it saves the
+*painting* work in a burst — the blit itself is bounded either way, since the
+minimum inter-blit interval already folds a burst's followers into one
+catch-up frame (the first wheel notch still paints immediately).
 
 ```js
 wnd.on('mousedown', (ev) => {
@@ -162,8 +178,8 @@ wnd.on('mousedown', (ev) => {
 Escape hatches, from mildest to rawest:
 
 - `frameInterval = 0` — fence-only pacing (fastest delivery that cannot
-  fall behind the server)
-- `frameSync: false` — timer-only pacing
+  fall behind the server), and unpaced blits
+- `frameSync: false` — timer-only pacing, for frames and for blits
 - `coalesceEvents: false` — per-event delivery, no merging at all
 - `wnd.on('event', ev => ...)` — the raw X event stream for this window,
   before any name mapping or coalescing
@@ -203,7 +219,8 @@ round-trip on slow connections — write the loop once, it behaves everywhere.
 - `wnd.id` — X window id
 - `wnd.width`, `wnd.height`, `wnd.x`, `wnd.y` — geometry, kept in sync on `resize`
 - `wnd.frameLatency` — last fence round-trip, ms (`null` before the first frame)
-- `wnd.frameInterval` — minimum ms between paced frames (writable)
+- `wnd.frameInterval` — minimum ms between paced frames, and between blits
+  (writable)
 - `wnd.app`, `wnd.X`, `wnd.display` — owning app / raw client shortcuts
 
 ## Methods

--- a/lib/window.js
+++ b/lib/window.js
@@ -364,7 +364,12 @@ export default class Window extends Drawable {
       inFlight: false, // fence round-trip awaiting the server's reply
       timer: null,
       scheduled: false,
-      needsRedraw: false
+      needsRedraw: false,
+      // minimum inter-blit pacing: when the last blit went out, and the timer
+      // that guarantees a blit held back by the interval still lands.
+      // -Infinity so the first blit after construction is never delayed.
+      lastPresentAt: -Infinity,
+      presentTimer: null
     };
 
     if (!args.id) {
@@ -802,8 +807,13 @@ export default class Window extends Drawable {
    *  - a timer: at most one paced frame per `frameInterval` ms, so a fast
    *    local server doesn't get redraws at input-device rate.
    *
-   * Discrete events (mousedown, keydown, ...) bypass the timer for latency,
-   * but their blits still respect the fence via _present().
+   * Discrete events (mousedown, keydown, ...) bypass the timer for latency:
+   * the first blit after a quiet moment goes out with the handler's own
+   * requests. Their blits are still bounded, by the fence and by a minimum
+   * inter-blit interval (also `frameInterval`) — see _present(). Without that
+   * interval a stream of discrete events blits at round-trip rate, which on a
+   * local server is several hundred per second, and under a compositor every
+   * blit is a recomposite.
    */
   _scheduleFrame() {
     const f = this._frame;
@@ -901,9 +911,10 @@ export default class Window extends Drawable {
         f.inFlight = false;
         this.frameLatency = performance.now() - start;
         if (this._presentPending) {
-          // a blit deferred while the fence was in flight: show it now
-          this._presentNow();
-          this._armFence();
+          // a blit deferred while the fence was in flight: show it as soon as
+          // the minimum inter-blit interval allows (immediately when the last
+          // blit is already older than that, which is the common case)
+          this._present();
         }
         if ((f.pending.size || f.rafCbs.length || f.needsRedraw) && !f.timer) this._scheduleFrame();
       });
@@ -926,6 +937,10 @@ export default class Window extends Drawable {
     if (f.timer) {
       clearTimeout(f.timer);
       f.timer = null;
+    }
+    if (f.presentTimer) {
+      clearTimeout(f.presentTimer);
+      f.presentTimer = null;
     }
     f.pending.clear();
     f.rafCbs = [];
@@ -963,9 +978,11 @@ export default class Window extends Drawable {
    * Drawing the response inside the event handler costs a frame less latency:
    * the blit goes out with the handler's own requests (see the `_present()`
    * at the end of the event dispatch) instead of waiting for the next paced
-   * frame. Drawing it while a frame is in flight costs a frame's *work* for
-   * nothing: the present is deferred until the ack and coalesces with the
-   * one already pending, so only the last paint is ever seen. So `false`
+   * frame — provided the last blit is at least `frameInterval` old, which is
+   * what a discrete input arriving out of the blue always is. Drawing it while
+   * a frame is in flight costs a frame's *work* for nothing: the present is
+   * deferred until the ack and coalesces with the one already pending, so only
+   * the last paint is ever seen. So `false`
    * means "draw it now", `true` means "leave it to the frame clock" — which
    * is how a burst of discrete events (a spun wheel) paints its first notch
    * immediately and folds the rest into one catch-up frame.
@@ -980,13 +997,57 @@ export default class Window extends Drawable {
 
   _present() {
     if (!this._backing) return;
-    if (this._frame.inFlight) {
-      // the server hasn't confirmed the previous frame yet — defer the blit
-      this._presentPending = true;
+    const wait = this._presentWait();
+    if (this._frame.inFlight || wait > 0) {
+      // the server hasn't confirmed the previous frame yet, or the last blit
+      // was too recent — defer, and leave a wakeup behind
+      this._deferPresent(wait);
       return;
     }
     this._presentNow();
     this._armFence();
+  }
+
+  /**
+   * How long until the next blit may go out; 0 when it may go now.
+   *
+   * The gate is `frameInterval`, the same knob that paces frames, so
+   * `frameInterval: 0` keeps the old fence-only behaviour — a caller who asked
+   * for no timer gate gets none here either.
+   */
+  _presentWait() {
+    const min = this.frameInterval;
+    if (!(min > 0)) return 0;
+    const since = performance.now() - this._frame.lastPresentAt;
+    return since >= min ? 0 : min - since;
+  }
+
+  /**
+   * Hold a blit back, and guarantee it still happens.
+   *
+   * This is the only place `_presentPending` is set, because every deferral has
+   * to leave a wakeup behind: the fence reply when the fence is what we are
+   * waiting on, this timer when the interval is. Nothing else reschedules a
+   * present — `_scheduleFrame()` bails while a frame timer is armed, and
+   * neither reschedule condition (in `_armFence`'s reply or `_armTimer`'s
+   * callback) looks at the present. Without the timer the last blit of a burst
+   * would simply never go out, leaving stale pixels on screen.
+   */
+  _deferPresent(wait) {
+    this._presentPending = true;
+    if (wait <= 0) return; // waiting on the fence: its reply blits this
+    const f = this._frame;
+    if (f.presentTimer) return; // already armed
+    f.presentTimer = setTimeout(() => {
+      f.presentTimer = null;
+      if (!this._presentPending && !this._dirty) return; // someone blitted it
+      const again = this._presentWait();
+      if (again > 0) return this._deferPresent(again); // a paced frame re-stamped
+      if (f.inFlight) return; // the fence ack is closer; it will blit
+      this._presentNow();
+      this._armFence();
+    }, wait);
+    if (typeof f.presentTimer.unref === 'function') f.presentTimer.unref();
   }
 
   _presentNow() {
@@ -1011,6 +1072,10 @@ export default class Window extends Drawable {
     }
     if (!clamped.length) return;
     const rects = this._blitList(clamped);
+    // Stamped here rather than at the call sites so it is a true inter-blit
+    // interval across all three of them, and only when pixels really move — a
+    // present that copies nothing must not push the next one out.
+    this._frame.lastPresentAt = performance.now();
     // a paced frame can fire after the connection started closing
     safeRelease(this.X, () => {
       for (const r of rects) {

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import { setImmediate as tick, setTimeout as sleep } from 'node:timers/promises';
 
 import Window from '../lib/window.js';
+import { withTimeout } from './helpers/async.js';
 
 // the wrapper cache is keyed per connection, so ids only have to be unique
 // within one mock app — keeping them unique across all of them anyway makes
@@ -16,6 +17,11 @@ let nextId = 0xa000;
 function makeMockApp() {
   const calls = { CopyArea: 0, copies: [] };
   const fences = []; // pending GetInputFocus callbacks, released by tests
+  // Waiters for the next blit. A blit held back by the minimum inter-blit
+  // interval lands on a timer, so `await tick()` is not enough to observe it;
+  // awaiting the blit itself works whether it is immediate or deferred, and
+  // fails loudly (named) if it is dropped altogether.
+  let copyWaiters = [];
   const X = {
     _closing: false,
     stream: { destroyed: false, writableEnded: false },
@@ -35,13 +41,18 @@ function makeMockApp() {
     CopyArea(src, dst, gc, sx, sy, dx, dy, width, height) {
       calls.CopyArea++;
       calls.copies.push({ x: dx, y: dy, w: width, h: height });
+      const wake = copyWaiters;
+      copyWaiters = [];
+      for (const resolve of wake) resolve();
     },
     GetInputFocus(cb) {
       fences.push(cb);
     }
   };
   const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
-  return { app: { X, display }, fences, calls };
+  const nextCopy = () =>
+    withTimeout(new Promise((resolve) => copyWaiters.push(resolve)), 2000, 'blit');
+  return { app: { X, display }, fences, calls, nextCopy };
 }
 
 const motion = (x, y) => ({ type: 6, x, y });
@@ -310,16 +321,16 @@ test('interactive resize drives one paced draw per frame', async () => {
 // The list is capped, and collapsed back to its box when splitting would not
 // save enough to pay for the extra requests.
 
-function backedWindow() {
-  const { app, fences, calls } = makeMockApp();
-  const wnd = new Window(app, { width: 200, height: 100 });
+function backedWindow(args) {
+  const { app, fences, calls, nextCopy } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, ...args });
   wnd.width = 200;
   wnd.height = 100;
   // the backing store is normally allocated by getContext('2d'); there is no
   // real context here, so stand one in and drive _markDirty directly
   wnd._backing = { id: 0xb000, width: 200, height: 100 };
   wnd._presentGc = 0xc000;
-  return { wnd, fences, calls };
+  return { wnd, fences, calls, nextCopy };
 }
 
 test('a present copies only the region the drawing reported', async () => {
@@ -460,14 +471,17 @@ test('one unreported operation gives up the bound for the whole frame', async ()
 });
 
 test('the region does not leak into the next frame', async () => {
-  const { wnd, fences, calls } = backedWindow();
+  const { wnd, fences, calls, nextCopy } = backedWindow();
   wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
   await tick();
   assert.deepEqual(calls.copies[0], { x: 0, y: 0, w: 10, h: 10 });
   // release the fence the first present armed, so the second is not deferred
   while (fences.length) fences.shift()();
+  // the second blit follows the first inside one frameInterval, so it is held
+  // back by the minimum inter-blit interval — wait for the blit, not a tick
+  const blitted = nextCopy();
   wnd._markDirty({ x: 100, y: 50, w: 10, h: 10 });
-  await tick();
+  await blitted;
   assert.equal(calls.CopyArea, 2);
   assert.deepEqual(
     calls.copies[1],
@@ -482,4 +496,111 @@ test('a reported region is clamped to the window', async () => {
   wnd._markDirty({ x: -20, y: -5, w: 400, h: 300 });
   await tick();
   assert.deepEqual(calls.copies[0], { x: 0, y: 0, w: 200, h: 100 });
+});
+
+// Minimum inter-blit interval (issue #180).
+//
+// Discrete events blit at the end of their handler rather than waiting for the
+// next paced frame — that latency is the point. But nothing used to bound how
+// often that could happen: on a local server the fence answers in a few
+// hundred microseconds, so a stream of discrete events blitted hundreds of
+// times a second, and under a compositor every blit is a recomposite. The
+// first blit after a quiet moment is still immediate; the ones behind it are
+// held back to one per `frameInterval` and coalesce.
+
+test('the first blit after a quiet moment is immediate', async () => {
+  const { wnd, calls } = backedWindow();
+  // no await: the latency-critical path must not even wait for a microtask
+  wnd._markDirtyNow = true;
+  wnd._dirty = true;
+  wnd._dirtyRegion = [{ x: 0, y: 0, w: 10, h: 10 }];
+  wnd._present();
+  assert.equal(calls.CopyArea, 1, 'blitted synchronously');
+});
+
+test('a burst of discrete blits is paced to one per frameInterval', async () => {
+  const { wnd, fences, calls } = backedWindow({ frameInterval: 20, frameSync: false });
+  const start = Date.now();
+  // ~10 "events", each in its own turn, well inside one interval
+  for (let i = 0; i < 10; i++) {
+    wnd._dirty = true;
+    wnd._dirtyRegion = [{ x: i, y: 0, w: 5, h: 5 }];
+    wnd._present();
+    await sleep(2);
+  }
+  const elapsed = Date.now() - start;
+  assert.equal(fences.length, 0, 'frameSync: false sends no fence, so only the interval paces');
+  // shape, not an exact count: one blit per interval plus the immediate first
+  assert.ok(
+    calls.CopyArea <= Math.ceil(elapsed / 20) + 1,
+    `paced: ${calls.CopyArea} blits in ${elapsed}ms at a 20ms interval`
+  );
+  assert.ok(calls.CopyArea < 10, `fewer blits than events (got ${calls.CopyArea})`);
+});
+
+test('the last blit of a burst still lands', async () => {
+  const { wnd, calls, nextCopy } = backedWindow({ frameInterval: 20, frameSync: false });
+  wnd._dirty = true;
+  wnd._dirtyRegion = [{ x: 0, y: 0, w: 5, h: 5 }];
+  wnd._present(); // immediate
+  const settled = nextCopy();
+  // a second mark right behind it is deferred, and nothing else follows: the
+  // deferral timer is the only thing that can still put it on screen
+  wnd._dirty = true;
+  wnd._dirtyRegion = [{ x: 150, y: 80, w: 20, h: 15 }];
+  wnd._present();
+  await settled;
+  assert.equal(calls.CopyArea, 2, 'the deferred blit was not dropped');
+  assert.deepEqual(
+    calls.copies[1],
+    { x: 150, y: 80, w: 20, h: 15 },
+    'and it carried the final region'
+  );
+  assert.equal(wnd._dirty, false, 'no dirt left behind');
+  assert.equal(wnd._presentPending, false, 'no present left pending');
+});
+
+test('regions marked during a deferral coalesce into the one present that follows', async () => {
+  const { wnd, calls, nextCopy } = backedWindow({ frameInterval: 20, frameSync: false });
+  wnd._dirty = true;
+  wnd._dirtyRegion = [{ x: 0, y: 0, w: 5, h: 5 }];
+  wnd._present(); // immediate, starts the interval
+  const first = calls.CopyArea;
+  const settled = nextCopy();
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  wnd._markDirty({ x: 180, y: 90, w: 10, h: 10 });
+  await settled;
+  await tick();
+  // one present, which may still split into a copy per rectangle (_blitList) —
+  // what matters is that both marks made it into that single deferred present
+  const after = calls.copies.slice(first);
+  const covers = (x, y) =>
+    after.some((r) => x >= r.x && y >= r.y && x < r.x + r.w && y < r.y + r.h);
+  assert.ok(covers(5, 5), `the top-left mark was blitted (got ${JSON.stringify(after)})`);
+  assert.ok(covers(185, 95), `the bottom-right mark was blitted (got ${JSON.stringify(after)})`);
+  assert.equal(wnd._dirty, false, 'nothing left dirty');
+});
+
+test('frameInterval: 0 keeps the old unpaced blit behaviour', async () => {
+  const { wnd, calls } = backedWindow({ frameInterval: 0, frameSync: false });
+  for (let i = 0; i < 5; i++) {
+    wnd._dirty = true;
+    wnd._dirtyRegion = [{ x: i, y: 0, w: 5, h: 5 }];
+    wnd._present();
+  }
+  assert.equal(calls.CopyArea, 5, 'every present blits when the timer gate is off');
+});
+
+test('destroy() cancels a blit held back by the interval', async () => {
+  const { wnd, calls } = backedWindow({ frameInterval: 20, frameSync: false });
+  wnd._dirty = true;
+  wnd._dirtyRegion = [{ x: 0, y: 0, w: 5, h: 5 }];
+  wnd._present(); // immediate
+  wnd._dirty = true;
+  wnd._dirtyRegion = [{ x: 50, y: 50, w: 5, h: 5 }];
+  wnd._present(); // deferred
+  const before = calls.CopyArea;
+  wnd._teardownFrame();
+  await sleep(60);
+  assert.equal(calls.CopyArea, before, 'the deferred blit did not fire after teardown');
 });


### PR DESCRIPTION
Item 1 of #180. Items 2 and 3 are follow-ups of their own; item 4 turned out to be a non-starter and is written up in the issue rather than implemented.

## The problem

A blit at the end of a discrete event's handler skips the frame timer on purpose — the response to a click should leave with the handler's own requests rather than wait for the next paced frame, and `docs/window.md` sells that latency as a feature. What was missing is that nothing *bounded* it: the fence was the only gate, and on a local server `GetInputFocus` answers in a few hundred microseconds.

Measured against Xorg before this change, a stream of discrete events that each redraw:

| | before | after |
|---|---|---|
| blits for ~450 events in 1s | 449 | **61** |
| blits/sec (nominal cap 63/s) | 448 | **61** |
| first-blit latency | 0.73 ms | 0.92 ms (unchanged, sub-ms) |

A wheel notch arrives as a `ButtonPress` *and* a `ButtonRelease`, so a scroll that redraws in both handlers blits twice per notch. Under a compositor every blit is a texture-from-pixmap recomposite, so this is work the display never asked for and cannot show.

## The change

Blits are now also bounded by a **minimum inter-blit interval**, reusing `frameInterval` rather than adding a knob — so `frameInterval: 0` still means "no timer gate", which is what keeps every existing `frameInterval: 0` test (and anyone relying on that escape hatch) behaving exactly as before.

The first blit after a quiet moment is still immediate. A discrete input arriving out of the blue is by definition more than an interval after the last blit, so the latency this protects is untouched; only a *burst's* followers are held back, and they coalesce into one.

## The subtle part: a deferred blit must still happen

`_presentPending` had exactly one wakeup — the fence reply — and neither reschedule condition in the frame clock looks at the present (`_scheduleFrame` bails while a frame timer is armed; `_armTimer`'s callback only checks pending events and rAF callbacks). So deferring without arming a timer would silently drop **the last blit of a burst** and leave stale pixels on screen forever, with no test failing.

`_deferPresent()` is therefore the only place that flag is set, and every deferral leaves a wakeup behind: the fence reply when the fence is what we are waiting on, its own timer when the interval is. The timer is cleared in `_teardownFrame()`, so `destroy()` cannot blit into a freed pixmap or hold the event loop. Verified empirically: after a burst ends, the final frame lands 12 ms later.

## Testing

651 tests pass (645 before). Six new cases in the existing mock-X style:

- the first blit after a quiet moment is immediate (synchronous, no `await` at all);
- a burst is paced to one blit per interval;
- **the last blit of a burst still lands, carrying the final region** — the regression above;
- regions marked during a deferral coalesce into the one present that follows;
- `frameInterval: 0` keeps the old unpaced behaviour;
- `destroy()`/teardown cancels a held blit.

The mock gained a blit waiter (`nextCopy()`), because a blit that lands on a timer cannot be observed with `await tick()`. That is also why the one existing test that did two blits microseconds apart — "the region does not leak into the next frame" — now awaits the blit instead of a tick; its subject is region accounting, and that assertion is unchanged.

Formatting note: `prettier --check` flags `lib/window.js`, `test/frame-pacing.test.js` and `docs/window.md`, but it does so on `master` too and prettier is not wired into CI, so I left formatting alone rather than bury the change in an unrelated reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
