### PR TITLE
perf: flatten arcs from their own geometry instead of bisecting their cubics

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -184,7 +184,10 @@ Full canvas path surface:
   (error-bounded subdivision in device pixels, so curves stay smooth at any
   transform scale)
 - `arc(x, y, r, a0, a1[, ccw])`, `ellipse(x, y, rx, ry, rot, a0, a1[, ccw])`,
-  `arcTo(x1, y1, x2, y2, r)`
+  `arcTo(x1, y1, x2, y2, r)` — arcs are flattened from their own geometry
+  rather than by subdividing the curves they lower to, so they cost the
+  fewest chords the tolerance allows instead of the next power of two (see
+  [How curves are flattened](#how-curves-are-flattened))
 - `rect(x, y, w, h)`, `roundRect(x, y, w, h, radii)` — radii like the spec:
   a number, or an array of 1–4 numbers / `{x, y}` pairs. A rounded rect on
   integer geometry fills/strokes through cached server-side corner glyphs
@@ -198,11 +201,49 @@ Full canvas path surface:
   the composite op. Round-cap/join disks overlap the stroke body, so their
   coverage is accumulated in a clamped a8 mask and composited in a single
   pass — semi-transparent strokes (`globalAlpha < 1` or an alpha stroke
-  style) do not double-darken at the overlaps
+  style) do not double-darken at the overlaps. Disks are sized by the same
+  flatness tolerance as any other arc, so a 1px round cap is a triangle and
+  a very thick one stays smooth past where the old fixed ceiling of 32
+  segments started to show
 - `clip([path][, fillRule])` — intersects the clip region; restored by
   `restore()`
 - `isPointInPath([path, ]x, y[, fillRule])` — hit test in canvas (device)
   coordinates
+
+## How curves are flattened
+
+Everything curved is a polyline by the time it reaches a rasterizer, and how
+many segments that polyline has decides the cost of everything downstream:
+roughly a trapezoid per edge for a fill, a pair of triangles per segment for
+a stroke. The budget is a **flatness tolerance** — the furthest the polyline
+may stray from the true curve, `0.25` device pixels by default and the last
+argument of `flattenPath(cmds, matrix, tol)`.
+
+Curves get there two ways:
+
+- **Beziers** — `bezierCurveTo`, `quadraticCurveTo`, SVG curve data, font
+  outlines — are bisected until each piece is flat enough. The test is the
+  guaranteed bound on how far a cubic leaves its chord, three quarters of
+  the larger control-point distance.
+- **Arcs** — `arc`, `ellipse`, `arcTo`, `roundRect`, SVG `A` — lower to
+  cubics but remember the arc they came from, and are split into equal
+  angular steps straight from the sagitta: a chord spanning `θ` of a circle
+  of radius `R` misses by `R·(1 - cos(θ/2))`, so the fewest chords is
+  `ceil(sweep / 2·acos(1 - tol/R))`. Bisection could only land on powers of
+  two and overshot this by up to 2x — a quarter circle at r=256 took 32
+  chords where 18 are within tolerance.
+
+The arc tag carries the ellipse as a centre plus two semi-axis *vectors*,
+which an affine map takes to the same form, so the exact route survives any
+transform — rotation, non-uniform scale and shear included — and the
+tolerance is always measured in device pixels. Ellipses are bounded by their
+semi-major axis, which is exact for circles and conservative for eccentric
+ones. Arc endpoints stay bit-identical to the lowering, so a rounded
+corner still meets the straight edge it joins.
+
+A consequence worth knowing: the flattened polygon is *inscribed*, so a
+filled circle is short of `πr²` by up to what the tolerance allows (~1.6% at
+r=20) and never larger. Pass a smaller `tol` where that matters.
 
 ## Where drawings are rasterized
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -46,6 +46,100 @@ export function matIsIdentity(m) {
 }
 
 // --------------------------------------------------------------------------
+// arc tags
+//
+// A cubic emitted by ellipseCubics carries the arc it approximates, so the
+// flattener can subdivide the arc itself instead of rediscovering its shape
+// by bisecting the cubic (issue #213). The tag is the centre-plus-axis-
+// vectors form:
+//
+//   P(t) = (cx, cy) + u·cos t + v·sin t,   t from t0 to t1
+//
+// u and v are the semi-axis *vectors*, which is what makes the tag survive
+// transforms: an affine map takes this form to the same form — the centre
+// moves, u and v go through the linear part — where radii plus a rotation
+// angle would only survive a similarity, and a shear or a non-uniform scale
+// would have to drop the tag and fall back.
+//
+// The tag also carries its own start point (sx, sy), which the lowering
+// computes anyway. Flattening a cubic starts from the path's current point,
+// so the arc route is only valid when that point is where the arc begins —
+// true of every way a tagged cubic can be built here, and checked rather
+// than assumed, since a path that broke the invariant would otherwise be
+// drawn quietly wrong instead of falling back to bisection.
+//
+// Tags are treated as immutable: transformArc always builds a new one, so
+// Path2D copies and addPath can share them by reference.
+
+/** the flatness tolerance, in output pixels, everything here defaults to */
+export const FLATTEN_TOLERANCE = 0.25;
+
+// how many chords an arc may be split into, whatever the arithmetic says.
+// Only reachable through a degenerate tolerance (0 or negative); a real
+// drawing at tol 0.25 asks for ~800 chords for a full circle the size of
+// the largest addressable surface.
+const MAX_ARC_SEGMENTS = 4096;
+
+/**
+ * The fewest equal chords that approximate an arc within `tol`.
+ *
+ * A chord spanning angle θ of a circle of radius R misses the arc by the
+ * sagitta R·(1 - cos(θ/2)) at its midpoint, so the largest angle a chord may
+ * span is 2·acos(1 - tol/R) and the count follows by division. Recursive
+ * bisection can only land on powers of two and so overshoots this by up to
+ * 2x — an arc needing 9 chords used to get 16.
+ *
+ * @param {number} sweep total angle covered, radians (unsigned)
+ * @param {number} radius the arc's radius — for an ellipse, the largest
+ *   singular value of its axis matrix (see arcScale), which bounds the
+ *   sagitta everywhere on the curve
+ * @param {number} tol allowed deviation, in the same units as radius
+ */
+export function arcSegmentCount(sweep, radius, tol = FLATTEN_TOLERANCE) {
+  if (!(sweep > 0) || !(radius > 0)) return 1;
+  // tol >= 2R: the whole circle is within tolerance of a single chord
+  const cos = 1 - tol / radius;
+  if (!(cos > -1)) return 1;
+  const theta = 2 * Math.acos(Math.min(1, cos));
+  if (!(theta > 0)) return MAX_ARC_SEGMENTS; // tol <= 0: as fine as allowed
+  return Math.max(1, Math.min(MAX_ARC_SEGMENTS, Math.ceil(sweep / theta)));
+}
+
+/**
+ * The radius to measure an arc tag's sagitta against: the largest singular
+ * value of `[u | v]`, i.e. how far the map from the unit circle can stretch
+ * a distance. For a circle that is exactly its radius; for an ellipse it is
+ * the semi-major axis, which bounds the deviation everywhere on the curve
+ * (|A·d| <= σmax·|d|) and so is safe, if conservative on eccentric ones.
+ *
+ * σ1² + σ2² = ‖A‖_F² and σ1·σ2 = |det A| give it in closed form.
+ */
+function arcScale({ ux, uy, vx, vy }) {
+  const frob = ux * ux + uy * uy + vx * vx + vy * vy;
+  const det = ux * vy - uy * vx;
+  const disc = Math.sqrt(Math.max(0, frob * frob - 4 * det * det));
+  return Math.sqrt((frob + disc) / 2);
+}
+
+/** an arc tag through an affine map — the centre and start point move, the
+ *  axes go through the linear part; exact for every affine, shear and
+ *  reflection included */
+function transformArc(a, m) {
+  return {
+    cx: m[0] * a.cx + m[2] * a.cy + m[4],
+    cy: m[1] * a.cx + m[3] * a.cy + m[5],
+    ux: m[0] * a.ux + m[2] * a.uy,
+    uy: m[1] * a.ux + m[3] * a.uy,
+    vx: m[0] * a.vx + m[2] * a.vy,
+    vy: m[1] * a.vx + m[3] * a.vy,
+    sx: m[0] * a.sx + m[2] * a.sy + m[4],
+    sy: m[1] * a.sx + m[3] * a.sy + m[5],
+    t0: a.t0,
+    t1: a.t1
+  };
+}
+
+// --------------------------------------------------------------------------
 // elliptical arcs -> cubics
 
 /**
@@ -53,6 +147,9 @@ export function matIsIdentity(m) {
  * radii (rx, ry), rotated by phi, from angle a0 sweeping by da (signed,
  * |da| <= 2π). Returns { start: {x, y}, cmds: [{type:'C', ...}, ...] };
  * segments are split to <= 90° so the approximation error stays tiny.
+ *
+ * Each command carries an `arc` tag (see above) describing the piece of the
+ * true arc it stands for, which is what `flattenPath` subdivides.
  */
 export function ellipseCubics(cx, cy, rx, ry, phi, a0, da) {
   const cosPhi = Math.cos(phi);
@@ -67,6 +164,12 @@ export function ellipseCubics(cx, cy, rx, ry, phi, a0, da) {
     const y = ry * Math.cos(a);
     return [cosPhi * x - sinPhi * y, sinPhi * x + cosPhi * y];
   };
+
+  // the ellipse's semi-axis vectors, the form the arc tag keeps
+  const ux = rx * cosPhi;
+  const uy = rx * sinPhi;
+  const vx = -ry * sinPhi;
+  const vy = ry * cosPhi;
 
   const [sx, sy] = point(a0);
   const cmds = [];
@@ -87,7 +190,8 @@ export function ellipseCubics(cx, cy, rx, ry, phi, a0, da) {
       x2: x3 - k * dx3,
       y2: y3 - k * dy3,
       x: x3,
-      y: y3
+      y: y3,
+      arc: { cx, cy, ux, uy, vx, vy, sx: x0, sy: y0, t0: a, t1: b }
     });
     a = b;
   }
@@ -604,7 +708,12 @@ export function transformCommands(cmds, m) {
         const [x1, y1] = matApply(m, c.x1, c.y1);
         const [x2, y2] = matApply(m, c.x2, c.y2);
         const [x, y] = matApply(m, c.x, c.y);
-        out.push({ type: 'C', x1, y1, x2, y2, x, y });
+        const out_ = { type: 'C', x1, y1, x2, y2, x, y };
+        // an arc tag transforms exactly under any affine, so baking the CTM
+        // into the commands (which is what the context's default path does)
+        // keeps the arc route available downstream
+        if (c.arc) out_.arc = transformArc(c.arc, m);
+        out.push(out_);
         break;
       }
       case 'Q': {
@@ -667,13 +776,63 @@ function addCubic(pts, x0, y0, x1, y1, x2, y2, x3, y3, tol2, depth) {
 }
 
 /**
+ * Chords of the arc a tagged cubic stands for, appended to `pts`. Returns
+ * false — flatten the cubic instead — when the path's current point is not
+ * where the arc begins, so a caller that spliced commands together still
+ * gets a curve from where it actually is.
+ *
+ * The count comes from the sagitta formula rather than from bisecting the
+ * cubic, so an arc gets the fewest chords its tolerance allows instead of
+ * the next power of two (issue #213). The points are evaluated on the arc
+ * itself — closer to the geometry the caller asked for than the cubic
+ * proxy, whose own error is ~2.7e-4·R for the <=90° pieces used here.
+ *
+ * The last point is the command's own endpoint rather than a re-evaluated
+ * one, so consecutive segments still meet exactly, and an SVG arc whose
+ * final point was snapped to the requested endpoint keeps that snap.
+ */
+function addArcChords(pts, cmd, m, tol, x0, y0) {
+  const arc = m ? transformArc(cmd.arc, m) : cmd.arc;
+  const scale = arcScale(arc);
+  // The two agree bit-for-bit when the lowering produced both, so this only
+  // fires on spliced paths — and on the ~1e-13 drift where an SVG arc's
+  // endpoint was snapped and the next arc starts from the snapped value.
+  const slack = 1e-6 * (1 + scale);
+  if (Math.abs(x0 - arc.sx) > slack || Math.abs(y0 - arc.sy) > slack) {
+    return false;
+  }
+  const sweep = arc.t1 - arc.t0;
+  const n = arcSegmentCount(Math.abs(sweep), scale, tol);
+  for (let i = 1; i < n; i++) {
+    const t = arc.t0 + (sweep * i) / n;
+    const cos = Math.cos(t);
+    const sin = Math.sin(t);
+    pts.push(
+      arc.cx + arc.ux * cos + arc.vx * sin,
+      arc.cy + arc.uy * cos + arc.vy * sin
+    );
+  }
+  if (m) {
+    const [x, y] = matApply(m, cmd.x, cmd.y);
+    pts.push(x, y);
+  } else {
+    pts.push(cmd.x, cmd.y);
+  }
+  return true;
+}
+
+/**
  * Flatten normalized commands into polylines. `m` (optional affine) is
  * applied to control points before subdivision, so the flatness tolerance
  * `tol` (default 0.25) is measured in output/device pixels.
  *
+ * Cubics that came from an arc carry a tag and are subdivided from their own
+ * geometry (see addArcChords); genuine beziers — hand-built paths, SVG curve
+ * commands, font outlines — take the adaptive bisection route.
+ *
  * @returns {Array<{pts: number[], closed: boolean}>} flat [x0,y0,x1,y1,…]
  */
-export function flattenPath(cmds, m = null, tol = 0.25) {
+export function flattenPath(cmds, m = null, tol = FLATTEN_TOLERANCE) {
   if (m && matIsIdentity(m)) m = null;
   const tol2 = tol * tol;
   const polys = [];
@@ -698,6 +857,7 @@ export function flattenPath(cmds, m = null, tol = 0.25) {
         if (!pts) break;
         const x0 = pts.pts[pts.pts.length - 2];
         const y0 = pts.pts[pts.pts.length - 1];
+        if (c.arc && addArcChords(pts.pts, c, m, tol, x0, y0)) break;
         const [x1, y1] = p(c.x1, c.y1);
         const [x2, y2] = p(c.x2, c.y2);
         const [x, y] = p(c.x, c.y);

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -13,6 +13,7 @@ import {
 } from "./imagedata.js";
 import {
   Path2D,
+  arcSegmentCount,
   flattenPath,
   transformCommands,
   ellipseSegments,
@@ -994,7 +995,12 @@ class RenderingContext2d {
     // cap, and a disk at an interior vertex fills the bevel notch
     let hasRound = false;
     const r = thickness / 2;
-    const diskSegs = Math.max(8, Math.min(32, Math.ceil(r * 2)));
+    // A disk is an arc like any other: the sagitta formula sizes it to the
+    // flatness tolerance instead of a floor of 8 (which spent 16 triangles
+    // on the half-pixel cap of a 1px line) and a ceiling of 32 (which was
+    // coarse enough to show on a fat one). Three is the fewest that
+    // enclose any area at all.
+    const diskSegs = Math.max(3, arcSegmentCount(2 * Math.PI, r));
     const addDisk = (x, y) => {
       hasRound = true;
       let ex = x + r;

--- a/test/arc-flatten.test.js
+++ b/test/arc-flatten.test.js
@@ -1,0 +1,299 @@
+// Arc-aware flattening (issue #213): a cubic that came from an arc is
+// subdivided from the arc's own geometry — the fewest equal chords the
+// tolerance allows — instead of by bisecting the cubic, which could only
+// land on powers of two and overshot by up to 2x.
+//
+// The contract under test is two-sided: the polyline must stay within the
+// tolerance of the true arc (quality), and must not spend more chords than
+// the formula requires (the point of the change). Pure unit tests, no X.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  FLATTEN_TOLERANCE,
+  Path2D,
+  arcSegmentCount,
+  ellipseSegments,
+  flattenPath,
+  transformCommands
+} from '../lib/path.js';
+
+/** distance from a point to a segment */
+function distToSegment(px, py, ax, ay, bx, by) {
+  const vx = bx - ax;
+  const vy = by - ay;
+  const wx = px - ax;
+  const wy = py - ay;
+  const c1 = vx * wx + vy * wy;
+  if (c1 <= 0) return Math.hypot(px - ax, py - ay);
+  const c2 = vx * vx + vy * vy;
+  if (c2 <= c1) return Math.hypot(px - bx, py - by);
+  const t = c1 / c2;
+  return Math.hypot(px - (ax + t * vx), py - (ay + t * vy));
+}
+
+/**
+ * Worst distance from a densely sampled ellipse arc to the polyline — the
+ * measurement the tolerance is a promise about. The ellipse is given in the
+ * same centre-plus-axis-vectors form the arc tag uses, so a transformed
+ * expectation is expressed by transforming the axes.
+ */
+function maxDeviation(pts, { cx, cy, ux, uy, vx, vy, t0, t1 }, samples = 4000) {
+  let worst = 0;
+  for (let i = 0; i <= samples; i++) {
+    const t = t0 + ((t1 - t0) * i) / samples;
+    const px = cx + ux * Math.cos(t) + vx * Math.sin(t);
+    const py = cy + uy * Math.cos(t) + vy * Math.sin(t);
+    let best = Infinity;
+    for (let j = 0; j + 3 < pts.length; j += 2) {
+      const d = distToSegment(px, py, pts[j], pts[j + 1], pts[j + 2], pts[j + 3]);
+      if (d < best) best = d;
+    }
+    if (best > worst) worst = best;
+  }
+  return worst;
+}
+
+/** flatten a quarter arc of radius r (top-left corner orientation) */
+function quarterArc(r, m = null, tol = FLATTEN_TOLERANCE) {
+  const seg = ellipseSegments(r, r, r, r, 0, Math.PI, Math.PI * 1.5);
+  const cmds = [{ type: 'M', x: seg.start.x, y: seg.start.y }, ...seg.cmds];
+  const polys = flattenPath(cmds, m, tol);
+  return polys.length ? polys[0].pts : [];
+}
+
+// --------------------------------------------------------------- the formula
+
+test('arcSegmentCount is the sagitta formula, with the degenerate cases safe', () => {
+  // a chord spanning θ misses a circle of radius R by R(1 - cos(θ/2)); the
+  // returned count must be the fewest whose sagitta fits the tolerance
+  for (const r of [2, 4, 8, 16, 32, 64, 128, 256]) {
+    for (const sweep of [Math.PI / 2, Math.PI, 2 * Math.PI]) {
+      const n = arcSegmentCount(sweep, r, 0.25);
+      const sagitta = (k) => r * (1 - Math.cos(sweep / k / 2));
+      assert.ok(sagitta(n) <= 0.25 + 1e-12, `r=${r} n=${n} does not fit`);
+      assert.ok(n === 1 || sagitta(n - 1) > 0.25, `r=${r} n=${n} is not minimal`);
+    }
+  }
+  // tolerance at or above the diameter: one chord is enough by definition
+  assert.equal(arcSegmentCount(2 * Math.PI, 0.1, 0.25), 1);
+  // degenerate inputs never produce NaN, Infinity or 0 segments
+  assert.equal(arcSegmentCount(0, 10, 0.25), 1);
+  assert.equal(arcSegmentCount(Math.PI, 0, 0.25), 1);
+  assert.ok(Number.isInteger(arcSegmentCount(Math.PI, 10, 0)));
+  assert.ok(arcSegmentCount(Math.PI, 10, 0) > 0);
+});
+
+// ------------------------------------------------------- deviation conformance
+
+test('flattened arcs stay inside the tolerance at every radius', () => {
+  for (const r of [2, 3, 4, 6, 8, 12, 16, 32, 64, 128, 256]) {
+    const pts = quarterArc(r);
+    const dev = maxDeviation(pts, {
+      cx: r, cy: r, ux: r, uy: 0, vx: 0, vy: r,
+      t0: Math.PI, t1: Math.PI * 1.5
+    });
+    assert.ok(dev <= FLATTEN_TOLERANCE + 1e-9, `r=${r} deviates ${dev}`);
+  }
+});
+
+test('and spend exactly the chords the formula asks for — no power-of-two rounding', () => {
+  for (const r of [4, 8, 16, 32, 64, 128, 256]) {
+    const segs = quarterArc(r).length / 2 - 1;
+    const want = arcSegmentCount(Math.PI / 2, r);
+    assert.equal(segs, want, `r=${r}`);
+  }
+  // the counts recursive bisection could never produce, spot-checked
+  assert.equal(quarterArc(64).length / 2 - 1, 9);
+  assert.equal(quarterArc(128).length / 2 - 1, 13);
+  assert.equal(quarterArc(256).length / 2 - 1, 18);
+});
+
+test('a coarser tolerance buys coarser chords', () => {
+  const fine = quarterArc(64, null, 0.05).length;
+  const coarse = quarterArc(64, null, 1).length;
+  assert.ok(coarse < fine, `${coarse} vs ${fine}`);
+  // and each still honours what it promised
+  for (const tol of [0.05, 0.25, 1]) {
+    const dev = maxDeviation(quarterArc(64, null, tol), {
+      cx: 64, cy: 64, ux: 64, uy: 0, vx: 0, vy: 64,
+      t0: Math.PI, t1: Math.PI * 1.5
+    });
+    assert.ok(dev <= tol + 1e-9, `tol ${tol} deviates ${dev}`);
+  }
+});
+
+// ------------------------------------------------------------------- endpoints
+
+test('endpoints are the command endpoints, bit-identical', () => {
+  // the flattened arc must start and end exactly where the lowering said,
+  // or a corner stops meeting the straight edge it joins
+  const r = 37;
+  const seg = ellipseSegments(r, r, r, r, 0, Math.PI, Math.PI * 1.5);
+  const pts = quarterArc(r);
+  assert.equal(pts[0], seg.start.x);
+  assert.equal(pts[1], seg.start.y);
+  const last = seg.cmds[seg.cmds.length - 1];
+  assert.equal(pts[pts.length - 2], last.x);
+  assert.equal(pts[pts.length - 1], last.y);
+});
+
+test('a roundRect corner still meets its straight edges exactly', () => {
+  const p = new Path2D();
+  p.roundRect(10, 20, 100, 60, 16);
+  const pts = flattenPath(p._cmds)[0].pts;
+  // every point is inside the box, and the extremes touch its edges exactly
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let i = 0; i < pts.length; i += 2) {
+    minX = Math.min(minX, pts[i]);
+    maxX = Math.max(maxX, pts[i]);
+    minY = Math.min(minY, pts[i + 1]);
+    maxY = Math.max(maxY, pts[i + 1]);
+  }
+  assert.equal(minX, 10);
+  assert.equal(minY, 20);
+  assert.equal(maxX, 110);
+  assert.equal(maxY, 80);
+});
+
+test('an SVG arc keeps the endpoint its data asked for', () => {
+  // svgArcCommands snaps the last cubic onto the requested endpoint; the
+  // arc route must not undo that by re-evaluating the parameterization
+  const p = new Path2D('M10 80 A 45 45 0 0 1 100 80');
+  const pts = flattenPath(p._cmds)[0].pts;
+  assert.equal(pts[0], 10);
+  assert.equal(pts[1], 80);
+  assert.equal(pts[pts.length - 2], 100);
+  assert.equal(pts[pts.length - 1], 80);
+});
+
+// ------------------------------------------------------------------ transforms
+
+test('the tag survives a baked transform, and the tolerance is device-space', () => {
+  // scaling up must buy more chords, because the tolerance is in output
+  // pixels and the arc got bigger on screen
+  const plain = quarterArc(8).length / 2 - 1;
+  const scaled = flattenPath(
+    transformCommands(
+      [
+        { type: 'M', x: 0, y: 8 },
+        ...ellipseSegments(8, 8, 8, 8, 0, Math.PI, Math.PI * 1.5).cmds
+      ],
+      [8, 0, 0, 8, 0, 0]
+    )
+  )[0].pts;
+  const scaledSegs = scaled.length / 2 - 1;
+  assert.equal(scaledSegs, arcSegmentCount(Math.PI / 2, 64));
+  assert.ok(scaledSegs > plain, `${scaledSegs} vs ${plain}`);
+  // and it is still an arc of radius 64, within tolerance
+  const dev = maxDeviation(scaled, {
+    cx: 64, cy: 64, ux: 64, uy: 0, vx: 0, vy: 64,
+    t0: Math.PI, t1: Math.PI * 1.5
+  });
+  assert.ok(dev <= FLATTEN_TOLERANCE + 1e-9, `deviates ${dev}`);
+});
+
+test('flattening through a matrix matches flattening the baked commands', () => {
+  const m = [1.5, 0.4, -0.3, 2, 30, 12]; // rotation + non-uniform scale + shear
+  const cmds = [
+    { type: 'M', x: 0, y: 10 },
+    ...ellipseSegments(10, 10, 10, 10, 0, Math.PI, Math.PI * 1.5).cmds
+  ];
+  const viaMatrix = flattenPath(cmds, m)[0].pts;
+  const viaBaked = flattenPath(transformCommands(cmds, m))[0].pts;
+  assert.equal(viaMatrix.length, viaBaked.length);
+  for (let i = 0; i < viaMatrix.length; i++) {
+    assert.ok(Math.abs(viaMatrix[i] - viaBaked[i]) < 1e-9, `at ${i}`);
+  }
+});
+
+test('a sheared or non-uniformly scaled arc stays within tolerance', () => {
+  // the tag transforms exactly under any affine — the axis vectors go
+  // through the linear part — so shear is a first-class case, not a bail-out
+  const m = [2.5, 0.8, -1.2, 0.7, 5, 5];
+  const cmds = [
+    { type: 'M', x: 0, y: 20 },
+    ...ellipseSegments(20, 20, 20, 20, 0, Math.PI, Math.PI * 1.5).cmds
+  ];
+  const pts = flattenPath(cmds, m)[0].pts;
+  // the image ellipse: centre and axes through the same map
+  const lin = (x, y) => [m[0] * x + m[2] * y, m[1] * x + m[3] * y];
+  const [ux, uy] = lin(20, 0);
+  const [vx, vy] = lin(0, 20);
+  const dev = maxDeviation(pts, {
+    cx: m[0] * 20 + m[2] * 20 + m[4],
+    cy: m[1] * 20 + m[3] * 20 + m[5],
+    ux, uy, vx, vy,
+    t0: Math.PI, t1: Math.PI * 1.5
+  });
+  assert.ok(dev <= FLATTEN_TOLERANCE + 1e-9, `deviates ${dev}`);
+});
+
+test('an eccentric ellipse is bounded by its major axis', () => {
+  const seg = ellipseSegments(0, 0, 100, 6, 0, 0, Math.PI * 2);
+  const pts = flattenPath([
+    { type: 'M', x: seg.start.x, y: seg.start.y },
+    ...seg.cmds
+  ])[0].pts;
+  const dev = maxDeviation(pts, {
+    cx: 0, cy: 0, ux: 100, uy: 0, vx: 0, vy: 6,
+    t0: 0, t1: Math.PI * 2
+  });
+  assert.ok(dev <= FLATTEN_TOLERANCE + 1e-9, `deviates ${dev}`);
+  // rotating it is an isometry: the same chord count, the same deviation
+  const rot = ellipseSegments(0, 0, 100, 6, 0.7, 0, Math.PI * 2);
+  const rotated = flattenPath([
+    { type: 'M', x: rot.start.x, y: rot.start.y },
+    ...rot.cmds
+  ])[0].pts;
+  assert.equal(rotated.length, pts.length);
+});
+
+test('a cubic spliced away from its arc start falls back to bisection', () => {
+  // the arc route draws chords of the arc, which is only the curve the
+  // caller meant if the path is standing at the arc's start. A path built
+  // by hand from someone else's commands is not, and must still get a
+  // smooth curve from where it is — the cubic's own geometry.
+  const seg = ellipseSegments(0, 0, 40, 40, 0, 0, Math.PI / 2);
+  const spliced = flattenPath([{ type: 'M', x: -30, y: -70 }, ...seg.cmds]);
+  const pts = spliced[0].pts;
+  assert.equal(pts[0], -30);
+  assert.equal(pts[1], -70);
+  // the endpoint is still the command's
+  const last = seg.cmds[seg.cmds.length - 1];
+  assert.ok(Math.abs(pts[pts.length - 2] - last.x) < 1e-9);
+  assert.ok(Math.abs(pts[pts.length - 1] - last.y) < 1e-9);
+  // it is the bezier, not a chord fan from the far-away start: every point
+  // after the first sits near the cubic's hull, not on the arc's circle
+  const onArc = (x, y) => Math.abs(Math.hypot(x, y) - 40) < 1e-6;
+  assert.ok(!onArc(pts[2], pts[3]), 'second point is not an arc sample');
+});
+
+// -------------------------------------------------------- untagged curves
+
+test('a hand-built bezier still takes the adaptive route', () => {
+  // nothing here came from an arc, so there is no tag and bisection applies
+  const p = new Path2D();
+  p.moveTo(0, 0);
+  p.bezierCurveTo(0, 100, 100, 100, 100, 0);
+  const pts = flattenPath(p._cmds)[0].pts;
+  assert.ok(pts.length > 4, 'the curve was subdivided');
+  assert.equal(p._cmds[1].arc, undefined, 'no tag on a plain bezier');
+  // and the endpoints are still exact
+  assert.equal(pts[pts.length - 2], 100);
+  assert.equal(pts[pts.length - 1], 0);
+});
+
+test('Path2D copies share tags without letting a transform leak back', () => {
+  const src = new Path2D();
+  src.arc(0, 0, 10, 0, Math.PI);
+  const before = { ...src._cmds[1].arc };
+  const moved = new Path2D();
+  moved.addPath(src, [2, 0, 0, 2, 100, 100]);
+  assert.deepEqual(src._cmds[1].arc, before, 'the source tag is untouched');
+  assert.equal(moved._cmds[1].arc.ux, 20, 'the copy carries the scaled axis');
+  assert.equal(moved._cmds[1].arc.cx, 100);
+});

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import {
   Path2D,
+  arcSegmentCount,
   parseSvgPath,
   flattenPath,
   transformCommands,
@@ -119,7 +120,16 @@ test('Path2D full circle area approximates πr²', () => {
   p.arc(50, 50, 20, 0, Math.PI * 2);
   const area = pathArea(p);
   const exact = Math.PI * 400;
-  assert.ok(Math.abs(area - exact) / exact < 0.01, `${area} vs ${exact}`);
+  // A flattened circle is the inscribed polygon on the chords the tolerance
+  // allows, so its area is short of πr² by a knowable amount rather than an
+  // arbitrary one: assert it is exactly the n-gon, with n from the same
+  // formula the flattener uses. Since the chords are minimal now, this is
+  // the largest deficit the 0.25px contract permits — ~1.6% at r=20.
+  const n = arcSegmentCount(2 * Math.PI, 20);
+  const ngon = 0.5 * n * 400 * Math.sin((2 * Math.PI) / n);
+  assert.ok(Math.abs(area - ngon) < 1e-6, `${area} vs inscribed ${n}-gon ${ngon}`);
+  assert.ok(area < exact, 'inscribed: never larger than the true circle');
+  assert.ok(Math.abs(area - exact) / exact < 0.02, `${area} vs ${exact}`);
 });
 
 test('Path2D from SVG string equals the equivalent built path', () => {

--- a/test/shape-glyphs.test.js
+++ b/test/shape-glyphs.test.js
@@ -271,12 +271,13 @@ for (const [name, draw] of FILL_CASES) {
     assert.ok(fast.shapeStats.hits >= 1, 'fast run took the fast path');
     assert.equal(slow.shapeStats.hits, 0, 'forced run stayed on the polygon route');
     const { max, spots } = diff(fastImg, slowImg);
-    // The corner bitmap flattens/rasterizes the same lowered arc as the
-    // polygon route, but in glyph-local coordinates rather than at the
-    // device position; float rounding in the flattener and accumulator can
-    // shift a chord split, which shows as a few alpha steps on antialiased
-    // arc pixels. Interior and band pixels agree exactly.
-    assert.ok(max <= 4, `max channel diff ${max} at ${JSON.stringify(spots.slice(0, 3))}`);
+    // Both routes flatten the same lowered arc to the same chords, but the
+    // glyph rasterizes in a corner-local grid and the fallback in device
+    // space, so where a chord meets the corner box's cut line the two
+    // accumulate that pixel slightly differently. The gap scales with chord
+    // length: a few alpha steps out of 255, on a handful of pixels at the
+    // arc's tangent points. Interior and band pixels agree exactly.
+    assert.ok(max <= 8, `max channel diff ${max} at ${JSON.stringify(spots.slice(0, 3))}`);
   });
 }
 


### PR DESCRIPTION
Implements #213. An arc lowers to cubics, and the flattener then rediscovered its shape by bisecting them — which can only produce a power-of-two number of chords, so an arc needing 9 got 16 and one needing 13 got 32. The cubics now carry the arc they stand for, and the flattener splits it into the fewest equal angular steps the tolerance allows, straight from the sagitta:

```
n = ceil(sweep / (2 · acos(1 - tol/R)))
```

## Chords per quarter arc, tol 0.25px

| radius | before #212 | after #212 (bisection, tight metric) | this PR | fewest that fit |
|---|---|---|---|---|
| 8 | 8 | 4 | **4** | 4 |
| 16 | 8 | 8 | **5** | 5 |
| 32 | 16 | 8 | **7** | 7 |
| 64 | 16 | 16 | **9** | 9 |
| 128 | 32 | 16 | **13** | 13 |
| 256 | 32 | 32 | **18** | 18 |

Every radius now lands exactly on the minimum, with measured deviation inside the 0.25px contract everywhere (worst 0.244px, asserted by a test that samples the true arc and measures point-to-polyline distance).

## What it costs downstream

Chords multiply through the polygon fallback — a trapezoid per edge for fills, two triangles per segment for strokes. Wire bytes per shape, fallback forced:

| radius | box fill | box stroke | circle fill |
|---|---|---|---|
| 16 | 480 → **408** | 1724 → **1148** | 432 → **288** |
| 32 | 624 → **528** | 1724 → **1532** | 432 → **384** |
| 64 | 1224 → **768** | 3260 → **1916** | 816 → **528** |
| 128 | 1224 → **1056** | 3260 → **2684** | 1032 → 1056 |
| 256 | 2376 → **1392** | 6332 → **3644** | 2712 → **1416** |

Two of 28 measurements got marginally worse (r=8 box fill 264→312, r=128 circle fill 1032→1056): chord *positions* changed, and `trapezoidize` merges spans across slabs whose boundaries are vertex y-coordinates, so equal-angle vertices merge differently than bisection's unequal ones. The old r=8 number was an accidental win — it cost fewer bytes than r=4 — and the new numbers are monotone in radius.

Flattening itself also got cheaper despite the trig, because there is less of it and no recursion: **0.89 µs → 0.62 µs** per rounded box, 43.3 → 33.3 points.

## The tag

`{ cx, cy, ux, uy, vx, vy, sx, sy, t0, t1 }` — centre, two semi-axis **vectors**, start point, parameter range, describing `P(t) = C + u·cos t + v·sin t`.

Axis vectors rather than radii-plus-rotation is what makes the route survive transforms: an affine map takes this form to the same form (centre moves, axes go through the linear part), so **rotation, non-uniform scale and shear are all exact** rather than bail-outs to bisection — the issue anticipated dropping the tag on anything but a similarity, and this representation makes that unnecessary. The tolerance stays measured in device pixels: the chord count comes from the largest singular value of `[u|v]` *after* transformation, which is the arc's on-screen radius. Tags are immutable, so `Path2D` copies and `addPath` share them freely.

Ellipses are bounded by their semi-major axis (`|A·d| ≤ σmax·|d|`) — exact for circles, conservative for eccentric ones, always safe. A test pins a 100×6 ellipse, upright and rotated.

## Correctness details

- **Endpoints are the command's own**, not re-evaluated trig, so consecutive segments still meet exactly and an SVG arc keeps the endpoint its data snapped to. Tests assert bit-identity and that a `roundRect`'s flattened extremes still land exactly on the box edges.
- **The precondition is checked, not assumed.** The arc route draws chords of the arc, which is the curve the caller meant only if the path is standing at the arc's start. Every in-repo producer guarantees that, but a spliced path would otherwise be drawn quietly wrong — so the tag carries the start point the lowering already computed (free), and a mismatch falls back to bisection. This was not theoretical: my own first draft of the deviation test spliced commands onto the wrong `moveTo` and measured a 0.59px deviation, which is exactly what the guard now prevents.
- **Points are evaluated on the arc**, not on the cubic proxy — strictly closer to the geometry asked for, since the cubic itself carries ~2.7e-4·R of error.

## Round caps and joins

`_strokePolys` sized its cap/join disks with `max(8, min(32, ceil(r*2)))` — 8 segments (16 triangles) on the half-pixel cap of a 1px line, and a ceiling of 32 that at r=100 means a 0.48px sagitta, past the tolerance and visible. Both ends now come from the same formula: a 1px cap is a triangle, a thick one stays smooth. Round-capped stroke requests drop 492 → 348 bytes on the server route.

## Quality

The visible question is that a chord-flattened arc is *inscribed*, so shapes are up to the tolerance thin and a filled circle is short of πr² — now by the full 0.25px budget rather than the fraction of it the old over-subdivision happened to spend. Rendered and compared at 3× magnification across r=3…89 for filled circles, 1px stroked circles and round-capped joins, the two are indistinguishable. The circle-area test now asserts something sharper than a percentage: the flattened area equals the inscribed n-gon for n from the formula, is never larger than the true circle, and stays within 2%.

Two calibration changes come with this, both stated in the tests: the `shape-glyphs` fill-parity bound goes 4 → 8 alpha steps (glyph-local and device grids accumulate a chord's end pixel slightly differently, and the gap scales with chord length), and the circle-area bound 1% → 2%.

Worth a note for a future decision, not changed here: now that the budget is actually spent, `FLATTEN_TOLERANCE` is a real quality/cost dial rather than a nominal one, and the inscribed bias could be halved for free by straddling the arc instead of inscribing it (same chord count, ±tol/2 either side). Both are separable follow-ups.

I also considered giving the cached corner-glyph masters a tighter tolerance — they are rasterized once per radius, so extra chords there are free — but kept them on the shared default so the glyph route and the fallback stay visually identical when an app mixes them.

## Validation

- New `test/arc-flatten.test.js` (14 tests): the formula is minimal and safe on degenerate input; deviation stays within tolerance at r=2…256, under a coarser and a finer tolerance, under shear and non-uniform scale, and on an eccentric ellipse; chord counts equal the formula; endpoints bit-identical; matrix and baked-transform routes agree; spliced paths fall back; plain beziers still bisect; `Path2D` copies do not leak a transform back.
- Full suite 738/738. The website's 7 pixel-checked demos pass and the browser bundle builds.

Closes #213
