### PR TITLE
feat: support Node 18.19 by reaching builtins through a version-tolerant helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        # 18.19 is the engines floor and lacks process.getBuiltinModule
+        # (added in 20.16), so it exercises builtin.js's createRequire fallback.
+        node: ['18.19', 20, 22, 24]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,14 +156,20 @@ What that means in practice:
   markdown parser and syntax highlighter were subtly wrong (e.g. intra-word
   `_` emphasis) and are now thin adapters over `marked` and `highlight.js`,
   the same way math rendering uses `katex`.
-- **ESM**, Node >= 20.19. No TypeScript for now (a possible later migration —
-  keep JSDoc accurate instead).
+- **ESM**, Node >= 18.19. No TypeScript for now (a possible later migration —
+  keep JSDoc accurate instead). `process.getBuiltinModule` (Node >= 20.16) is
+  reached through `lib/builtin.js`, which falls back to `createRequire` below
+  that. `Symbol.dispose`/`using` (Node >= 20.4) degrade gracefully on 18: the
+  method is parked but inert, and `destroy()` + the GC fallback still run.
 - **Browser-bundleable lib/**: never statically import node builtins in
-  `lib/` — fetch them lazily via `process.getBuiltinModule('node:...')`
-  behind a capability check, and route environment-dependent behavior
-  through the pluggable hooks (FontSource for font lookup, `configureTex`
-  for KaTeX assets, HtmlView's `loadResource`, `createClient({ glxVisual })`)
-  so browser playgrounds can substitute implementations.
+  `lib/` — fetch them lazily via `builtin('node:...')` (which wraps
+  `process.getBuiltinModule` behind a capability check) and route
+  environment-dependent behavior through the pluggable hooks (FontSource for
+  font lookup, `configureTex` for KaTeX assets, HtmlView's `loadResource`,
+  `createClient({ glxVisual })`) so browser playgrounds can substitute
+  implementations. The only sanctioned static node imports are `node:events`
+  in `drawable.js` and `node:module` in `builtin.js` (enforced by
+  test/packaging.test.js).
 - Server-side resources (windows, pixmaps, pictures, glyphsets) must offer
   `destroy()`, `Symbol.dispose` and a `FinalizationRegistry` GC fallback.
 

--- a/lib/builtin.js
+++ b/lib/builtin.js
@@ -1,0 +1,47 @@
+// Reach a Node builtin from ESM across Node versions.
+//
+// `process.getBuiltinModule(id)` is the browser-safe accessor — the string is
+// a function argument, so no bundler treats it as a module specifier — but it
+// only exists on Node >= 20.16. ntk's floor is lower (Node 18.19, for
+// react-x11), and there is no browser-safe, synchronous way to reach a builtin
+// from ESM on an older Node: `getBuiltinModule` is the API that was added to
+// fill exactly that gap. So where it is absent we fall back to `createRequire`.
+//
+// The `node:module` import below is a real specifier and the one place in lib/
+// allowed to statically import a builtin other than node:events — a sanctioned
+// exception in test/packaging.test.js, scoped to this file. A *browser* bundle
+// of the text stack must stub this one specifier, but the fallback that uses it
+// never runs in a browser (guarded on process.versions.node) and ntk ships no
+// browser build. It is not a top-level await, so the CJS/SEA bundle path (see
+// docs/packaging.md) is unaffected.
+import { createRequire } from 'node:module';
+
+let _require;
+
+// One createRequire bound to ntk, made lazily. Builtins ('node:*') resolve
+// regardless of the base URL, so this also serves callers that resolve a
+// package in ntk's own dependency graph (e.g. KaTeX's font directory).
+function req() {
+  return (_require ??= createRequire(import.meta.url));
+}
+
+/**
+ * `process.getBuiltinModule(id)` with a Node-18 fallback.
+ * @param {string} id e.g. 'node:child_process'
+ * @returns the builtin module, or `undefined` outside Node (a browser
+ *   embedding of the text stack — supply a custom FontSource / callback there).
+ */
+export function builtin(id) {
+  const p = globalThis.process;
+  if (!p?.versions?.node) return undefined;
+  if (typeof p.getBuiltinModule === 'function') return p.getBuiltinModule(id);
+  return req()(id);
+}
+
+/**
+ * A `require` for resolving packages in ntk's dependency graph.
+ * @returns {NodeRequire|null} `null` outside Node.
+ */
+export function nodeRequire() {
+  return globalThis.process?.versions?.node ? req() : null;
+}

--- a/lib/fontconfig.js
+++ b/lib/fontconfig.js
@@ -1,8 +1,10 @@
-// node:child_process is fetched lazily (not via static import) so that
-// browser bundles of the package never try to resolve it; in non-node
+// node:child_process is fetched lazily (via builtin(), not a static import) so
+// that browser bundles of the package never try to resolve it; in non-node
 // environments use a custom FontSource instead (see text/fontsource.js).
+import { builtin } from './builtin.js';
+
 function childProcess() {
-  return globalThis.process?.getBuiltinModule?.('node:child_process');
+  return builtin('node:child_process');
 }
 
 function execFileSync(...args) {

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,6 +1,7 @@
 import jpeg from 'jpeg-js';
 import { PNG } from 'pngjs';
 
+import { builtin } from './builtin.js';
 import { fromStraightRgba, pixelLayout } from './imagedata.js';
 import Picture from './picture.js';
 
@@ -126,7 +127,7 @@ export function decodeImage(buffer) {
 export async function loadImage(source) {
   if (typeof source === 'string' || source instanceof URL) {
     // lazy builtin lookup: browser bundles must not depend on node:fs
-    const fsp = globalThis.process?.getBuiltinModule?.('node:fs/promises');
+    const fsp = builtin('node:fs/promises');
     if (!fsp) {
       throw new Error('loadImage: file paths need node — pass the encoded bytes instead');
     }

--- a/lib/text/fontsource.js
+++ b/lib/text/fontsource.js
@@ -30,10 +30,11 @@
 // fontconfig: ntk ships no fonts, so the app has to hand over the ones it
 // ships, and the spec is the short way to say so.
 //
-// node:fs is fetched through `getBuiltinModule` inside the path branch rather
-// than imported, because this file is the one the browser bundle keeps — its
-// whole purpose is running the text stack without a filesystem. Do not turn
-// that into a static import (test/packaging.test.js fails if you do).
+// node:fs is fetched lazily through builtin() inside the path branch, never a
+// direct static import, because this file is the one the browser bundle keeps
+// — its whole purpose is running the text stack without a filesystem. See
+// builtin.js for how the lazy lookup stays version-tolerant.
+import { builtin } from '../builtin.js';
 import { charsetHas, matchSortedSync, noFontsError, prewarm, supported } from '../fontconfig.js';
 import Font from './font.js';
 
@@ -267,7 +268,7 @@ const ACCEPTED =
   'docs/fonts.md';
 
 function fs() {
-  const mod = globalThis.process?.getBuiltinModule?.('node:fs');
+  const mod = builtin('node:fs');
   if (!mod) {
     throw new Error(
       'ntk: a font path can only be read in node. In a browser, fetch the font ' +

--- a/lib/widgets/htmlview.js
+++ b/lib/widgets/htmlview.js
@@ -1,6 +1,7 @@
 import { selectAll } from 'css-select';
 import { textContent } from 'domutils';
 import { parseDocument } from 'htmlparser2';
+import { builtin } from '../builtin.js';
 import Yoga from '../yoga.js';
 
 import { decodeImage, Image } from '../image.js';
@@ -467,15 +468,14 @@ export default class HtmlView {
     // default policy: local files, only relative to an explicit baseUrl.
     // node builtins are fetched lazily — in environments without them
     // (browser bundles) pass a `loadResource` callback instead.
-    const getBuiltin = globalThis.process?.getBuiltinModule;
-    const fs = getBuiltin?.call(process, 'node:fs');
+    const fs = builtin('node:fs');
     if (!fs || !this.baseUrl) return null;
     let base = this.baseUrl;
     if (typeof base === 'string' && !/^[a-z][a-z0-9+.-]*:/i.test(base)) {
       // filesystem path; point at the directory itself when given one
       let p = base;
       if (!/[/\\]$/.test(p) && fs.existsSync(p) && fs.statSync(p).isDirectory()) p += '/';
-      base = getBuiltin.call(process, 'node:url').pathToFileURL(p);
+      base = builtin('node:url').pathToFileURL(p);
     }
     const url = new URL(src, base);
     if (url.protocol !== 'file:') return null;

--- a/lib/widgets/tex.js
+++ b/lib/widgets/tex.js
@@ -21,14 +21,11 @@
 import { parseSvgPath } from '../path.js';
 import { flatten } from '../rasterize.js';
 import { trapezoidize } from '../trapezoid.js';
+import { builtin, nodeRequire } from '../builtin.js';
 import Font from '../text/font.js';
 
-// node builtins are fetched lazily so browser bundles never resolve them;
-// there, inject the assets with configureTex() instead.
-function nodeRequire() {
-  const mod = globalThis.process?.getBuiltinModule?.('node:module');
-  return mod ? mod.createRequire(import.meta.url) : null;
-}
+// node builtins are fetched lazily (nodeRequire/builtin) so browser bundles
+// never resolve them; there, inject the assets with configureTex() instead.
 
 // katex is sizable — load it on first formula, not on package import
 let katex = null;
@@ -82,8 +79,8 @@ function katexFontFiles() {
           'TeX rendering: KaTeX fonts cannot be read here — inject them with configureTex({ fonts })'
         );
       }
-      const { readdirSync } = process.getBuiltinModule('node:fs');
-      const { dirname, join } = process.getBuiltinModule('node:path');
+      const { readdirSync } = builtin('node:fs');
+      const { dirname, join } = builtin('node:path');
       fontDir = join(dirname(require.resolve('katex/package.json')), 'dist', 'fonts');
       fontFiles = new Set(readdirSync(fontDir).filter((f) => f.endsWith('.ttf')));
     }

--- a/lib/window.js
+++ b/lib/window.js
@@ -1,5 +1,6 @@
 import x11 from 'x11';
 
+import { builtin } from './builtin.js';
 import { safeRelease } from './cleanup.js';
 import Drawable from './drawable.js';
 import { packIcons, unpackIcons } from './imagedata.js';
@@ -1917,7 +1918,7 @@ export default class Window extends Drawable {
   /** os.hostname(), looked up once, and absent in a browser bundle. */
   static _hostname() {
     if (Window._cachedHostname === undefined) {
-      const os = globalThis.process?.getBuiltinModule?.('node:os');
+      const os = builtin('node:os');
       Window._cachedHostname = os?.hostname?.() ?? null;
     }
     return Window._cachedHostname;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=18.19.0"
   },
   "dependencies": {
     "bidi-js": "^1.0.3",

--- a/test/packaging.test.js
+++ b/test/packaging.test.js
@@ -41,12 +41,20 @@ test('nothing in lib/ statically imports a node builtin', () => {
   // browser, so a node builtin has to be fetched lazily through
   // `process.getBuiltinModule` behind a capability check. A static import
   // breaks the bundle at build time, a long way from whoever added it.
-  // node:events is the one exception — lib/drawable.js extends EventEmitter.
+  //
+  // Two files are sanctioned exceptions, each for one specifier in that one
+  // file — anywhere else the same specifier is still an offender:
+  //   node:events — drawable.js extends EventEmitter.
+  //   node:module — builtin.js's createRequire is the Node < 20.16 fallback
+  //     for getBuiltinModule itself, guarded on process.versions.node and
+  //     never evaluated in a browser (a browser build stubs this one
+  //     specifier). See lib/builtin.js.
+  const ALLOW = { 'node:events': 'drawable.js', 'node:module': 'builtin.js' };
   const offenders = [];
   for (const path of sources(libDir)) {
-    const imports = readFileSync(path, 'utf8').matchAll(/from\s+['"](node:[\w/]+)['"]/g);
-    for (const [, mod] of imports) {
-      if (mod !== 'node:events') offenders.push(`${path.slice(libDir.length + 1)}: ${mod}`);
+    const rel = path.slice(libDir.length + 1);
+    for (const [, mod] of readFileSync(path, 'utf8').matchAll(/from\s+['"](node:[\w/]+)['"]/g)) {
+      if (ALLOW[mod] !== rel) offenders.push(`${rel}: ${mod}`);
     }
   }
   assert.deepEqual(

--- a/test/window-hints.test.js
+++ b/test/window-hints.test.js
@@ -3,6 +3,7 @@
 // Hermetic: runs against node-x11's in-process pure-JS X server and reads
 // the properties back over the wire.
 import assert from 'node:assert/strict';
+import { hostname } from 'node:os';
 import { after, before, test } from 'node:test';
 
 import xserver from 'x11/lib/xserver/index.js';
@@ -527,12 +528,11 @@ test('createWindow takes hint names at the top level and under hints', async () 
 // ---------------------------------------------------------------------
 
 test('a top-level window declares its process and host', async () => {
-  const os = process.getBuiltinModule('node:os');
   const wnd = app.createWindow({ width: 40, height: 40 });
   await settle();
 
   const machine = await getProp(wnd.id, app.X.atoms.WM_CLIENT_MACHINE);
-  assert.equal(machine.data.toString('latin1'), os.hostname());
+  assert.equal(machine.data.toString('latin1'), hostname());
   const pid = await wnd.getProperty('_NET_WM_PID', { as: 'numbers' });
   assert.deepEqual(pid, [process.pid]);
 });

--- a/website/scripts/browser-shims/module.js
+++ b/website/scripts/browser-shims/module.js
@@ -1,0 +1,9 @@
+// Browser stub for node's `module`. lib/builtin.js imports `createRequire`
+// from here for its Node < 20.16 fallback, but that path is guarded on
+// process.versions.node and never runs in the browser — so this only has to
+// resolve at bundle time, never be called.
+module.exports = {
+    createRequire: () => () => {
+        throw new Error('ntk: createRequire is not available in the browser bundle');
+    }
+};

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -92,6 +92,9 @@ await esbuild.build({
     'node:path': path.join(shimsDir, 'path.js'),
     util: path.join(shimsDir, 'util.js'),
     'node:util': path.join(shimsDir, 'util.js'),
+    // createRequire, imported by lib/builtin.js for its node-only fallback
+    module: path.join(shimsDir, 'module.js'),
+    'node:module': path.join(shimsDir, 'module.js'),
     // heavy optional deps no playground demo needs
     // both entries: ntk imports the WASM-free 'yoga-layout/load'
     'yoga-layout': path.join(stubsDir, 'yoga-layout.js'),


### PR DESCRIPTION
`process.getBuiltinModule` lands in Node 20.16. Below that — on a real Node 18.19 — ntk's lazy builtin lookups returned `undefined` and threw `ntk: no fonts available … this is not a node environment`, so a working Node with fontconfig installed still crashed on the first text layout. The reported failure was an old Node, not a missing fontconfig.

This routes all six lazy-builtin sites through a new `lib/builtin.js`: `process.getBuiltinModule` when present, a `createRequire` fallback below 20.16. Converted sites: fontconfig child_process, font-source fs, image fs/promises, window os, tex module/fs/path, htmlview fs/url.

The engines floor drops to `>=18.19.0`, and the CI test matrix gains an 18.19 job — that version has no `getBuiltinModule`, so it exercises the fallback.

The fallback needs one static `node:module` import. It is sanctioned in `test/packaging.test.js` as a per-file exception, mirroring `node:events` in `drawable.js`, and guarded on `process.versions.node` so it never runs in a browser bundle. The website playground is a real browser build, so it stubs that one specifier through the existing `browser-shims` alias map — the same way it already stubs `node:fs`, `node:os` and `node:path`. `Symbol.dispose` and `using`, added in Node 20.4, degrade gracefully on 18: the disposal method is parked but inert, while `destroy()` and the `FinalizationRegistry` fallback still run.

One test read the expected hostname through `process.getBuiltinModule` directly; it now imports `node:os` statically, which test files may do.

Verified: full suite passes with `getBuiltinModule` forced absent to simulate 18.19; the website demo bundle builds and its demos run.
