### PR TITLE
feat: _NET_WM_SYNC_REQUEST, so window managers can pace interactive resizes

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -58,6 +58,9 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 - `frameInterval: ms` — minimum time between paced frames, and the minimum
   time between blits (default `16`, ~60 fps; `0` disables both gates). Also
   writable later as `wnd.frameInterval`.
+- `syncRequest: true` — let the window manager pace interactive resizes to
+  this window's repaint rate (see
+  [Resize synchronization](#resize-synchronization--syncrequest--enablesyncrequest))
 
 ## Double buffering (backing store)
 
@@ -368,7 +371,42 @@ app.createWindow({ protocols: ['WM_DELETE_WINDOW'] });
 
 For `WM_DELETE_WINDOW` specifically there is no need to do this by hand:
 listening for [`close`](#closing--onclose-ev--evpreventdefault) advertises
-it for you.
+it for you. `_NET_WM_SYNC_REQUEST` has its own opt-in too, below — adding
+that atom here on its own advertises a protocol the window cannot answer,
+which is worse than staying quiet, because the counter a window manager
+then looks for is not there.
+
+### Resize synchronization — `syncRequest` / `enableSyncRequest()`
+
+Without this, a window manager driving an interactive resize has no idea
+when the client has actually repainted: it sends `ConfigureNotify` as fast
+as the pointer moves and the window lags behind the frame being dragged.
+`_NET_WM_SYNC_REQUEST` (EWMH §6.2) closes that loop — the WM sends a serial
+before each resize and waits for the window to echo it back once the new
+size is on screen, so the resize runs at the rate the client can paint.
+
+```js
+const wnd = app.createWindow({ width: 800, height: 600, syncRequest: true });
+wnd.map();
+
+// or, when map() follows immediately and the ordering matters:
+await wnd.enableSyncRequest();
+wnd.map();
+```
+
+The counter and its `_NET_WM_SYNC_REQUEST_COUNTER` property must exist
+before the window leaves the withdrawn state, because that is when the
+window manager reads them — hence the awaitable form. Everything after that
+is automatic: the acknowledgement is queued behind the requests that
+repaint, so the WM hears about a frame only once the server has drawn it,
+and a request that needs no repaint (a move, or a resize to the size the
+window already is) is answered by a watchdog rather than left hanging.
+
+Opt-in, and silently inert when the server has no SYNC extension or the
+window manager does not use the protocol. Only basic (single-counter)
+synchronization is implemented; the extended two-counter form is about
+frame-timing feedback rather than resize pacing, and a compositor that
+supports it falls back to basic mode on its own.
 
 The property is a **set**, so these are read-modify-write and return
 promises: `addProtocol`, `removeProtocol`, `setProtocols(names)` to replace

--- a/lib/window.js
+++ b/lib/window.js
@@ -355,6 +355,13 @@ export default class Window extends Drawable {
     // (see docs/window.md "Frames, coalescing and slow connections")
     this._coalesce = args.coalesceEvents !== false;
     this._frameSyncEnabled = args.frameSync !== false;
+    // _NET_WM_SYNC_REQUEST (see enableSyncRequest): the counter the window
+    // manager watches, the value it last asked for, and the watchdog that
+    // guarantees an answer even when nothing repaints
+    this._syncCounter = null;
+    this._syncRequestAtom = 0;
+    this._syncPending = null;
+    this._syncWatchdog = null;
     this.frameInterval = args.frameInterval ?? 16;
     this.frameLatency = null;
     this._frame = {
@@ -487,6 +494,12 @@ export default class Window extends Drawable {
     if (args.alwaysOnTop) {
       this.setAlwaysOnTop(true);
     }
+    if (args.syncRequest && !args.id) {
+      // fire and forget: the window manager only reads the counter when it
+      // starts managing the window, and map() is the caller's next line at
+      // the earliest. `await wnd.enableSyncRequest()` when that is too close.
+      this.enableSyncRequest().catch((err) => this.app.options.onXError?.(err));
+    }
 
     X.event_consumers[this.id] = this;
     this.on('event', (ev) => {
@@ -542,7 +555,10 @@ export default class Window extends Drawable {
       this.emit(eventName, ntkev);
       // a WM_DELETE_WINDOW ClientMessage is the window manager *asking*, and
       // 'close' is that question in a form an application can answer
-      if (eventName === 'message') this._emitCloseRequest(ntkev);
+      if (eventName === 'message') {
+        this._emitCloseRequest(ntkev);
+        this._handleSyncRequest(ntkev);
+      }
       // anything drawn during the handlers becomes visible in one blit
       if (this._dirty) this._present();
     });
@@ -841,7 +857,15 @@ export default class Window extends Drawable {
 
   _runFrame() {
     const f = this._frame;
-    if (!f.pending.size && !f.rafCbs.length && !f.needsRedraw && !this._dirty && !this._presentPending) return;
+    if (
+      !f.pending.size &&
+      !f.rafCbs.length &&
+      !f.needsRedraw &&
+      !this._dirty &&
+      !this._presentPending &&
+      this._syncPending == null
+    )
+      return;
     this._flushCoalesced();
     if (f.needsRedraw) {
       f.needsRedraw = false;
@@ -864,6 +888,9 @@ export default class Window extends Drawable {
       for (const entry of cbs) entry.cb(now);
     }
     if (this._dirty || this._presentPending) this._presentNow();
+    // covers a window with no backing store, and a resize that changed
+    // nothing: _presentNow did not run, but the frame is still "handled"
+    this._ackSyncRequest();
     this._armFence();
     this._armTimer();
   }
@@ -992,6 +1019,21 @@ export default class Window extends Drawable {
     if (f.presentTimer) {
       clearTimeout(f.presentTimer);
       f.presentTimer = null;
+    }
+    if (this._syncWatchdog) {
+      clearTimeout(this._syncWatchdog);
+      this._syncWatchdog = null;
+    }
+    // Destroying the counter releases any Await the window manager is
+    // blocked in, so a window that goes away mid-drag does not strand it.
+    if (this._syncCounter && this._sync) {
+      const counter = this._syncCounter;
+      this._syncCounter = null;
+      this._syncPending = null;
+      safeRelease(this.X, () => {
+        this._sync.DestroyCounter(counter);
+        this.X.ReleaseID(counter);
+      });
     }
     f.pending.clear();
     f.rafCbs = [];
@@ -1133,6 +1175,9 @@ export default class Window extends Drawable {
         this.X.CopyArea(this._backing.id, this.id, this._presentGc, r.x, r.y, r.x, r.y, r.w, r.h);
       }
     });
+    // queued behind the copies, so the window manager hears about the new size
+    // only once the server has drawn it
+    this._ackSyncRequest();
   }
 
   /**
@@ -1569,6 +1614,10 @@ export default class Window extends Drawable {
    *
    * `WM_DELETE_WINDOW` needs none of this by hand: listening for the
    * `'close'` event adds the protocol and decodes the message for you.
+   * `_NET_WM_SYNC_REQUEST` likewise has a real opt-in — `enableSyncRequest()`
+   * / `createWindow({ syncRequest: true })`. Adding that atom here instead
+   * advertises a protocol this window cannot answer, which is worse than not
+   * advertising it: the counter the window manager looks for is missing.
    *
    * Replaces the whole list. `addProtocol`/`removeProtocol` are the
    * accumulating forms, and the ones to reach for: the property is a *set*,
@@ -2602,6 +2651,116 @@ export default class Window extends Drawable {
    * existed — keeps behaving exactly as it did, rather than suddenly
    * acquiring a second handler that destroys it.
    */
+  /**
+   * Opt into `_NET_WM_SYNC_REQUEST` (EWMH §6.2): let the window manager pace
+   * an interactive resize to how fast this window actually repaints.
+   *
+   * Without it a WM has no idea when a resize has been drawn, so it either
+   * throws ConfigureNotify at the client as fast as the pointer moves — and
+   * the window lags behind the frame the user is dragging — or guesses with a
+   * timer. With it, the WM sends a serial before each resize and waits for
+   * this window to echo it back once the new size is on screen.
+   *
+   * Also available as `createWindow({ syncRequest: true })`. This is the
+   * awaitable form, for when `map()` follows immediately: the counter and the
+   * `_NET_WM_SYNC_REQUEST_COUNTER` property have to exist before the window
+   * leaves the withdrawn state, because that is when the WM reads them.
+   *
+   * Silently does nothing when the server has no SYNC extension — a WM that
+   * finds no counter simply drives the resize the old way.
+   *
+   * Only basic (single-counter) synchronization is implemented. The extended
+   * two-counter form buys frame-timing feedback rather than resize pacing, and
+   * its odd/even parity rules freeze the window if they are ever got wrong; a
+   * compositor that supports it falls back to basic mode on its own when the
+   * property holds one counter.
+   *
+   * @returns {Promise<Window>}
+   */
+  enableSyncRequest() {
+    if (this._syncCounter || this._destroyed) return Promise.resolve(this);
+    const X = this.X;
+    return new Promise((resolve, reject) => {
+      X.require('sync', (err, Sync) => {
+        if (err || !Sync || this._destroyed) return resolve(this); // no SYNC: stay quiet
+        this._sync = Sync;
+        const counter = X.AllocID();
+        safeRelease(X, () => Sync.CreateCounter(counter, 0));
+        this._syncCounter = counter;
+        // The dispatch path compares against both atoms, and node-x11 caches
+        // interned atoms per connection, so this is one round trip and no more.
+        this.atom('WM_PROTOCOLS').catch(() => {});
+        this._withAtoms(['_NET_WM_SYNC_REQUEST_COUNTER', '_NET_WM_SYNC_REQUEST'], (atoms) => {
+          this._syncRequestAtom = atoms._NET_WM_SYNC_REQUEST;
+          safeRelease(X, () =>
+            X.ChangeProperty(
+              0,
+              this.id,
+              atoms._NET_WM_SYNC_REQUEST_COUNTER,
+              X.atoms.CARDINAL,
+              32,
+              [counter]
+            )
+          );
+          // property first, protocol second: a window manager that sees the
+          // protocol advertised must always find the counter behind it
+          this.addProtocol('_NET_WM_SYNC_REQUEST').then(() => resolve(this), reject);
+        });
+      });
+    });
+  }
+
+  /**
+   * The window manager asking us to report when a resize has been painted.
+   *
+   * Only the value is recorded here — acknowledging now would claim a frame
+   * that has not been drawn. `_ackSyncRequest` sends it once the pixels are on
+   * their way. EWMH is explicit that only the *last* message is acknowledged,
+   * so a newer request simply overwrites an older one.
+   */
+  _handleSyncRequest(ev) {
+    if (!this._syncCounter || ev.format !== 32) return;
+    const X = this.X;
+    if (!X.atoms.WM_PROTOCOLS || ev.message_type !== X.atoms.WM_PROTOCOLS) return;
+    if (!this._syncRequestAtom || ev.data?.[0] !== this._syncRequestAtom) return;
+    // data[2] is the low half of the 64-bit request number, data[3] the high
+    this._syncPending = ev.data[3] * 0x100000000 + ev.data[2];
+    // Not every request leads to a repaint — a move, or a resize to the size
+    // we already are, leaves nothing dirty and no frame scheduled. The
+    // watchdog turns a missed acknowledgement into a stutter instead of a
+    // window manager that waits forever.
+    this._armSyncWatchdog();
+  }
+
+  _armSyncWatchdog() {
+    if (this._syncWatchdog || this._syncPending == null) return;
+    this._syncWatchdog = setTimeout(() => {
+      this._syncWatchdog = null;
+      this._ackSyncRequest();
+    }, Math.max(this.frameInterval, 16) * 2);
+    if (typeof this._syncWatchdog.unref === 'function') this._syncWatchdog.unref();
+  }
+
+  /**
+   * Answer the window manager's last sync request.
+   *
+   * Called after the requests that repaint have been queued, never before: X
+   * runs a client's requests in order, so a SetCounter queued behind the
+   * copies is executed behind them too, which is exactly the "having handled
+   * all repainting" the spec asks for. (It rides the same output batch, which
+   * is flushed before the event loop polls — no manual flush needed.)
+   */
+  _ackSyncRequest() {
+    const value = this._syncPending;
+    if (value == null || !this._syncCounter || !this._sync) return;
+    this._syncPending = null;
+    if (this._syncWatchdog) {
+      clearTimeout(this._syncWatchdog);
+      this._syncWatchdog = null;
+    }
+    safeRelease(this.X, () => this._sync.SetCounter(this._syncCounter, value));
+  }
+
   _emitCloseRequest(ev) {
     if (ev.format !== 32 || !this.listenerCount('close')) return;
     // node-x11 caches interned atoms per connection, so these are the ids

--- a/test/wm-sync-request.test.js
+++ b/test/wm-sync-request.test.js
@@ -1,0 +1,204 @@
+// _NET_WM_SYNC_REQUEST (EWMH 6.2) against a mock X client.
+//
+// The protocol is one rule — echo back the number the window manager sent,
+// once the resize has been painted — and one failure mode: an acknowledgement
+// that never goes out leaves the window manager waiting, which stalls the
+// interactive resize. So these tests are mostly about *ordering* (the counter
+// is set after the copies, never before) and about the paths where nothing
+// repaints at all.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick, setTimeout as sleep } from 'node:timers/promises';
+
+import Window from '../lib/window.js';
+
+let nextId = 0xd000;
+
+function makeMockApp({ withSync = true } = {}) {
+  const calls = { order: [], setCounter: [], created: [], destroyed: [], props: [] };
+  const Sync = {
+    CreateCounter(id, value) {
+      calls.created.push({ id, value });
+    },
+    SetCounter(counter, value) {
+      calls.order.push('SetCounter');
+      calls.setCounter.push({ counter, value });
+    },
+    DestroyCounter(counter) {
+      calls.destroyed.push(counter);
+    }
+  };
+  const atoms = { WM_PROTOCOLS: 100, CARDINAL: 6 };
+  let nextAtom = 500;
+  const named = {};
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    atoms,
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    ChangeProperty(mode, wid, atom, type, format, data) {
+      calls.props.push({ atom, type, format, data });
+    },
+    GetProperty(del, wid, atom, type, offset, len, cb) {
+      cb(null, { data: Buffer.alloc(0), type: 0, format: 0 });
+    },
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea() {
+      calls.order.push('CopyArea');
+    },
+    GetInputFocus(cb) {
+      cb(null, {});
+    },
+    InternAtom(onlyIfExists, name, cb) {
+      // node-x11 caches interned atoms per connection, so a name already in
+      // X.atoms keeps its id — including the ones seeded above
+      if (!named[name]) named[name] = atoms[name] ?? ++nextAtom;
+      atoms[name] = named[name];
+      cb(null, named[name]);
+    },
+    require(name, cb) {
+      if (name === 'sync' && withSync) return cb(null, Sync);
+      cb(new Error(`no ${name}`));
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display, options: {} }, calls, named };
+}
+
+async function syncWindow(opts) {
+  const { app, calls, named } = makeMockApp(opts);
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._backing = { id: 0xb100, width: 200, height: 100, destroy() {} };
+  wnd._presentGc = 0xc100;
+  await wnd.enableSyncRequest();
+  return { wnd, calls, named, app };
+}
+
+// the ClientMessage a window manager sends before each ConfigureNotify
+const syncMessage = (syncAtom, lo, hi = 0) => ({
+  type: 33,
+  format: 32,
+  message_type: 100, // WM_PROTOCOLS
+  data: [syncAtom, 0, lo, hi, 0]
+});
+
+test('enableSyncRequest publishes the counter before advertising the protocol', async () => {
+  const { wnd, calls, named } = await syncWindow();
+  assert.equal(calls.created.length, 1, 'a counter was created');
+  assert.equal(calls.created[0].value, 0, 'starting at 0');
+  const counterProp = calls.props.find((p) => p.atom === named._NET_WM_SYNC_REQUEST_COUNTER);
+  assert.ok(counterProp, '_NET_WM_SYNC_REQUEST_COUNTER was written');
+  assert.equal(counterProp.format, 32);
+  assert.deepEqual(counterProp.data, [calls.created[0].id], 'holds the counter xid');
+  wnd.destroy();
+});
+
+test('the acknowledgement is sent after the copies, carrying the exact value', async () => {
+  const { wnd, calls, named } = await syncWindow();
+  wnd.emit('event', syncMessage(named._NET_WM_SYNC_REQUEST, 0x2a));
+  assert.deepEqual(calls.setCounter, [], 'nothing acknowledged before the repaint');
+
+  wnd._markDirty({ x: 0, y: 0, w: 50, h: 50 });
+  await tick();
+
+  assert.deepEqual(
+    calls.order.slice(-2),
+    ['CopyArea', 'SetCounter'],
+    'the counter is set after the blit, not before'
+  );
+  assert.equal(calls.setCounter.length, 1);
+  assert.equal(calls.setCounter[0].value, 0x2a);
+  wnd.destroy();
+});
+
+test('a 64-bit request number is recomposed from its two halves', async () => {
+  const { wnd, calls, named } = await syncWindow();
+  wnd.emit('event', syncMessage(named._NET_WM_SYNC_REQUEST, 0x2a, 1)); // hi=1
+  wnd._markDirty();
+  await tick();
+  assert.equal(calls.setCounter[0].value, 0x10000002a);
+  wnd.destroy();
+});
+
+test('only the last request is acknowledged', async () => {
+  const { wnd, calls, named } = await syncWindow();
+  wnd.emit('event', syncMessage(named._NET_WM_SYNC_REQUEST, 11));
+  wnd.emit('event', syncMessage(named._NET_WM_SYNC_REQUEST, 12));
+  wnd.emit('event', syncMessage(named._NET_WM_SYNC_REQUEST, 13));
+  wnd._markDirty();
+  await tick();
+  assert.equal(calls.setCounter.length, 1, 'one acknowledgement, not three');
+  assert.equal(calls.setCounter[0].value, 13, 'the newest request number');
+  wnd.destroy();
+});
+
+test('a request that triggers no repaint is still acknowledged by the watchdog', async () => {
+  const { wnd, calls, named } = await syncWindow();
+  wnd.emit('event', syncMessage(named._NET_WM_SYNC_REQUEST, 7));
+  // nothing is marked dirty: a move, or a resize to the size we already are
+  await sleep(120); // longer than the watchdog (2x frameInterval, min 32ms)
+  assert.equal(calls.setCounter.length, 1, 'the window manager was not left waiting');
+  assert.equal(calls.setCounter[0].value, 7);
+  wnd.destroy();
+});
+
+test('messages that are not sync requests are ignored', async () => {
+  const { wnd, calls, named } = await syncWindow();
+  // a WM_DELETE_WINDOW-shaped message on the same message_type
+  wnd.emit('event', { type: 33, format: 32, message_type: 100, data: [999, 0, 5, 0, 0] });
+  // and a sync-atom message with the wrong format
+  wnd.emit('event', { type: 33, format: 8, message_type: 100, data: [named._NET_WM_SYNC_REQUEST, 0, 5, 0, 0] });
+  wnd._markDirty();
+  await tick();
+  await sleep(80);
+  assert.deepEqual(calls.setCounter, [], 'nothing acknowledged');
+  wnd.destroy();
+});
+
+test('a window without the opt-in never touches a counter', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._backing = { id: 0xb100, width: 200, height: 100, destroy() {} };
+  wnd._presentGc = 0xc100;
+  wnd.emit('event', syncMessage(501, 5));
+  wnd._markDirty();
+  await tick();
+  assert.deepEqual(calls.created, [], 'no counter created');
+  assert.deepEqual(calls.setCounter, [], 'nothing acknowledged');
+  wnd.destroy();
+});
+
+test('destroy releases the counter, unblocking a window manager waiting on it', async () => {
+  const { wnd, calls } = await syncWindow();
+  const counter = calls.created[0].id;
+  wnd.destroy();
+  assert.deepEqual(calls.destroyed, [counter]);
+});
+
+test('a server without SYNC degrades silently', async () => {
+  const { app, calls, named } = makeMockApp({ withSync: false });
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  await wnd.enableSyncRequest(); // must resolve, not reject
+  assert.deepEqual(calls.created, [], 'no counter');
+  assert.equal(wnd._syncCounter, null, 'and none recorded on the window');
+  // a sync request now arrives anyway: it must be ignored, not throw
+  wnd.emit('event', syncMessage(named._NET_WM_SYNC_REQUEST ?? 999, 5));
+  await sleep(80);
+  assert.deepEqual(calls.setCounter, [], 'nothing acknowledged, nothing thrown');
+  wnd.destroy();
+});


### PR DESCRIPTION
Item 3 of #180.

## Why

A window manager driving an interactive resize has no way to know when the client has actually repainted. Without a handshake it throws `ConfigureNotify` at the client as fast as the pointer moves, and the window lags behind the frame the user is dragging. `_NET_WM_SYNC_REQUEST` (EWMH §6.2) closes that loop: the WM sends a serial before each resize and waits for the client to echo it back once the new size is on screen, so the resize runs at the rate the client can actually paint.

The issue noted this was missing; the `setProtocols` docs made it worse by listing `_NET_WM_SYNC_REQUEST` alongside `WM_DELETE_WINDOW` as if adding the atom were enough. Adding it alone advertises a protocol the window cannot answer — a conforming WM then looks for `_NET_WM_SYNC_REQUEST_COUNTER`, finds nothing, and skips the protocol. That doc is corrected here.

## Using it

```js
const wnd = app.createWindow({ width: 800, height: 600, syncRequest: true });
wnd.map();

// or, when map() follows immediately and the ordering matters:
await wnd.enableSyncRequest();
wnd.map();
```

Opt-in, and silently inert when the server has no SYNC extension or the WM doesn't use the protocol. The counter and its property must exist **before** the window leaves the withdrawn state, since that is when the WM reads them — hence the awaitable form. The property is written before the protocol is advertised, so a WM that sees the protocol always finds the counter behind it.

## The ordering rule

The acknowledgement is queued **behind** the requests that repaint, never before them. X runs a client's requests in order, so a `SetCounter` sent after the copies is executed after them — which is exactly the spec's "having handled all repainting associated with the ConfigureNotify events". Only the last request is answered, as EWMH requires.

## The failure mode, and why it can't happen here

An acknowledgement that never goes out leaves the window manager waiting and stalls the resize. Four paths could do that, and all four are covered:

- **a window with no backing store** — never blits, so the ack also fires from the end of the frame;
- **a resize to the size we already are** (or a plain move) — nothing is marked dirty, same fix, plus `_runFrame`'s early return now accounts for a pending request;
- **destroy/unmap mid-drag** — `destroy()` releases the counter, which per the SYNC spec also releases any `Await` the WM is blocked in;
- **anything else** — a watchdog answers whatever is still outstanding, turning a missed ack into a stutter rather than a freeze.

## Scope

Basic single-counter synchronization only. The extended two-counter form buys frame-timing feedback rather than resize pacing, and its odd/even parity rules **freeze the window** if they are ever got wrong (odd = "mid-frame, don't composite me"). A compositor that supports extended mode falls back to basic on its own when the property holds one counter, so there is no downside to stopping here.

## Testing

Verified end to end against Xorg with a second connection playing the window manager: the property and protocol land, the request arrives, and the counter reads back carrying the exact value — including both paths where nothing repaints.

Nine unit tests in the existing mock-X style cover the ordering (`['CopyArea', 'SetCounter']`, in that order), the 64-bit split across `data[2]`/`data[3]`, last-request-wins, the watchdog, non-sync messages on the same `message_type`, a window that never opted in, counter teardown, and silent degradation on a server without SYNC. **669 tests pass.**

Note this could not be tested against the live desktop's WM: Compiz doesn't advertise `_NET_WM_SYNC_REQUEST` (mutter, kwin, xfwm4 and marco do), hence the hand-driven WM side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
