### PR TITLE
fix(window): frameInFlight reports a present deferred by the inter-blit interval

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -203,9 +203,13 @@ discrete input's response *inside* the handler, so the pixels leave with the
 handler's own requests rather than on the next paced frame — a click's
 `:active` flip is one paint of a few hundred microseconds, and waiting a
 frame interval for it buys nothing. `wnd.frameInFlight()` is the gate to
-make that decision with: `false` means the server is caught up and drawing
-now costs nothing extra, `true` means a frame is already on its way and the
-present would only be deferred and coalesced with it. Gating on it saves the
+make that decision with: `false` means no blit is queued and drawing now
+costs nothing extra, `true` means one already is — because the fence is
+unanswered or because the minimum inter-blit interval is still running — and
+a paint now would only coalesce into it. Both gates are reported, since which
+one bites depends on the connection: the fence on a slow one, the inter-blit
+interval on a fast local server, where the fence for one wheel notch is
+answered before the next notch is even read. Gating on it saves the
 *painting* work in a burst — the blit itself is bounded either way, since the
 minimum inter-blit interval already folds a burst's followers into one
 catch-up frame (the first wheel notch still paints immediately).
@@ -280,9 +284,11 @@ All return `this` unless noted.
 - `getContext(name)` — `'2d'`, `'opengl'` or `'x11'`; see the context docs
 - `requestAnimationFrame(cb)` — returns an id, does not return `this`;
   `cancelAnimationFrame(id)` (see above)
-- `frameInFlight()` — returns a boolean, not `this`: whether the last frame's
-  fence is still unanswered. The gate for painting a discrete input's
-  response from its own handler instead of on the next paced frame (see
+- `frameInFlight()` — returns a boolean, not `this`: whether a blit this
+  window owes is still waiting to go out, because the last frame's fence is
+  unanswered or a present is deferred behind the inter-blit interval. The gate
+  for painting a discrete input's response from its own handler instead of on
+  the next paced frame (see
   [above](#frames-coalescing-and-slow-connections))
 - `createWindow(params)` — child window (`parent` preset to this window)
 - `createPixmap(params)` — pixmap defaulting to this window's size, depth 32

--- a/lib/window.js
+++ b/lib/window.js
@@ -1086,29 +1086,35 @@ export default class Window extends Drawable {
   }
 
   /**
-   * Whether the fence for the last frame is still unanswered — the server has
-   * not yet confirmed it consumed everything that frame drew.
+   * Whether a blit this window already owes is still waiting to go out —
+   * because the fence for the last frame is unanswered, or because a present
+   * is deferred behind the minimum inter-blit interval.
    *
    * The one bit of frame-clock state worth publishing, because it is the
    * difference between the two ways a toolkit can answer a discrete input.
    * Drawing the response inside the event handler costs a frame less latency:
    * the blit goes out with the handler's own requests (see the `_present()`
    * at the end of the event dispatch) instead of waiting for the next paced
-   * frame — provided the last blit is at least `frameInterval` old, which is
-   * what a discrete input arriving out of the blue always is. Drawing it while
-   * a frame is in flight costs a frame's *work* for nothing: the present is
-   * deferred until the ack and coalesces with the one already pending, so only
-   * the last paint is ever seen. So `false`
+   * frame. Drawing it when a blit is already queued costs a frame's *work* for
+   * nothing: the paint lands in the same backing store and coalesces into the
+   * present already pending, so only the last one is ever seen. So `false`
    * means "draw it now", `true` means "leave it to the frame clock" — which
    * is how a burst of discrete events (a spun wheel) paints its first notch
    * immediately and folds the rest into one catch-up frame.
    *
-   * Always `false` under `frameSync: false`: no fence is ever sent, so there
-   * is nothing to wait for, and a caller gating on this gets the unpaced
-   * behaviour that option asks for.
+   * Both gates have to be reported, not just the fence. The fence is the one
+   * that bites on a slow connection. The minimum inter-blit interval (#195) is
+   * the one that bites on a fast local server, where the fence for a notch is
+   * answered well before the next notch is even read, and what actually holds
+   * the burst back is the interval. Reporting only the fence there answers
+   * "draw it now" to every notch — the precise work this gate exists to skip.
+   *
+   * `false` whenever nothing gates blits at all: `frameSync: false` sends no
+   * fence and `frameInterval: 0` keeps no interval, so a caller who asked for
+   * both gets the unpaced behaviour those options ask for.
    */
   frameInFlight() {
-    return this._frame.inFlight;
+    return this._frame.inFlight || this._presentPending;
   }
 
   _present() {

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -266,6 +266,43 @@ test('a discrete handler that draws sees the gate open, then closed', async () =
   wnd.destroy();
 });
 
+// The same gate with the minimum inter-blit interval in play — which is the
+// default, and the case #195 added. On a local server the fence for one notch
+// is answered long before the next notch is read, so the fence alone reads
+// "draw it now" for the whole burst; the interval is what actually holds the
+// blits back, and the gate has to say so or every notch does its painting for
+// a present that coalesces the work away.
+test('the gate shuts behind a deferred blit, not just behind the fence', async () => {
+  const { wnd, calls, fences, nextCopy } = backedWindow({ frameInterval: 20 });
+  const gate = [];
+  wnd.on('mousedown', () => {
+    const shut = wnd.frameInFlight();
+    gate.push(shut);
+    if (!shut) wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 }); // as painting would
+  });
+  const notch = () => wnd.emit('event', { type: 4, x: 1, y: 1, keycode: 4 });
+
+  // one notch to start the interval running: nothing gates this one, so it
+  // blits with the handler's own requests and arms a fence
+  notch();
+  assert.equal(calls.CopyArea, 1, 'the first notch blitted');
+  fences.shift()(null); // as a local server does, between one notch and the next
+  const settled = nextCopy();
+
+  // three more, all inside the interval the first one started
+  notch();
+  notch();
+  notch();
+  assert.deepEqual(gate, [false, false, true, true], 'shut once a blit is queued');
+  assert.equal(calls.CopyArea, 1, 'and nothing more went out inside the burst');
+
+  await settled;
+  assert.equal(calls.CopyArea, 2, 'the burst caught up in one deferred blit');
+  fences.shift()(null);
+  assert.equal(wnd.frameInFlight(), false, 'and the gate is open again');
+  wnd._teardownFrame();
+});
+
 test('frameInFlight stays false when frameSync is off', async () => {
   const { app, fences } = makeMockApp();
   const wnd = new Window(app, { frameSync: false, frameInterval: 0 });


### PR DESCRIPTION
## The gap

#195 gave `_present` a second reason to defer a blit: the last one being newer
than `frameInterval`. That path marks `_presentPending` and leaves a timer
behind, but it never arms the fence — and `frameInFlight` reported the fence
alone, so it kept answering `false` for the whole of a burst.

That contradicts what the method documents, and what `docs/window.md` sells it
as: `false` means "draw it now", `true` means "leave it to the frame clock".
It is the gate a toolkit uses to decide whether to paint a discrete input's
response from inside its own handler. When a blit is already queued it should
not — the paint lands in the same backing store and coalesces into the present
already pending, so only the last one is ever seen.

## Which gate actually bites

The fence is the one that bites on a slow link, and that case was always
reported correctly. On a fast local server the fence for one wheel notch is
answered before the next notch is even read, so the interval is the thing
holding the burst back — and reporting only the fence answers "draw it now" to
every notch of a spun wheel. That is the precise work the gate exists to skip.

Downstream, react-x11 gates its discrete paints on this and painted all ten
notches of a wheel burst instead of one. Same pixels, ten times the work.
`_presentPending` is private and nothing else public means "a blit is already
queued", so a consumer cannot work around it without reaching into internals.

## The change

```js
frameInFlight() {
  return this._frame.inFlight || this._presentPending;
}
```

Still `false` when nothing gates blits at all: `frameSync: false` sends no
fence and `frameInterval: 0` keeps no interval, so a caller who asked for both
gets the unpaced behaviour those options ask for.

## Why the tests missed it

`a discrete handler that draws sees the gate open, then closed` covers exactly
this scenario, but builds the window with `frameInterval: 0` — which switches
off the very gate #195 added, leaving the default path untested.

The test added here uses a real interval and answers the fence between notches,
so the interval is provably the thing under test rather than the fence. It
fails on `master` and passes with the change.
