### PR TITLE
perf(clip): route non-rectangular clip masks through the local rasterizer

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -17,8 +17,8 @@ const app2 = await createClient({ display: ':1' });
     as `'/app/fonts'` or `[bytes]` naming the faces the app ships, which is
     what an environment without fontconfig needs
     (see [fonts.md](fonts.md#environments-without-fontconfig));
-  - `rasterizer` / `rasterPolicy` — where fills and strokes are rasterized,
-    and the thresholds for that choice (see
+  - `rasterizer` / `rasterPolicy` — where fills, strokes and clip masks are
+    rasterized, and the thresholds for that choice (see
     [context-2d.md](context-2d.md#where-drawings-are-rasterized));
   - `glxVisual` — visual id `getContext('opengl')` should use instead of
     querying the server for one (see [context-opengl.md](context-opengl.md));
@@ -57,8 +57,8 @@ const app2 = await createClient({ display: ':1' });
 - `app.fonts` — lazy [FontManager](fonts.md): font matching/loading, shaping
 - `app.clipboard` — lazy [Clipboard](clipboard.md): selection/clipboard
   transfer (`write()`/`read()`/`clear()`), text or arbitrary targets
-- `app.rasterizer` — the Rasterizer small fills and strokes go through;
-  writable, `null` sends every drawing to the server
+- `app.rasterizer` — the Rasterizer small fills, strokes and clip masks go
+  through; writable, `null` sends every drawing to the server
   ([context-2d.md](context-2d.md#swapping-the-rasterizer))
 - `app.rasterPolicy` — the thresholds for that choice, merged over
   `DEFAULT_RASTER_POLICY`

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -225,6 +225,15 @@ An icon-sized drawing takes the local route, and a wall of 400 of them costs
 (a full-window rounded rectangle) takes the server route, where a handful of
 trapezoids beat a megabyte of coverage.
 
+The same choice covers the a8 mask a **non-rectangular clip** builds: a
+`clip()` whose path is not a rectangle rasterizes its coverage into a temp the
+size of its bounding box, locally or as trapezoids, by the same policy. A
+rectangle-only clip stack still rasterizes nothing at all, so this is only
+reached by rounded corners and genuine paths. It matters where trapezoids are
+a software fallback: a screen of
+rounded cards can hold more clip masks than fills, and before this they were
+the one drawing no policy could move.
+
 Because what crosses the wire is **coverage, not colour**, the route is
 invisible to everything else: gradients, solid fills, `globalAlpha`, clip and
 composite ops all work identically either way, and a widget that draws through

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -325,14 +325,14 @@ class RenderingContext2d {
 
     this._clips = [];
     this._dropMasks();
-    for (const gc of [this._gc, this._fillMaskGC]) {
+    for (const gc of [this._gc, this._fillMaskGC, this._clipMaskGC]) {
       if (!gc) continue;
       safeRelease(this.X, () => {
         this.X.FreeGC(gc);
         this.X.ReleaseID(gc);
       });
     }
-    this._gc = this._fillMaskGC = null;
+    this._gc = this._fillMaskGC = this._clipMaskGC = null;
     this._gcs.length = 0;
 
     this._backgroundPicture = this._glyphSource = null;
@@ -1644,13 +1644,15 @@ class RenderingContext2d {
       drawable: tmpPixmap,
       format: R.a8,
     });
-    R.FillRectangles(
-      R.PictOp.Src,
-      tmpMask.id,
-      [0, 0, 0, 0],
-      [0, 0, bb.w, bb.h],
-    );
-    this._rasterizePolys(tmpMask, entry.polys, entry.rule, -bb.x, -bb.y);
+    if (!this._uploadClipCoverage(tmpPixmap, entry, bb)) {
+      R.FillRectangles(
+        R.PictOp.Src,
+        tmpMask.id,
+        [0, 0, 0, 0],
+        [0, 0, bb.w, bb.h],
+      );
+      this._rasterizePolys(tmpMask, entry.polys, entry.rule, -bb.x, -bb.y);
+    }
     R.Composite(
       op,
       tmpMask.id,
@@ -1667,6 +1669,96 @@ class RenderingContext2d {
     );
     tmpMask.destroy();
     tmpPixmap.destroy();
+  }
+
+  /**
+   * The clip-mask twin of `_uploadCoverage`: rasterize one clip entry here
+   * and PutImage the coverage into the bbox temp, instead of asking the
+   * server for trapezoids. Returns false — caller falls back to AddTraps —
+   * with no rasterizer, when the policy routes this shape to the server, or
+   * when the rasterizer declines.
+   *
+   * Without this the routing was only half applied. `_uploadCoverage` covers
+   * fills and strokes, so an app that set `rasterPolicy` to keep every
+   * drawing local still emitted an AddTraps per non-rectangular clip, and on
+   * glamor those were the whole remaining cost: a wall of 48 rounded cards
+   * spent 12 AddTraps a frame on clips alone (react-x11#199), 116ms of
+   * server drain per frame, with no policy able to reach them.
+   *
+   * PutImage writes Src, so it replaces the temp's clear as well.
+   */
+  _uploadClipCoverage(tmpPixmap, entry, bb) {
+    const rasterizer = this.window.app.rasterizer;
+    if (!rasterizer) return false;
+    const flat = [];
+    let edges = 0;
+    for (const p of entry.polys) {
+      if (p.pts.length < 6) continue;
+      flat.push(p.pts);
+      edges += p.pts.length / 2;
+    }
+    if (!flat.length) return false;
+    if (
+      routeRaster(bb.w, bb.h, edges, this.window.app.rasterPolicy) !== "local"
+    ) {
+      return false;
+    }
+
+    const coverage = rasterizer.rasterize({
+      polys: flat,
+      rule: entry.rule,
+      dx: -bb.x,
+      dy: -bb.y,
+      width: bb.w,
+      height: bb.h,
+    });
+    if (!coverage) return false;
+
+    // scanlines padded to 4 bytes, as in _uploadCoverage — and as there, a
+    // width that is already a multiple of 4 goes out as a view over the
+    // rasterizer's own bytes with no copy
+    const stride = (bb.w + 3) & ~3;
+    let data;
+    if (stride === bb.w) {
+      data = Buffer.isBuffer(coverage)
+        ? coverage
+        : Buffer.from(coverage.buffer, coverage.byteOffset, coverage.length);
+    } else {
+      data = Buffer.alloc(stride * bb.h);
+      for (let y = 0; y < bb.h; ++y) {
+        Buffer.from(coverage.buffer, coverage.byteOffset + y * bb.w, bb.w).copy(
+          data,
+          y * stride,
+        );
+      }
+    }
+    this.X.PutImage(
+      2,
+      tmpPixmap.id,
+      this._clipGC(tmpPixmap),
+      bb.w,
+      bb.h,
+      0,
+      0,
+      0,
+      8,
+      data,
+    );
+    return true;
+  }
+
+  /**
+   * GC for uploading coverage into a clip temp. Created against the first
+   * temp and kept: every one of them is depth 8 on the same root, which is
+   * all a GC binds to, and the temps themselves come and go per clip entry.
+   */
+  _clipGC(tmpPixmap) {
+    if (!this._clipMaskGC) {
+      this._clipMaskGC = this.X.AllocID();
+      this._gcs.push(this._clipMaskGC);
+      this.X.CreateGC(this._clipMaskGC, tmpPixmap.id);
+    }
+    return this._clipMaskGC;
   }
 
   _rebuildClipMask() {

--- a/test/clip-lazy.test.js
+++ b/test/clip-lazy.test.js
@@ -129,3 +129,110 @@ test("restore drops the mask and later rect clips stay virtual", async () => {
   assert.deepEqual(at(img, 50, 50), [0, 0, 255], "inside the rect clip");
   assert.ok(isWhite(at(img, 20, 20)), "outside it");
 });
+
+// The clip mask's own routing (#177): a non-rectangular entry is coverage
+// like any other, so it goes through the same local/server decision as a
+// fill. Before this it always went to the server, which meant an app that
+// asked for everything local still paid an AddTraps per rounded clip — and
+// on glamor that fallback is the whole frame cost.
+
+/** Run `draw` on a fresh context under `policy`, counting AddTraps. */
+async function underPolicy(policy, draw) {
+  if (policy) app.options.rasterPolicy = policy;
+  else delete app.options.rasterPolicy;
+  const ctx = freshCtx();
+  const traps = countingTraps(ctx, () => draw(ctx));
+  const img = await read(ctx);
+  delete app.options.rasterPolicy;
+  return { traps, img };
+}
+
+const roundedClipFill = (ctx) => {
+  ctx.save();
+  ctx.beginPath();
+  ctx.roundRect(10, 10, 80, 80, 24);
+  ctx.clip();
+  ctx.fillStyle = "red";
+  ctx.fillRect(0, 0, W, H);
+  ctx.restore();
+};
+
+test("a rounded clip rasterizes locally when the policy allows", async () => {
+  const local = await underPolicy(
+    { maxArea: Infinity, bytesPerEdge: Infinity, maxBytes: 1 << 22 },
+    roundedClipFill,
+  );
+  assert.equal(local.traps, 0, "the clip mask went out as coverage");
+  assert.deepEqual(at(local.img, 50, 50), [255, 0, 0], "center filled");
+  assert.ok(isWhite(at(local.img, 12, 12)), "the corner the radius cuts off");
+  assert.ok(isWhite(at(local.img, 95, 95)), "outside the clip");
+});
+
+test("...and falls back to trapezoids when the policy says server", async () => {
+  const server = await underPolicy(
+    { maxArea: 0, bytesPerEdge: 0, maxBytes: 0 },
+    roundedClipFill,
+  );
+  assert.ok(server.traps > 0, "the server route is still reachable");
+  assert.deepEqual(at(server.img, 50, 50), [255, 0, 0], "center filled");
+  assert.ok(isWhite(at(server.img, 12, 12)), "corner still cut");
+});
+
+test("both clip routes paint the same pixels", async () => {
+  const local = await underPolicy(
+    { maxArea: Infinity, bytesPerEdge: Infinity, maxBytes: 1 << 22 },
+    roundedClipFill,
+  );
+  const server = await underPolicy(
+    { maxArea: 0, bytesPerEdge: 0, maxBytes: 0 },
+    roundedClipFill,
+  );
+  let sum = 0;
+  let max = 0;
+  for (let i = 0; i < local.img.data.length; i++) {
+    const d = Math.abs(local.img.data[i] - server.img.data[i]);
+    sum += d;
+    if (d > max) max = d;
+  }
+  const mean = sum / local.img.data.length;
+  // the two rasterizers antialias the corner arc slightly differently;
+  // everything else must agree
+  assert.ok(mean < 2, `mean channel difference ${mean.toFixed(2)}`);
+});
+
+test("a clip temp GC is created once and freed with the context", async () => {
+  app.options.rasterPolicy = {
+    maxArea: Infinity,
+    bytesPerEdge: Infinity,
+    maxBytes: 1 << 22,
+  };
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext("2d");
+  let created = 0;
+  const realCreateGC = ctx.X.CreateGC;
+  ctx.X.CreateGC = function (...args) {
+    created += 1;
+    return realCreateGC.apply(this, args);
+  };
+  try {
+    for (let i = 0; i < 4; i++) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.roundRect(10 + i, 10, 60, 60, 20);
+      ctx.clip();
+      ctx.fillStyle = "red";
+      ctx.fillRect(0, 0, W, H);
+      ctx.restore();
+    }
+  } finally {
+    ctx.X.CreateGC = realCreateGC;
+    delete app.options.rasterPolicy;
+  }
+  assert.ok(
+    created <= 2,
+    `one GC for the temps, not one per clip (${created})`,
+  );
+  ctx.destroy();
+  assert.equal(ctx._clipMaskGC, null, "and it is released with the context");
+  pixmap.destroy();
+});


### PR DESCRIPTION
Refs #177.

## The hole

`routeRaster` was only half applied. `_uploadCoverage` serves the fill and stroke paths, but `_applyPolyClip` — the a8 mask a non-rectangular `clip()` builds — always went to the server as trapezoids and **never consulted the policy at all**.

So an app that set `rasterPolicy` to keep every drawing local still emitted an `AddTraps` per rounded clip, and there was no knob that could reach them. On a glamor-class server, where `AddTraps` is a software fallback that maps its whole target pixmap, that residue was the entire frame cost.

Attributed by stack, with the policy set to always-local, on a wall of 48 rounded cards repainting in full ([react-x11#199](https://github.com/sidorares/react-x11/pull/199)):

```
248 calls  1984 traps  AddTraps < _rasterizePolys < _applyPolyClip
                                < _intersectClip < _materializeClipMask
```

100% of them. Zero from fills or strokes.

## The change

`_uploadClipCoverage` is the clip-mask twin of `_uploadCoverage`: same policy, same decline-and-fall-back contract, same 4-byte scanline padding, and `PutImage`'s `Src` semantics replace the temp's clear exactly as they do for fills. A rectangle-only clip stack still rasterizes nothing at all — this is only reached by rounded corners and genuine paths.

The GC it uploads through is created against the first temp and kept: every temp is depth 8 on the same root, which is all a GC binds to, and the temps themselves come and go per clip entry. It is freed with the context alongside `_gc` and `_fillMaskGC`.

## Measured

Xorg 21.1.22, glamor on virgl (aarch64 VM), 6s of forced full repaints of the 48-cell wall, `rasterPolicy` set to always-local:

| | AddTraps/frame | server fence | fps |
|---|---|---|---|
| master | 12.0 | 116.9ms | 7.6 |
| this branch | **0.0** | **38.8ms** | **17.3** |

2.3x throughput from twelve clip masks per frame.

Under the **default** policy the residual trapezoid traffic on that scene is now entirely `_fillPolys` — the card backgrounds — which is the tuning question #177 is actually about. The clips are no longer in the way of measuring it.

## Correctness

- Four new tests in `test/clip-lazy.test.js`: the local route emits no traps and still cuts the corner, the server route stays reachable when the policy says so, both routes agree pixel-wise (mean channel difference < 2, arc antialiasing aside), and the temp GC is created once and released with the context.
- Full suite: 684 pass.
- Downstream: react-x11's 482 tests pass against this branch, and a frozen-animation capture of that 48-card scene is **pixel-identical** to master (0 of 780,000 pixels differ).

## Note for review

This reuses `rasterPolicy` as-is, so the change is purely "clips now obey the policy fills already obey". Whether a clip mask deserves *its own*, more aggressive thresholds is a real question — it is composited rather than drawn once, so the economics differ from a fill's — but that is a tuning decision for #177 rather than something this needs to settle.