### PR TITLE
feat: blit with the Present extension, opt-in per window

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -55,6 +55,8 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 - `coalesceEvents: false` — deliver every noisy event individually (see
   [Frames, coalescing and slow connections](#frames-coalescing-and-slow-connections))
 - `frameSync: false` — don't pace frames with a server round-trip fence
+- `present: true` — blit with the Present extension instead of `CopyArea`
+  (see [Blitting with Present](#blitting-with-present--present-true))
 - `frameInterval: ms` — minimum time between paced frames, and the minimum
   time between blits (default `16`, ~60 fps; `0` disables both gates). Also
   writable later as `wnd.frameInterval`.
@@ -85,6 +87,41 @@ automatically (opt out with `createWindow({ backingStore: false })`):
 
 Foreign windows (`{ id }`) and windows drawing via the `'opengl'` or
 `'x11'` contexts are not double-buffered.
+
+### Blitting with Present — `present: true`
+
+By default a frame's dirty rectangles go out as one `CopyArea` each, and
+because each rectangle costs a request, scattered damage is collapsed into
+the box around it when the split stops paying for itself (see
+`scrollRegion` above and the note on blit lists). With
+`createWindow({ present: true })` the frame becomes a single `PresentPixmap`
+carrying an update region instead:
+
+```js
+const wnd = app.createWindow({ width: 800, height: 600, present: true });
+// or, to know whether it took effect:
+await wnd.enablePresent();
+```
+
+Two things follow. A frame is a fixed two requests however fragmented the
+damage is — measured here, eight scattered rectangles went from 8 requests to
+2 — and the exact rectangles are sent, so the bounding-box collapse is no
+longer needed and pixels outside the damage are never touched. Presents are
+also scheduled by the server against the display's refresh rather than run on
+arrival, so a burst cannot produce more updates than the output can show; the
+server drops superseded frames itself.
+
+Worth being precise about what this does **not** do: under a compositing
+window manager the window is redirected, so this schedules the server's copy
+into the redirect pixmap — the compositor still composites on its own
+schedule. Aligning with *that* is what the extended counters of
+[`_NET_WM_SYNC_REQUEST`](#resize-synchronization--syncrequest--enablesyncrequest)
+are for, and ntk implements the basic form only.
+
+Opt-in, and inert unless both Present and XFixes are available — blits fall
+back to `CopyArea`, which stays correct at all times, so the two paths can
+even alternate. The frame clock is unchanged: frames are still paced by the
+fence and the interval, not by the display's refresh.
 
 ### `wnd.scrollRegion(rect, dx, dy)` → boolean
 

--- a/lib/window.js
+++ b/lib/window.js
@@ -362,6 +362,13 @@ export default class Window extends Drawable {
     this._syncRequestAtom = 0;
     this._syncPending = null;
     this._syncWatchdog = null;
+    // Present-based blits (see enablePresent): the extension objects, the
+    // XFixes region reused as the update region, and the serial the server
+    // echoes back in its completion events
+    this._presentExt = null;
+    this._fixesExt = null;
+    this._updateRegion = 0;
+    this._presentSerial = 0;
     this.frameInterval = args.frameInterval ?? 16;
     this.frameLatency = null;
     this._frame = {
@@ -499,6 +506,11 @@ export default class Window extends Drawable {
       // starts managing the window, and map() is the caller's next line at
       // the earliest. `await wnd.enableSyncRequest()` when that is too close.
       this.enableSyncRequest().catch((err) => this.app.options.onXError?.(err));
+    }
+    if (args.present && !args.id) {
+      // fire and forget: until the extensions answer, blits use CopyArea,
+      // which is what they would have done anyway
+      this.enablePresent().catch((err) => this.app.options.onXError?.(err));
     }
 
     X.event_consumers[this.id] = this;
@@ -1035,6 +1047,17 @@ export default class Window extends Drawable {
         this.X.ReleaseID(counter);
       });
     }
+    if (this._updateRegion && this._fixesExt) {
+      const region = this._updateRegion;
+      this._updateRegion = 0;
+      this._presentExt = null;
+      const fixes = this._fixesExt;
+      this._fixesExt = null;
+      safeRelease(this.X, () => {
+        fixes.DestroyRegion(region);
+        this.X.ReleaseID(region);
+      });
+    }
     f.pending.clear();
     f.rafCbs = [];
     f.needsRedraw = false;
@@ -1143,6 +1166,76 @@ export default class Window extends Drawable {
     if (typeof f.presentTimer.unref === 'function') f.presentTimer.unref();
   }
 
+  /**
+   * Blit with the Present extension instead of `CopyArea`.
+   *
+   * A frame's dirty rectangles become one `PresentPixmap` with an update
+   * region, in place of one `CopyArea` per rectangle. Two things follow:
+   * a frame is a fixed two requests however fragmented the damage is, and
+   * `_blitList`'s bounding-box collapse becomes unnecessary — its whole
+   * premise is "each rectangle costs a request", so with Present the exact
+   * rectangles are sent and pixels outside them are never touched.
+   *
+   * Presents are also scheduled by the server against the display's refresh
+   * rather than executed on arrival, so a burst cannot produce more updates
+   * than the output can show; the server drops superseded frames itself.
+   *
+   * Worth being precise about what this does *not* do: under a compositing
+   * manager the window is redirected, so this schedules the server's copy
+   * into the redirect pixmap — the compositor still composites on its own
+   * schedule. Aligning with *that* is what `_NET_WM_SYNC_REQUEST`'s extended
+   * counters are for.
+   *
+   * Opt-in via `createWindow({ present: true })`, and inert unless both
+   * Present and XFixes are available — blits fall back to `CopyArea`, which
+   * stays correct at all times, so the two paths can even alternate.
+   *
+   * @returns {Promise<Window>}
+   */
+  enablePresent() {
+    if (this._presentExt || this._destroyed) return Promise.resolve(this);
+    const X = this.X;
+    const need = (name) =>
+      new Promise((resolve) => X.require(name, (err, ext) => resolve(err ? null : ext)));
+    return Promise.all([need('present'), need('fixes')]).then(([present, fixes]) => {
+      if (!present || !fixes || this._destroyed) return this; // stay on CopyArea
+      this._updateRegion = X.AllocID();
+      safeRelease(X, () => fixes.CreateRegion(this._updateRegion, []));
+      this._presentExt = present;
+      this._fixesExt = fixes;
+      return this;
+    });
+  }
+
+  /**
+   * The Present form of the blit. Returns false when it did not happen, so
+   * the caller falls back to CopyArea — which is also what runs before the
+   * extensions have answered.
+   */
+  _presentWithExtension(rects) {
+    const P = this._presentExt;
+    if (!P || !this._fixesExt || !this._updateRegion) return false;
+    safeRelease(this.X, () => {
+      this._fixesExt.SetRegion(
+        this._updateRegion,
+        rects.map((r) => ({ x: r.x, y: r.y, width: r.w, height: r.h }))
+      );
+      this._presentExt.Pixmap(this.id, this._backing.id, {
+        serial: ++this._presentSerial,
+        update: this._updateRegion,
+        // Option.Copy forces the copy path. Without it the server may *flip*
+        // the pixmap to the screen and take ownership of it until an
+        // IdleNotify — and ntk reuses one grow-only backing pixmap, so
+        // drawing into it while the server owned it would paint the screen
+        // directly. Removing this needs a swap chain, not just a smaller diff.
+        options: P.Option.Copy
+        // targetMsc stays 0: "the next vblank", which is what we want. An
+        // explicit target only adds ways to fall behind.
+      });
+    });
+    return true;
+  }
+
   _presentNow() {
     this._presentPending = false;
     if (!this._backing) return;
@@ -1164,19 +1257,26 @@ export default class Window extends Drawable {
       if (x1 > x0 && y1 > y0) clamped.push({ x: x0, y: y0, w: x1 - x0, h: y1 - y0 });
     }
     if (!clamped.length) return;
-    const rects = this._blitList(clamped);
     // Stamped here rather than at the call sites so it is a true inter-blit
     // interval across all three of them, and only when pixels really move — a
     // present that copies nothing must not push the next one out.
     this._frame.lastPresentAt = performance.now();
-    // a paced frame can fire after the connection started closing
-    safeRelease(this.X, () => {
-      for (const r of rects) {
-        this.X.CopyArea(this._backing.id, this.id, this._presentGc, r.x, r.y, r.x, r.y, r.w, r.h);
-      }
-    });
-    // queued behind the copies, so the window manager hears about the new size
-    // only once the server has drawn it
+    // Present sends the exact rectangles in one request, so the bounding-box
+    // collapse — which trades pixels for fewer requests — has nothing to buy
+    if (!this._presentWithExtension(clamped)) {
+      const rects = this._blitList(clamped);
+      // a paced frame can fire after the connection started closing
+      safeRelease(this.X, () => {
+        for (const r of rects) {
+          this.X.CopyArea(this._backing.id, this.id, this._presentGc, r.x, r.y, r.x, r.y, r.w, r.h);
+        }
+      });
+    }
+    // Queued behind whichever of the two put the pixels on their way, so the
+    // window manager hears about the new size only once the server has drawn
+    // it. Both paths must reach this: a window using Present *and*
+    // _NET_WM_SYNC_REQUEST would otherwise never answer, and the resize would
+    // stall.
     this._ackSyncRequest();
   }
 

--- a/test/present-blit.test.js
+++ b/test/present-blit.test.js
@@ -1,0 +1,200 @@
+// Blitting through the Present extension (lib/window.js) against a mock X
+// client. The dirty rectangles of a frame become one PresentPixmap with an
+// update region instead of one CopyArea each, and the CopyArea path stays
+// correct so the two can alternate.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import Window from '../lib/window.js';
+
+let nextId = 0xe000;
+
+function makeMockApp({ present = true, fixes = true } = {}) {
+  const calls = { copies: [], presents: [], regions: [], destroyedRegions: [] };
+  const Present = {
+    Option: { None: 0, Async: 1, Copy: 2, UST: 4, Suboptimal: 8 },
+    Pixmap(window, pixmap, opts) {
+      calls.presents.push({ window, pixmap, opts });
+    }
+  };
+  const Fixes = {
+    CreateRegion(region, rects) {
+      calls.regions.push({ region, rects, created: true });
+    },
+    SetRegion(region, rects) {
+      calls.regions.push({ region, rects });
+    },
+    DestroyRegion(region) {
+      calls.destroyedRegions.push(region);
+    }
+  };
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    atoms: {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    ChangeProperty() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea(src, dst, gc, sx, sy, dx, dy, width, height) {
+      calls.copies.push({ x: dx, y: dy, w: width, h: height });
+    },
+    GetInputFocus(cb) {
+      cb(null, {});
+    },
+    InternAtom(o, name, cb) {
+      cb(null, 1);
+    },
+    require(name, cb) {
+      if (name === 'present') return present ? cb(null, Present) : cb(new Error('no present'));
+      if (name === 'fixes') return fixes ? cb(null, Fixes) : cb(new Error('no fixes'));
+      cb(new Error(`no ${name}`));
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display, options: {} }, calls };
+}
+
+async function presentWindow(opts) {
+  const { app, calls } = makeMockApp(opts);
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._backing = { id: 0xb200, width: 200, height: 100, destroy() {} };
+  wnd._presentGc = 0xc200;
+  await wnd.enablePresent();
+  return { wnd, calls };
+}
+
+test('a frame becomes one PresentPixmap instead of a CopyArea per rectangle', async () => {
+  const { wnd, calls } = await presentWindow();
+  // two rectangles far enough apart that the CopyArea path would keep them split
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  wnd._markDirty({ x: 180, y: 90, w: 10, h: 10 });
+  await tick();
+
+  assert.deepEqual(calls.copies, [], 'no CopyArea');
+  assert.equal(calls.presents.length, 1, 'one PresentPixmap');
+  assert.equal(calls.presents[0].window, wnd.id);
+  assert.equal(calls.presents[0].pixmap, wnd._backing.id);
+  wnd.destroy();
+});
+
+test('the update region carries the exact rectangles, not their bounding box', async () => {
+  const { wnd, calls } = await presentWindow();
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  wnd._markDirty({ x: 180, y: 90, w: 10, h: 10 });
+  await tick();
+
+  const set = calls.regions.filter((r) => !r.created).at(-1);
+  assert.ok(set, 'the region was set');
+  assert.equal(set.rects.length, 2, 'both rectangles, not one box around them');
+  // XFixes wants {x, y, width, height}; ntk tracks {x, y, w, h}
+  assert.deepEqual(set.rects[0], { x: 0, y: 0, width: 10, height: 10 });
+  assert.deepEqual(set.rects[1], { x: 180, y: 90, width: 10, height: 10 });
+  assert.equal(calls.presents[0].opts.update, set.region, 'and it is the update region');
+  wnd.destroy();
+});
+
+test('Option.Copy is always set, so the server never takes the backing pixmap', async () => {
+  const { wnd, calls } = await presentWindow();
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  const opts = calls.presents[0].opts;
+  assert.equal(opts.options & 2, 2, 'Option.Copy');
+  assert.ok(!opts.targetMsc, 'no explicit target msc: the next vblank is what we want');
+  assert.ok(opts.serial > 0, 'serialised so completions can be correlated');
+  wnd.destroy();
+});
+
+test('a second frame reuses the same region and bumps the serial', async () => {
+  const { wnd, calls } = await presentWindow();
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  wnd._frame.lastPresentAt = -Infinity; // let the next blit through the pacer
+  wnd._markDirty({ x: 20, y: 20, w: 10, h: 10 });
+  await tick();
+
+  assert.equal(calls.presents.length, 2);
+  assert.equal(
+    calls.presents[0].opts.update,
+    calls.presents[1].opts.update,
+    'one region for the life of the window'
+  );
+  assert.ok(calls.presents[1].opts.serial > calls.presents[0].opts.serial);
+  wnd.destroy();
+});
+
+test('falls back to CopyArea when Present is missing', async () => {
+  const { wnd, calls } = await presentWindow({ present: false });
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.deepEqual(calls.presents, [], 'no present');
+  assert.equal(calls.copies.length, 1, 'blitted with CopyArea');
+  wnd.destroy();
+});
+
+test('falls back to CopyArea when XFixes is missing', async () => {
+  const { wnd, calls } = await presentWindow({ fixes: false });
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.deepEqual(calls.presents, [], 'no present without a region to update');
+  assert.equal(calls.copies.length, 1);
+  wnd.destroy();
+});
+
+test('a window that did not opt in keeps using CopyArea', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._backing = { id: 0xb200, width: 200, height: 100, destroy() {} };
+  wnd._presentGc = 0xc200;
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.deepEqual(calls.presents, []);
+  assert.equal(calls.copies.length, 1);
+  wnd.destroy();
+});
+
+test('destroy releases the update region', async () => {
+  const { wnd, calls } = await presentWindow();
+  const region = calls.regions.find((r) => r.created).region;
+  wnd.destroy();
+  assert.deepEqual(calls.destroyedRegions, [region]);
+});
+
+test('the sync-request acknowledgement still goes out on the Present path', async () => {
+  // A window using both features must still answer the window manager. The
+  // Present blit replaces the CopyArea loop, and an early return there would
+  // skip the acknowledgement and stall the resize — silently, since neither
+  // feature's own tests would notice.
+  const { app, calls } = makeMockApp();
+  const acks = [];
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._backing = { id: 0xb200, width: 200, height: 100, destroy() {} };
+  wnd._presentGc = 0xc200;
+  await wnd.enablePresent();
+  // stand in for an armed sync request rather than driving the whole protocol
+  wnd._syncCounter = 0xf000;
+  wnd._sync = { SetCounter: (counter, value) => acks.push({ counter, value }) };
+  wnd._syncPending = 0x2a;
+
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+
+  assert.equal(calls.presents.length, 1, 'blitted with Present');
+  assert.deepEqual(acks, [{ counter: 0xf000, value: 0x2a }], 'and still acknowledged');
+  wnd.destroy();
+});


### PR DESCRIPTION
Item 2 of #180, scoped to the half that is independently valuable and does not redefine the frame clock.

## What changes

A frame's dirty rectangles go out as one `CopyArea` each today. Because each rectangle costs a request, scattered damage has to be collapsed into the box around it once the split stops paying for itself — trading pixels the frame never touched for fewer requests.

With `createWindow({ present: true })` the frame becomes a single `PresentPixmap` carrying an XFixes update region:

| | CopyArea path | Present path |
|---|---|---|
| requests for 8 scattered rects | 8 | **2** (`SetRegion` + `PresentPixmap`) |
| rectangles sent | collapsed to the bounding box when fragmented | **exact** |

Presents are also scheduled by the server against the display's refresh rather than executed on arrival, so a burst cannot produce more updates than the output can show — the server drops superseded frames itself and says so in the completion event.

```js
const wnd = app.createWindow({ width: 800, height: 600, present: true });
// or, to know whether it took effect:
await wnd.enablePresent();
```

## `Option.Copy` is load-bearing

It is always set, and that is not incidental. Without it the server may **flip** the pixmap to the screen and take ownership of it until an `IdleNotify` — and ntk reuses one grow-only backing pixmap, so drawing into it while the server owned it would paint the screen directly. Removing that flag to chase a fullscreen fast path needs a 2-deep swap chain, not just a smaller diff, so it is a named constant with the hazard written next to it.

## What this does *not* do

The issue says Present would align presents with the compositor's frame. That is only half right, and worth correcting: under a compositing window manager the window is **redirected**, so `PresentPixmap` schedules the server's copy into the redirect pixmap at the vblank — the compositor still composites on its own schedule. `target_msc` controls when the server's copy happens, not when pixels reach the screen. The mechanism that genuinely handshakes with a compositor is the extended-counter half of `_NET_WM_SYNC_REQUEST` (#197 implements the basic half).

## Scope

The frame clock is deliberately untouched — frames are still paced by the fence and the interval, not by `CompleteNotify`. Moving the clock onto Present's completion events redefines what `frameSync`, `frameInterval` and `frameInFlight()` mean, needs a stall watchdog, and beats a 16 ms interval against a 13.3 ms vblank; that belongs in its own change, on top of this one. This half ships value on its own and is trivially revertible.

Opt-in, and inert unless both Present and XFixes are available: blits fall back to `CopyArea`, which stays correct at all times, so the two paths can even alternate.

## Testing

Verified against Xorg: the Present path produces pixels **identical** to the CopyArea path, clipped to the dirty region (pixels outside it untouched), and the request count drops as in the table.

Eight unit tests in the existing mock-X style cover the request shape, the exact rectangles reaching the region in XFixes' `{x,y,width,height}` form, `Option.Copy`, region reuse and serial bumping across frames, both fallbacks (no Present, no XFixes), a window that never opted in, and region teardown. **668 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
