### PR TITLE
fix(window): the backing store cleared to white, whatever the window's background

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -110,9 +110,26 @@ automatically (opt out with `createWindow({ backingStore: false })`):
   the window emits `draw` and `expose` (once per tick, with full-window
   geometry and `ev.synthetic = true`). Existing `wnd.on('expose', draw)`
   code keeps working, it just runs far less often.
-- The backing pixmap grows monotonically with the window (fresh area is
-  white); `ctx.getImageData` reads it directly, so results are valid even
+- The backing pixmap grows monotonically with the window, and what is
+  already drawn is **copied across** a grow — only the area the grow adds is
+  cleared. `ctx.getImageData` reads it directly, so results are valid even
   where the window is occluded on screen.
+- **What that area is cleared to follows the window's `backgroundPixel`**,
+  which is also what the server paints into exposed area on a window with no
+  backing store. Without one it is the screen's white, or transparent on a
+  depth-32 ARGB window. This matters more than it sounds: the pixmap is
+  rounded up to a 128px granularity, so a window dragged a little larger
+  grows into area that was cleared when the pixmap was created and is never
+  reallocated — a window that draws itself dark and left this at white shows
+  a white strip until something damages it.
+
+  ```js
+  const wnd = app.createWindow({ width: 400, height: 300, backgroundPixel: 0x1e2228 });
+  wnd.setBackgroundPixel(0xffffff);   // later — both the attribute and the clear
+  ```
+
+  `setBackgroundPixel` also recolours the pixmap's headroom, which holds no
+  content yet, so a later grow does not expose the previous colour.
 - Windows are created with NorthWest `bit-gravity`, so the server keeps old
   content anchored during a resize instead of clearing to background.
 

--- a/lib/window.js
+++ b/lib/window.js
@@ -348,6 +348,9 @@ export default class Window extends Drawable {
     this._foreign = !!args.id;
     this._backingOptOut = args.backingStore === false;
     this._backing = null;
+    // What the backing store clears to, and the window attribute it mirrors.
+    // Undefined means "nothing was asked for" — see _clearColour.
+    this._clearPixel = args.backgroundPixel;
     this._dirty = false;
     this._presentPending = false;
 
@@ -696,9 +699,60 @@ export default class Window extends Drawable {
     });
   }
 
+  /**
+   * The pixel the backing store's unpainted area is cleared to.
+   *
+   * A pixmap's contents start *undefined* — whatever was in that memory — so
+   * something has to be written before it can be presented, and the same goes
+   * for the region a grow adds. What that something is follows the window's
+   * own `backgroundPixel`, which is exactly what the server would paint into
+   * exposed area on a window with no backing store. Without one: transparent
+   * for a depth-32 ARGB window, and the screen's white otherwise.
+   */
+  _clearColour() {
+    if (this._clearPixel !== undefined) return this._clearPixel;
+    const depth = this.depth || this.display.screen[0].root_depth;
+    return depth === 32 ? 0 : this.display.screen[0].white_pixel;
+  }
+
+  /**
+   * The window's background colour, as an X pixel value.
+   *
+   * A double-buffered window has two of them and they have to agree: the X
+   * window attribute the server paints into exposed area, and the colour the
+   * backing store clears to. Setting one and not the other is why a resize
+   * could show white on a window that draws itself dark.
+   *
+   * The backing store's *headroom* — the area a future grow will expand
+   * into, which by definition holds nothing yet — is recoloured too, so a
+   * later resize does not expose the previous colour.
+   */
+  setBackgroundPixel(pixel) {
+    this._clearPixel = pixel;
+    if (this._destroyed) return this;
+    if (this._clearGc) this.X.ChangeGC(this._clearGc, { foreground: pixel });
+    if (!this._foreign) {
+      this.X.ChangeWindowAttributes(this.id, { backgroundPixel: pixel }, () => {});
+    }
+    const backing = this._backing;
+    if (backing && this._clearGc) {
+      const rects = [];
+      if (backing.width > this.width) {
+        rects.push(this.width, 0, backing.width - this.width, backing.height);
+      }
+      if (backing.height > this.height) {
+        rects.push(0, this.height, this.width, backing.height - this.height);
+      }
+      if (rects.length) this.X.PolyFillRectangle(backing.id, this._clearGc, rects);
+    }
+    return this;
+  }
+
   // grow-only backing pixmap (re)allocation, with headroom (see
-  // BACKING_GRANULARITY); new area is cleared to the window's background
-  // (white for opaque windows, fully transparent for depth-32 ARGB ones)
+  // BACKING_GRANULARITY). What is already drawn is carried across and only
+  // the region the grow adds is cleared (see _clearColour) — clearing the
+  // whole pixmap made the *entire* window flash the clear colour between a
+  // resize and the redraw, not just the new strip.
   _allocBacking(w, h) {
     const cur = this._backing;
     if (cur && cur.width >= w && cur.height >= h) return;
@@ -715,11 +769,21 @@ export default class Window extends Drawable {
     if (!this._clearGc) {
       this._clearGc = this.X.AllocID();
       this.X.CreateGC(this._clearGc, pixmap.id, {
-        foreground: depth === 32 ? 0 : this.display.screen[0].white_pixel,
+        foreground: this._clearColour(),
         graphicsExposures: 0
       });
     }
-    this.X.PolyFillRectangle(pixmap.id, this._clearGc, [0, 0, newW, newH]);
+    if (cur) {
+      // The new pixmap is strictly larger, so the old content lands at the
+      // same coordinates and only the L-shaped remainder is new.
+      this.X.CopyArea(cur.id, pixmap.id, this._clearGc, 0, 0, 0, 0, cur.width, cur.height);
+      const rects = [];
+      if (newW > cur.width) rects.push(cur.width, 0, newW - cur.width, newH);
+      if (newH > cur.height) rects.push(0, cur.height, cur.width, newH - cur.height);
+      if (rects.length) this.X.PolyFillRectangle(pixmap.id, this._clearGc, rects);
+    } else {
+      this.X.PolyFillRectangle(pixmap.id, this._clearGc, [0, 0, newW, newH]);
+    }
     if (cur) cur.destroy();
     this._backing = pixmap;
     this._backingValid = false;

--- a/test/backing-headroom.test.js
+++ b/test/backing-headroom.test.js
@@ -91,3 +91,115 @@ test('a grow step inside the headroom leaves the backing pixmap alone', async ()
 
   wnd.destroy();
 });
+
+// --- what the unpainted area is cleared to ------------------------------
+//
+// A pixmap's contents start undefined, so the backing store has to be written
+// before it can be presented — but the colour used to be the screen's white
+// full stop, with no way to change it. On a window that draws itself dark
+// that is a white flash on every resize, and it survives until something
+// damages the strip, because a grow inside the headroom reallocates nothing.
+
+function clearingApp() {
+  const { app, fences, calls } = makeMockApp();
+  calls.gcs = [];
+  calls.fills = [];
+  calls.copies = [];
+  app.X.CreateGC = (id, drawable, values) => calls.gcs.push({ id, values });
+  app.X.ChangeGC = (id, values) => calls.gcs.push({ id, values, changed: true });
+  app.X.PolyFillRectangle = (drawable, gc, rects) =>
+    calls.fills.push({ drawable, rects });
+  app.X.CopyArea = (src, dst, gc, sx, sy, dx, dy, width, height) =>
+    calls.copies.push({ src, dst, width, height });
+  return { app, fences, calls };
+}
+
+/** The foreground the clear GC is using, after any ChangeGC. */
+const clearPixel = (calls) =>
+  calls.gcs
+    .filter((g) => g.values && 'foreground' in g.values)
+    .map((g) => g.values.foreground)
+    .pop();
+
+test('the backing store clears to the window background, not to white', () => {
+  const { app, calls } = clearingApp();
+  const wnd = new Window(app, {
+    width: 200,
+    height: 100,
+    backgroundPixel: 0x1e2228
+  });
+  wnd._enableBackingStore();
+
+  assert.equal(clearPixel(calls), 0x1e2228, 'the colour the window asked for');
+  wnd.destroy();
+});
+
+test('with no background asked for, white — and 0 on an ARGB window', () => {
+  {
+    const { app, calls } = clearingApp();
+    const wnd = new Window(app, { width: 200, height: 100 });
+    wnd._enableBackingStore();
+    assert.equal(clearPixel(calls), 0xffffff, 'the screen white, as before');
+    wnd.destroy();
+  }
+  {
+    const { app, calls } = clearingApp();
+    const wnd = new Window(app, { width: 200, height: 100, depth: 32 });
+    wnd._enableBackingStore();
+    assert.equal(clearPixel(calls), 0, 'transparent, not white');
+    wnd.destroy();
+  }
+});
+
+test('setBackgroundPixel recolours the headroom a later grow will expose', () => {
+  const { app, calls } = clearingApp();
+  const wnd = new Window(app, { width: 200, height: 100 });
+  wnd._enableBackingStore();
+  const backing = wnd._backing;
+  calls.fills.length = 0;
+
+  wnd.setBackgroundPixel(0x1e2228);
+
+  assert.equal(clearPixel(calls), 0x1e2228, 'the clear GC followed');
+  const filled = calls.fills.filter((f) => f.drawable === backing.id);
+  assert.equal(filled.length, 1, 'the headroom was repainted');
+  // the L outside the 200x100 window, and nothing inside it: that area holds
+  // drawn content, and recolouring it would be a flash rather than a fix
+  const rects = filled[0].rects;
+  assert.deepEqual(
+    rects,
+    [200, 0, backing.width - 200, backing.height, 0, 100, 200, backing.height - 100],
+    'right strip then bottom strip, both outside the window'
+  );
+  wnd.destroy();
+});
+
+test('a grow carries the drawn content across instead of clearing it', async () => {
+  const { app, fences, calls } = clearingApp();
+  const wnd = new Window(app, { width: 200, height: 100, frameInterval: 0 });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._enableBackingStore();
+  const before = wnd._backing;
+  calls.fills.length = 0;
+  calls.copies.length = 0;
+
+  // past the headroom, so this really reallocates
+  wnd.emit('event', configure(600, 600));
+  await tick();
+  while (fences.length) fences.shift()(null);
+  await tick();
+
+  assert.notEqual(wnd._backing, before, 'reallocated');
+  const carried = calls.copies.find((c) => c.dst === wnd._backing.id);
+  assert.ok(carried, 'the old pixmap was copied into the new one');
+  assert.equal(carried.src, before.id);
+  assert.equal(carried.width, before.width);
+
+  // only the L-shaped remainder is cleared; a full-pixmap fill here is what
+  // made the whole window flash rather than just the new strip
+  const cleared = calls.fills.filter((f) => f.drawable === wnd._backing.id);
+  assert.equal(cleared.length, 1);
+  assert.deepEqual(cleared[0].rects.slice(0, 2), [before.width, 0]);
+  wnd.destroy();
+});

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -16,6 +16,8 @@ let nextId = 0xa000;
 
 function makeMockApp() {
   const calls = { CopyArea: 0, copies: [] };
+  /** Ids of pixmaps this mock handed out, so a copy *to* one is not a blit. */
+  const pixmaps = new Set();
   const fences = []; // pending GetInputFocus callbacks, released by tests
   // Waiters for the next blit. A blit held back by the minimum inter-blit
   // interval lands on a timer, so `await tick()` is not enough to observe it;
@@ -35,10 +37,16 @@ function makeMockApp() {
     ChangeWindowAttributes() {},
     ChangeProperty() {},
     CreateGC() {},
-    CreatePixmap() {},
+    CreatePixmap(id) {
+      pixmaps.add(id);
+    },
     FreePixmap() {},
     PolyFillRectangle() {},
     CopyArea(src, dst, gc, sx, sy, dx, dy, width, height) {
+      // A *present* is a copy to the window. Growing the backing store also
+      // copies — old pixmap to new, to carry the drawn content across a
+      // resize — and that is bookkeeping, not a frame going out.
+      if (pixmaps.has(dst)) return;
       calls.CopyArea++;
       calls.copies.push({ x: dx, y: dy, w: width, h: height });
       const wake = copyWaiters;


### PR DESCRIPTION
A pixmap's contents start undefined, so the backing store has to be written
before it can be presented — but the colour was the screen's white full stop,
with no way for a caller to change it. On a window that draws itself dark that
is a white flash on every resize.

It survives, too, which is what makes it a bug rather than a blink: the pixmap
is rounded up to a 128px granularity, so a window dragged a little larger grows
into area that was cleared when the pixmap was created and is **never
reallocated**. Nothing damages it, so the strip stays white until something
else does.

In `_allocBacking`, before this change, the clear GC was created once with

```
foreground: depth === 32 ? 0 : screen.white_pixel
```

and the whole pixmap was filled through it.

## What changes

**The clear follows the window's own `backgroundPixel`.** That is already what
the server paints into exposed area on a window with no backing store, so the
two agree by construction rather than by luck — a double-buffered window has
two backgrounds and they were free to disagree. Unset behaves exactly as before:
the screen's white, or transparent on a depth-32 ARGB window.

```js
const wnd = app.createWindow({ width: 400, height: 300, backgroundPixel: 0x1e2228 });
```

**`setBackgroundPixel` changes both halves afterwards**, for a window whose
colour follows something that can move underneath it — the desktop's light and
dark preference, say. It recolours the pixmap's headroom as well, since that
area holds no content yet and a later grow would otherwise expose the old
colour. It deliberately does *not* touch the area inside the window: that holds
drawn content, and repainting it would be a flash rather than a fix.

**A grow carries the drawn content across.** `CopyArea` from the old pixmap,
then clear only the L-shaped remainder. Clearing the whole new pixmap meant the
*entire* window flashed the clear colour between the resize and the redraw, not
just the strip the resize added. `_backingValid` is still cleared, so the
redraw that follows is unchanged — this is only about what is on screen in the
interval before it.

## Why not leave all painting to the consumer

That was the first instinct and it does not hold: a fresh pixmap is
uninitialised memory, and so is the region a grow adds. There is a real
interval between the pixmap existing and the consumer's first frame, and
something gets presented in it. The clear is necessary; the *colour* was the
bug.

## Tests

Four in `test/backing-headroom.test.js`: the clear follows `backgroundPixel`,
the unset cases still give white and 0, `setBackgroundPixel` repaints the
headroom and only the headroom, and a grow copies rather than clears.

One existing test needed a change. `test/frame-pacing.test.js` counted every
`CopyArea` as a present, and growing the backing store copies too — so the
mock now counts only copies whose destination is not a pixmap it handed out,
which is what "a frame went out" actually means.

## Found from

react-x11 sidorares/react-x11#213, making an app follow the desktop's light and
dark scheme. It works around this today by reaching into `_clearGc` and
`_backing`; that can come out once this ships.
