### PR TITLE
feat(window): ARGB visual discovery and transparent windows

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -115,7 +115,12 @@ to the anchor point, but glyphs are not rotated/scaled — size text via
 - `fillRect(x, y, w, h)` — respects clip, transform, `globalAlpha` and the
   composite op
 - `strokeRect(x, y, w, h)` — outlines a rect without touching the current path
-- `clearRect(x, y, w, h)` — resets to opaque white (honors clip + transform)
+- `clearRect(x, y, w, h)` — resets to nothing (honors clip + transform).
+  What "nothing" is depends on the target: **transparent black** on a
+  drawable with an alpha channel — a depth-32 ARGB window, see
+  [Transparent windows](window.md#transparent-windows) — so a compositor
+  shows what is behind it, and **opaque white** anywhere else, since a
+  depth-24 window has no alpha to write and white is the paper it starts from
 - `drawImage(image, dx, dy)` / `drawImage(image, dx, dy, dw, dh)` /
   `drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh)` — draws an ntk
   [`Image`](images.md) (decoded PNG/JPEG). The image uploads to the server

--- a/docs/window.md
+++ b/docs/window.md
@@ -64,6 +64,37 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
   this window's repaint rate (see
   [Resize synchronization](#resize-synchronization--syncrequest--enablesyncrequest))
 
+## Transparent windows
+
+`app.findArgbVisual([screen])` looks for a 32-bit TrueColor visual and
+returns `{ visual, depth: 32 }`, or `null` where the server has none
+(XQuartz). Spread it into `createWindow` with a transparent background and
+the window has a real alpha channel: whatever it does not paint is blended
+away by the compositor.
+
+```js
+const argb = app.findArgbVisual();
+const wnd = app.createWindow({ ...argb, backgroundPixel: 0, width: 320, height: 180 });
+const ctx = wnd.getContext('2d');
+wnd.on('draw', () => {
+  ctx.clearRect(0, 0, 320, 180);        // transparent, not white — the window has alpha
+  ctx.fillStyle = 'rgba(32, 32, 36, 0.92)';
+  ctx.beginPath();
+  ctx.roundRect(0, 0, 320, 180, 16);    // the corners it skips stay empty
+  ctx.fill();
+});
+```
+
+That is a rounded window with **antialiased** edges, and no Shape extension
+anywhere: the corners are alpha, not a 1-bit mask. `backgroundPixel: 0` is
+transparent black rather than the server's white, so nothing flashes before
+the first paint — and the backing store clears to the same.
+
+The client does nothing else. No Composite extension calls, no EWMH
+property: a compositing manager blends any ARGB window automatically.
+Without one running, X shows the raw pixels and the transparent regions come
+out **black**. See `examples/transparent-popup.js`.
+
 ## Double buffering (backing store)
 
 Requesting a 2d context on a window you created enables double buffering

--- a/examples/transparent-popup.js
+++ b/examples/transparent-popup.js
@@ -1,0 +1,89 @@
+// Rounded transparent popup using a 32-bit ARGB visual and the compositor's
+// alpha blending.  Needs a running compositor (picom, kwin, mutter, …);
+// without one transparent regions render black.  XQuartz has no 32-bit
+// visuals, so this is Linux-only.
+//
+//   node examples/transparent-popup.js
+
+import { createClient } from '../lib/index.js';
+
+const app = await createClient();
+const argb = app.findArgbVisual();
+if (!argb) {
+  console.error('no 32-bit TrueColor visual — compositor + depth-32 support required');
+  process.exit(1);
+}
+
+const W = 320;
+const H = 180;
+const R = 16;
+
+const win = app.createWindow({
+  ...argb,
+  overrideRedirect: true,
+  backgroundPixel: 0,
+  width: W,
+  height: H,
+  x: 200,
+  y: 200,
+});
+
+const ctx = win.getContext('2d');
+
+win.on('draw', () => {
+  // clear to fully transparent
+  ctx.clearRect(0, 0, W, H);
+
+  // --- drop shadow (offset, blurred via stacked translucent rounds) ---
+  for (let i = 6; i > 0; i--) {
+    ctx.fillStyle = `rgba(0, 0, 0, ${0.02})`;
+    ctx.beginPath();
+    ctx.roundRect(i, i + 2, W - 1, H - 1, R + i);
+    ctx.fill();
+  }
+
+  // --- popup body: rounded rectangle with slight transparency ---
+  ctx.fillStyle = 'rgba(32, 32, 36, 0.92)';
+  ctx.beginPath();
+  ctx.roundRect(0, 0, W, H, R);
+  ctx.fill();
+
+  // --- 1 px border for definition ---
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.roundRect(0.5, 0.5, W - 1, H - 1, R - 0.5);
+  ctx.stroke();
+
+  // --- title text ---
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+  ctx.font = '15px sans-serif';
+  ctx.fillText('Transparent popup', 20, 36);
+
+  // --- body text ---
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.55)';
+  ctx.font = '13px sans-serif';
+  ctx.fillText('ARGB visual · compositor alpha blending', 20, 64);
+  ctx.fillText('No Shape extension — antialiased edges', 20, 84);
+
+  // --- colour swatches showing alpha blending ---
+  const swatches = [
+    'rgba(239, 68, 68, 0.8)',
+    'rgba(34, 197, 94, 0.8)',
+    'rgba(59, 130, 246, 0.8)',
+    'rgba(250, 204, 21, 0.8)',
+  ];
+  swatches.forEach((colour, i) => {
+    ctx.fillStyle = colour;
+    ctx.beginPath();
+    ctx.roundRect(20 + i * 52, 110, 40, 40, 8);
+    ctx.fill();
+  });
+});
+
+win.on('mousedown', () => {
+  app.close();
+});
+
+win.map();
+console.log('transparent popup mapped — click it to close');

--- a/lib/app.js
+++ b/lib/app.js
@@ -146,6 +146,26 @@ export default class App {
     return chooseGLXConfig(this, spec);
   }
 
+  /**
+   * Find a 32-bit TrueColor visual with an alpha channel, for per-pixel
+   * transparent windows (ARGB). Returns `{ visual, depth: 32 }` — pass
+   * these to `createWindow()` together with `backgroundPixel: 0`. Returns
+   * `null` when the server has no such visual (XQuartz, for example).
+   *
+   * The compositor blends the window's alpha channel automatically; no
+   * Composite extension calls or EWMH properties are needed from the client.
+   * Without a running compositor, transparent regions render black.
+   */
+  findArgbVisual(screen = 0) {
+    const depths = this.display.screen[screen].depths;
+    const visuals = depths?.[32];
+    if (!visuals) return null;
+    for (const [id, visual] of Object.entries(visuals)) {
+      if (visual.class === 4) return { visual: Number(id), depth: 32 };
+    }
+    return null;
+  }
+
   rootWindow(screen = 0) {
     return new Window(this, { id: this.display.screen[screen].root });
   }

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -284,6 +284,9 @@ class RenderingContext2d {
         : depth === 8
           ? this.Render.a8
           : this.Render.rgb24;
+    // Does the target have a real alpha channel? Only then is "transparent"
+    // a colour it can hold, which is what clearRect turns on.
+    this._hasAlpha = depth === 32;
     this.picture = new Picture(this.window.app, {
       drawable: target,
       format,
@@ -1363,12 +1366,19 @@ class RenderingContext2d {
   // ------------------------------------------------------------------
   // drawing
 
+  // Clearing means "back to nothing", and what nothing looks like depends on
+  // whether the target can hold transparency. A depth-32 ARGB window gets
+  // transparent black, the canvas spec's answer, and the compositor shows
+  // whatever is behind it. Anything else has no alpha channel to write, so
+  // clearing stays opaque white — the paper an opaque window starts from,
+  // and what every caller predating ARGB windows expects.
   clearRect(x, y, w, h) {
+    const alpha = this._hasAlpha;
     if (matIsIdentity(this._m) && !this._clips.length) {
       this.Render.FillRectangles(
         this.Render.PictOp.Src,
         this.picture.id,
-        [1, 1, 1, 1],
+        alpha ? [0, 0, 0, 0] : [1, 1, 1, 1],
         [x, y, w, h],
       );
       this._markDirty();
@@ -1376,11 +1386,18 @@ class RenderingContext2d {
     }
     const tmp = new Path2D();
     tmp.rect(x, y, w, h);
-    // clear = opaque white, ignoring alpha and the composite op (but
-    // honoring the clip), matching the identity fast path above
+    // Transformed or clipped, so the rect is a polygon and the erase has to
+    // run through the coverage mask. OutReverse is `dst OUT src`: against an
+    // opaque source it scales the destination by 1 - coverage, erasing to
+    // transparent with an antialiased edge. PictOpSrc would take the whole
+    // bounding box with it, coverage or not. Opaque targets keep the old
+    // behaviour: paint white over the shape, ignoring alpha and the
+    // composite op but honoring the clip, matching the fast path above.
     this._fillPolys(flattenPath(tmp._cmds, this._m), "nonzero", {
-      src: this.createSolidPicture(1, 1, 1, 1),
-      op: this.Render.PictOp.Over,
+      src: alpha
+        ? this.createSolidPicture(0, 0, 0, 1)
+        : this.createSolidPicture(1, 1, 1, 1),
+      op: alpha ? this.Render.PictOp.OutReverse : this.Render.PictOp.Over,
       alpha: 1,
     });
   }

--- a/lib/window.js
+++ b/lib/window.js
@@ -697,27 +697,25 @@ export default class Window extends Drawable {
   }
 
   // grow-only backing pixmap (re)allocation, with headroom (see
-  // BACKING_GRANULARITY); new area is cleared to white
+  // BACKING_GRANULARITY); new area is cleared to the window's background
+  // (white for opaque windows, fully transparent for depth-32 ARGB ones)
   _allocBacking(w, h) {
     const cur = this._backing;
     if (cur && cur.width >= w && cur.height >= h) return;
     const roundUp = (v) => Math.ceil(v / BACKING_GRANULARITY) * BACKING_GRANULARITY;
     const newW = roundUp(Math.max(w, cur ? cur.width : 0));
     const newH = roundUp(Math.max(h, cur ? cur.height : 0));
+    const depth = this.depth || this.display.screen[0].root_depth;
     const pixmap = new Pixmap(this.app, {
       parent: this,
       width: newW,
       height: newH,
-      // must match the window's depth: CopyArea between drawables of
-      // different depths is a BadMatch
-      depth: this.depth || this.display.screen[0].root_depth
+      depth
     });
     if (!this._clearGc) {
-      // reusable across reallocs: a GC is valid for any drawable of the
-      // same screen and depth, so one outlives every backing pixmap
       this._clearGc = this.X.AllocID();
       this.X.CreateGC(this._clearGc, pixmap.id, {
-        foreground: this.display.screen[0].white_pixel,
+        foreground: depth === 32 ? 0 : this.display.screen[0].white_pixel,
         graphicsExposures: 0
       });
     }

--- a/test/clear-rect.test.js
+++ b/test/clear-rect.test.js
@@ -1,0 +1,107 @@
+// clearRect resets to "nothing", and what nothing is depends on the target.
+// A depth-32 drawable has an alpha channel, so it clears to transparent
+// black and a compositor shows what is behind it; a depth-24 one has no
+// alpha to write, so it keeps clearing to the opaque white it always did.
+//
+// The transformed/clipped path matters as much as the fast one: it goes
+// through a coverage mask, where the naive "composite transparent black over
+// it" is a no-op and leaves the pixels untouched.
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+let app = null;
+const W = 64;
+const H = 64;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+  });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+/** a context on a drawable of the given depth, painted opaque red first, so
+ *  a clear that does nothing is visible as red rather than as a pass */
+function ctxOfDepth(depth) {
+  const pixmap = app.createPixmap({ width: W, height: H, depth });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'red';
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+const pixels = async (ctx) => {
+  const img = await ctx.getImageData(0, 0, W, H);
+  return (x, y) => [...img.data.slice((y * W + x) * 4, (y * W + x) * 4 + 4)];
+};
+
+test('depth 32 clears to transparent black', async () => {
+  const ctx = ctxOfDepth(32);
+  ctx.clearRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(10, 10), [0, 0, 0, 0], 'nothing left, not even alpha');
+  assert.deepEqual(at(W - 1, H - 1), [0, 0, 0, 0]);
+});
+
+test('depth 24 still clears to opaque white', async () => {
+  const ctx = ctxOfDepth(24);
+  ctx.clearRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  const [r, g, b] = at(10, 10);
+  assert.ok(
+    r > 240 && g > 240 && b > 240,
+    `an opaque target has no transparency to clear to, got ${at(10, 10)}`,
+  );
+});
+
+test('a clear bounded to part of the surface leaves the rest alone', async () => {
+  const ctx = ctxOfDepth(32);
+  ctx.clearRect(0, 0, 32, 32);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(10, 10), [0, 0, 0, 0], 'inside the rect');
+  assert.deepEqual(at(40, 40).slice(3), [255], 'outside it is untouched');
+});
+
+test('a clipped clear erases only inside the clip, and really erases', async () => {
+  const ctx = ctxOfDepth(32);
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, 0, 32, H);
+  ctx.clip();
+  // the whole surface, narrowed by the clip — this is the masked path, where
+  // compositing transparent black with Over would silently do nothing
+  ctx.clearRect(0, 0, W, H);
+  ctx.restore();
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(10, 10), [0, 0, 0, 0], 'inside the clip is gone');
+  assert.deepEqual(at(50, 10).slice(3), [255], 'outside the clip survives');
+});
+
+test('a translated clear follows the transform', async () => {
+  const ctx = ctxOfDepth(32);
+  ctx.save();
+  ctx.translate(32, 0);
+  ctx.clearRect(0, 0, 32, 32);
+  ctx.restore();
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(40, 10), [0, 0, 0, 0], 'cleared where it was moved to');
+  assert.deepEqual(at(10, 10).slice(3), [255], 'not where it was asked from');
+});


### PR DESCRIPTION
Per-pixel transparent windows: a 32-bit ARGB visual the compositor blends, so a window can have rounded, antialiased corners without the Shape extension.

## What's here

- `App#findArgbVisual([screen])` → `{ visual, depth: 32 }`, or `null` where the server has none (XQuartz). Spread it into `createWindow` with `backgroundPixel: 0` and the window has an alpha channel.
- The backing store clears to 0 rather than `white_pixel` on depth 32 — `0x00ffffff` is non-premultiplied garbage that could flash before the first paint.
- `clearRect` clears to *transparent* black on a target with an alpha channel, and keeps clearing to opaque white everywhere else.
- `examples/transparent-popup.js`, and docs in `window.md` / `context-2d.md`.

## Why the second commit exists

The first commit alone didn't work — transparent windows came out with white corners. `clearRect` filled opaque white unconditionally, and clearing is the first thing a transparent window's draw handler does, so the whole window went white before anything else was painted. The rounded card then composited *over* that white: corners opaque, and a `rgba(32,32,36,0.92)` body landing at `a=255 r=49` instead of `a=235 r=29`.

Reading the backing pixmap back, before and after:

```
before   corner a=255 r=255 g=255 b=255     center a=255 r= 49 g= 49 b= 53
after    corner a=  0 r=  0 g=  0 b=  0     center a=235 r= 29 g= 29 b= 33
```

`a=235` is `0.92 × 255` and `r=29` is `32 × 0.92` — correctly premultiplied.

The clipped/transformed path needed a different fix from the fast path: it goes through a coverage mask, where compositing transparent black with `PictOpOver` is a no-op and silently leaves the pixels alone. It uses `PictOpOutReverse` against an opaque source, which scales the destination by `1 - coverage` — erasing exactly under the shape, antialiased edge intact. `PictOpSrc` would have taken the whole bounding box with it. `test/clear-rect.test.js` covers that case specifically; it fails against the naive fix.

## Testing

690 tests pass (5 new, hermetic — node-x11's in-process X server, no `$DISPLAY` needed). Verified live against Muffin 6.6.3 by reading pixels back from the backing store, including 30 consecutive partial repaints to confirm alpha doesn't accumulate.

## Note

Without a running compositor, X shows the raw pixels and transparent regions come out black — documented in `window.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)