### PR TITLE
perf: an odd border width belongs on the rounded-stroke fast path

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -316,10 +316,15 @@ The recognizer only fires when it can reproduce the polygon route's output:
 - the clip stack is absent or rectangular (applied server-side as a picture
   clip, the way text glyph runs already do);
 - strokes additionally need a uniform circular radius, no dashes, a border
-  no thicker than the corner radius — and the band on pixel boundaries:
-  `x ± lineWidth/2` integral, which a 1px border drawn the correct way (path
-  inset by half the width) satisfies. A 1px stroke on integer coordinates is
-  genuinely a two-row 50% band and keeps the polygon route.
+  no thicker than the corner radius — and the band's *ink* on pixel
+  boundaries: `x ± lineWidth/2` integral and `lineWidth` itself integral,
+  which a border of any width drawn the correct way (path inset by half the
+  width) satisfies. The path *radius* is free to be fractional — nesting a
+  border inside a background corner of radius `R` means a path radius of
+  `R - lineWidth/2`, half-integer at every odd width, and the corner glyph
+  carries that half pixel the same way the polygon route does. A 1px stroke
+  on integer coordinates is a different shape — a genuine two-row 50% band —
+  and keeps the polygon route.
 - `strokeRect()` and radius-0 strokes lower further, to 4 `FillRectangles`
   with no glyphs at all.
 
@@ -340,11 +345,12 @@ app.shapePolicy = { maxRadius: 0 };      // disable the route entirely
 
 `NTK_NO_SHAPE_GLYPHS=1` in the environment disables it too (for A/B
 measurement — `examples/rounded-boxes.js` and
-`scripts/bench-rounded-boxes.mjs` draw the comparison). The corner cache is
-per connection and evicts by resetting the page when the budget is exceeded,
-so an adversarial animated-radius load stays bounded; a real UI's population
-(a design system's radii × border widths) is a few dozen tiny bitmaps that
-never approach it.
+`scripts/bench-rounded-boxes.mjs` draw the comparison, and
+`scripts/bench-odd-border.mjs` sweeps a bordered card wall by border width
+alone). The corner cache is per connection and evicts by resetting the page
+when the budget is exceeded, so an adversarial animated-radius load stays
+bounded; a real UI's population (a design system's radii × border widths) is
+a few dozen tiny bitmaps that never approach it.
 
 ### Swapping the rasterizer
 

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -345,9 +345,11 @@ app.shapePolicy = { maxRadius: 0 };      // disable the route entirely
 
 `NTK_NO_SHAPE_GLYPHS=1` in the environment disables it too (for A/B
 measurement — `examples/rounded-boxes.js` and
-`scripts/bench-rounded-boxes.mjs` draw the comparison, and
+`scripts/bench-rounded-boxes.mjs` draw the comparison,
 `scripts/bench-odd-border.mjs` sweeps a bordered card wall by border width
-alone). The corner cache is per connection and evicts by resetting the page
+alone, and `examples/odd-border.js` puts both routes side by side with the
+corners magnified, for eyeballing parity rather than timing it). The corner
+cache is per connection and evicts by resetting the page
 when the budget is exceeded, so an adversarial animated-radius load stays
 bounded; a real UI's population (a design system's radii × border widths) is
 a few dozen tiny bitmaps that never approach it.

--- a/examples/odd-border.js
+++ b/examples/odd-border.js
@@ -1,0 +1,213 @@
+// A bordered card, drawn both ways, magnified (issue #217).
+//
+// `examples/rounded-boxes.js` insets its borders by half the line width but
+// keeps an integer path radius, so it never shows this case. A border that
+// *nests* inside its background — the usual reason to draw one — takes the
+// background's radius minus the inset: `roundRect(x + bw/2, y + bw/2,
+// w - bw, h - bw, R - bw/2)`, a half-integer radius at every odd width.
+//
+// Each row is one border width, drawn twice from identical geometry: left on
+// the corner-glyph route, right on the polygon route, with the top-left
+// corner of each blown up so the antialiasing can be compared pixel by
+// pixel. The two should be indistinguishable — that is the claim. Colours are
+// translucent, so a pixel the glyphs and the FillRectangles both painted
+// would show up as a dark seam.
+//
+// The last row is the odd one out: `lineWidth = 1.5` on an *integer* path
+// radius, which is not the nesting geometry but did pass every test the old
+// recognizer applied. It took the fast path and then emitted FillRectangles
+// with fractional extents, dropping the half-covered row of ink — a border
+// visibly thinner on the left than on the right. Now it falls back and the
+// two columns agree.
+//
+//   node odd-border.js                    a window; g toggles, q quits
+//   node odd-border.js --png=out.png      render once to a PNG, no window
+//
+// The header line counts what each route did: with the fix every row is a
+// fast-path hit on the left, and the `fractional` counter stays at zero.
+import { writeFileSync } from 'node:fs';
+
+import { PNG } from 'pngjs';
+
+import { createClient } from '../lib/index.js';
+
+const pngPath = (process.argv.find((a) => a.startsWith('--png=')) || '').slice(6);
+
+const R = 16; // the background's corner radius, shared by every row
+// one row per border width, path radius R - bw/2 unless the row overrides it
+const ROWS = [
+  { bw: 1 },
+  { bw: 2 },
+  { bw: 3 },
+  { bw: 4 },
+  { bw: 1.5, r: R, note: 'integer r' }
+].map((row) => ({ r: R - row.bw / 2, ...row }));
+const CARD = { w: 190, h: 92 };
+const ZOOM = { size: 22, scale: 6 }; // corner pixels, magnification
+const ROW = Math.max(CARD.h, ZOOM.size * ZOOM.scale) + 22;
+const COL = CARD.w + ZOOM.size * ZOOM.scale + 26;
+const PAD = { x: 74, y: 52 };
+const SURFACE = {
+  width: PAD.x + 2 * COL + 16,
+  height: PAD.y + ROWS.length * ROW + 12
+};
+
+const BACKDROP = '#dee2e6';
+const FILL = 'rgba(120, 150, 230, 0.85)';
+const STROKE = 'rgba(24, 28, 52, 0.7)';
+const INK = '#212529';
+
+const app = await createClient();
+
+/** where row i's card sits on route column `col` (0 fast, 1 polygon) */
+const cardAt = (i, col) => ({
+  x: PAD.x + col * COL,
+  y: PAD.y + i * ROW
+});
+
+/** the card's background */
+function background(ctx, x, y) {
+  ctx.fillStyle = FILL;
+  ctx.beginPath();
+  ctx.roundRect(x, y, CARD.w, CARD.h, R);
+  ctx.fill();
+}
+
+/**
+ * The border, stroked on the path inset by half its width — the nesting
+ * geometry, whose radius is R - bw/2.
+ */
+function border(ctx, x, y, bw, r) {
+  ctx.strokeStyle = STROKE;
+  ctx.lineWidth = bw;
+  ctx.beginPath();
+  ctx.roundRect(x + bw / 2, y + bw / 2, CARD.w - bw, CARD.h - bw, r);
+  ctx.stroke();
+}
+
+/** what the route did during one drawing: hits, and any bail-out reasons */
+function measure(ctx, draw) {
+  const hits = ctx.shapeStats.hits;
+  const before = { ...ctx.shapeStats.misses };
+  draw();
+  const misses = [];
+  for (const [k, n] of Object.entries(ctx.shapeStats.misses)) {
+    if (n - (before[k] || 0) > 0) misses.push(k);
+  }
+  return { hit: ctx.shapeStats.hits > hits, misses };
+}
+
+/** the scene, minus the magnifiers: both routes, one row per border width */
+function drawCards(ctx, fastPath) {
+  ctx.fillStyle = BACKDROP;
+  ctx.fillRect(0, 0, SURFACE.width, SURFACE.height);
+  ctx.fillStyle = INK;
+  ctx.font = '12px sans-serif';
+  ctx.fillText(fastPath ? 'corner glyphs' : 'polygon route (forced)', PAD.x, PAD.y - 30);
+  ctx.fillText('polygon route (forced)', PAD.x + COL, PAD.y - 30);
+
+  const stats = [];
+  for (let i = 0; i < ROWS.length; i++) {
+    const { bw, r, note } = ROWS[i];
+    const a = cardAt(i, 0);
+    const b = cardAt(i, 1);
+    ctx.fillStyle = INK;
+    ctx.fillText(`${bw}px`, 20, a.y + 18);
+    ctx.fillText(`r ${r}`, 20, a.y + 34);
+    if (note) ctx.fillText(note, 20, a.y + 50);
+
+    // left column on whichever route is selected, right column always forced
+    app.shapePolicy = fastPath ? null : { maxRadius: 0 };
+    background(ctx, a.x, a.y);
+    const took = measure(ctx, () => border(ctx, a.x, a.y, bw, r));
+    app.shapePolicy = { maxRadius: 0 };
+    background(ctx, b.x, b.y);
+    border(ctx, b.x, b.y, bw, r);
+    stats.push({ bw, ...took });
+  }
+  app.shapePolicy = fastPath ? null : { maxRadius: 0 };
+  return stats;
+}
+
+/**
+ * Magnify each card's top-left corner from the pixels actually drawn — one
+ * readback per card, scaled by nearest neighbour so every pixel is a block.
+ */
+async function drawZooms(ctx) {
+  const { size, scale } = ZOOM;
+  for (let i = 0; i < ROWS.length; i++) {
+    const { bw } = ROWS[i];
+    for (const col of [0, 1]) {
+      const at = cardAt(i, col);
+      // start one pixel outside the band's outer corner
+      const sx = Math.floor(at.x - bw / 2) - 1;
+      const sy = Math.floor(at.y - bw / 2) - 1;
+      const src = await ctx.getImageData(sx, sy, size, size);
+      const out = ctx.createImageData(size * scale, size * scale);
+      for (let y = 0; y < size * scale; y++) {
+        for (let x = 0; x < size * scale; x++) {
+          const s = (((y / scale) | 0) * size + ((x / scale) | 0)) * 4;
+          const d = (y * size * scale + x) * 4;
+          out.data[d] = src.data[s];
+          out.data[d + 1] = src.data[s + 1];
+          out.data[d + 2] = src.data[s + 2];
+          out.data[d + 3] = 255;
+        }
+      }
+      ctx.putImageData(out, at.x + CARD.w + 14, at.y);
+    }
+  }
+}
+
+async function paint(ctx, fastPath) {
+  const stats = drawCards(ctx, fastPath);
+  await drawZooms(ctx);
+  return stats;
+}
+
+/** what each border width did on the left column */
+function report(stats, fastPath) {
+  const took = stats
+    .map((s) => `${s.bw}px ${s.hit ? 'glyphs' : `polygons (${s.misses.join(' ') || 'no tag'})`}`)
+    .join(', ');
+  return `left column ${fastPath ? 'on the glyph route' : 'forced to polygons'} — borders: ${took}`;
+}
+
+if (pngPath) {
+  const pixmap = app.createPixmap({ ...SURFACE, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  const stats = await paint(ctx, true);
+  console.log(report(stats, true));
+  const img = await ctx.getImageData(0, 0, SURFACE.width, SURFACE.height);
+  const png = new PNG({ width: SURFACE.width, height: SURFACE.height });
+  png.data.set(img.data);
+  writeFileSync(pngPath, PNG.sync.write(png));
+  console.log(`wrote ${pngPath}`);
+  await app.close();
+} else {
+  const wnd = app.createWindow({
+    title: 'odd border widths',
+    width: SURFACE.width,
+    height: SURFACE.height
+  });
+  const ctx = wnd.getContext('2d');
+  wnd.map();
+  let fastPath = !process.env.NTK_NO_SHAPE_GLYPHS;
+  const redraw = async () => {
+    const stats = await paint(ctx, fastPath);
+    const line = report(stats, fastPath);
+    wnd.setTitle(`odd border widths — ${line} — g toggles, q quits`);
+    console.log(line);
+  };
+  await redraw();
+  wnd.on('keydown', (ev) => {
+    const key = String.fromCodePoint(ev.codepoint ?? 0).toLowerCase();
+    if (key === 'g') {
+      fastPath = !fastPath;
+      redraw();
+    } else if (key === 'q' || ev.keysym === 0xff1b) {
+      app.close();
+    }
+  });
+  wnd.on('close', () => app.close());
+}

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -1676,10 +1676,10 @@ class RenderingContext2d {
    * Stroke fast path for a device-space box (from a roundRect tag or
    * strokeRect). Beyond the fill's conditions: uniform lineWidth, no
    * dashes — and the half-pixel one that matters: the stroke band must land
-   * on pixel boundaries. A 1px border drawn the correct way (path inset by
-   * bw/2, so the band [X, X+1] sits on integers) passes; a 1px stroke on
-   * integer path coordinates is genuinely a two-row 50% band and must keep
-   * falling back, because the fast path would not reproduce it.
+   * on pixel boundaries. A border drawn the correct way (path inset by bw/2,
+   * so the band [X, X+bw] sits on integers) passes at any width, odd or even;
+   * a 1px stroke on integer path coordinates is genuinely a two-row 50% band
+   * and must keep falling back, because the fast path would not reproduce it.
    */
   _tryStrokeBox(box) {
     // the same off switch as the fill's — see _tryRoundRectFill
@@ -1708,12 +1708,27 @@ class RenderingContext2d {
     const Y0 = y - bw / 2;
     const W = w + bw; // outer band size
     const H = h + bw;
+    // What the route needs is that the *ink* is pixel-aligned: the band's
+    // four outer edges on integers, which is what the four tests below say,
+    // and an integer width so the straight runs are whole rows and columns
+    // of FillRectangles (fractional extents would be truncated on the wire —
+    // and a fractional lineWidth passes the outer-band tests, e.g. x = 0.75
+    // with bw = 1.5, so this clause carries real weight).
+    //
+    // The *path* radius is free. The corner glyph box is cut at
+    // K = ceil(r + bw/2), and from the arc's tangent point out to that cut
+    // the band is already its own straight continuation — bw whole rows —
+    // so a fractional radius rides inside the glyph, which rasterizes on the
+    // device pixel grid, exactly as it does on the polygon route. This is
+    // what a border inset by bw/2 needs: nesting inside a background corner
+    // of radius R means a path radius of R - bw/2, half-integer for every
+    // odd width (issue #217).
     if (
       !Number.isInteger(X0) ||
       !Number.isInteger(Y0) ||
       !Number.isInteger(W) ||
       !Number.isInteger(H) ||
-      !Number.isInteger(r)
+      !Number.isInteger(bw)
     ) {
       return this._shapeMiss("fractional");
     }

--- a/scripts/bench-odd-border.mjs
+++ b/scripts/bench-odd-border.mjs
@@ -1,0 +1,230 @@
+// Benchmark for one scenario only (issue #217): a wall of rounded cards with
+// a *border*, drawn the way a UI draws one — the background filled on
+// `roundRect(x, y, w, h, R)`, the border stroked on the path inset by half
+// its width, `roundRect(x + bw/2, y + bw/2, w - bw, h - bw, R - bw/2)`, so
+// the band's ink lands on integers and the border nests inside the
+// background's corner. Everything is recoloured every frame, so the frame is
+// box chrome and nothing else.
+//
+// The inset path radius is `R - bw/2` — half-integer whenever the border
+// width is odd. The sweep is over the border width alone, with the geometry,
+// the corner radius and the frame count fixed, so the only thing that moves
+// between rows is the parity of `bw`.
+//
+//   node scripts/bench-odd-border.mjs [cards] [frames] [--js] [--radius=N]
+//
+// Runs against $DISPLAY by default (the real measurement: the polygon route's
+// cost is mostly server-side); --js uses node-x11's in-process JS X server,
+// which is hermetic but measures client + JS-server cost in one process.
+import { performance } from 'node:perf_hooks';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const flags = process.argv.slice(2).filter((a) => a.startsWith('--'));
+const has = (f) => flags.includes(f);
+const opt = (name, dflt) => {
+  const hit = flags.find((f) => f.startsWith(`--${name}=`));
+  return hit ? Number(hit.slice(name.length + 3)) : dflt;
+};
+
+const CARDS = Math.max(1, Number(args[0]) || 24);
+const FRAMES = Math.max(5, Number(args[1]) || 20);
+const RADIUS = opt('radius', 10);
+const WIDTHS = [1, 2, 3, 4];
+const SURFACE = { width: 1200, height: 800 };
+
+async function connect() {
+  if (has('--js') || !process.env.DISPLAY) {
+    const { default: xserver } = await import('x11/lib/xserver/index.js');
+    const server = xserver.createServer({ width: 1600, height: 1200 });
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    const app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+    return { app, target: 'in-process JS X server' };
+  }
+  const app = await createClient();
+  return { app, target: `X server on ${process.env.DISPLAY}` };
+}
+
+/** a grid of cards, geometry fixed across the whole sweep */
+function makeCards() {
+  const cols = Math.ceil(Math.sqrt((CARDS * SURFACE.width) / SURFACE.height));
+  const rows = Math.ceil(CARDS / cols);
+  const cellW = Math.floor(SURFACE.width / cols);
+  const cellH = Math.floor(SURFACE.height / rows);
+  const margin = 8;
+  const cards = [];
+  for (let i = 0; i < CARDS; i++) {
+    cards.push({
+      x: (i % cols) * cellW + margin,
+      y: ((i / cols) | 0) * cellH + margin,
+      w: Math.max(4 * RADIUS, cellW - 2 * margin),
+      h: Math.max(4 * RADIUS, cellH - 2 * margin)
+    });
+  }
+  return cards;
+}
+
+const hueOf = (frame, i) => (frame * 7 + i * 13) % 360;
+const fillOf = (hue) => `hsl(${hue}, 60%, 88%)`;
+const strokeOf = (hue) => `hsl(${hue}, 55%, 42%)`;
+
+/**
+ * Every colour the sweep will use, drawn once into a 1x1 corner. The app's
+ * solid pictures are shared per connection, so without this the first width
+ * measured pays every CreateSolidFill and the rest inherit them. Synced in
+ * batches — the in-process JS server reads its socket recursively and a burst
+ * this size overflows its stack.
+ */
+async function warmColors(app, ctx) {
+  let n = 0;
+  for (let frame = 0; frame < FRAMES; frame++) {
+    for (let i = 0; i < CARDS; i++) {
+      const hue = hueOf(frame, i);
+      ctx.fillStyle = fillOf(hue);
+      ctx.fillRect(0, 0, 1, 1);
+      ctx.fillStyle = strokeOf(hue);
+      ctx.fillRect(0, 0, 1, 1);
+      if (++n % 64 === 0) await app.X.sync();
+    }
+  }
+  await app.X.sync();
+}
+
+/** one frame: every card refilled and re-bordered in a fresh colour */
+function drawFrame(ctx, cards, bw, frame) {
+  ctx.fillStyle = '#f1f3f5';
+  ctx.fillRect(0, 0, SURFACE.width, SURFACE.height);
+  const inset = bw / 2;
+  const r = RADIUS - inset; // the border's path radius: half-integer for odd bw
+  let i = 0;
+  for (const c of cards) {
+    const hue = hueOf(frame, i);
+    ctx.fillStyle = fillOf(hue);
+    ctx.beginPath();
+    ctx.roundRect(c.x, c.y, c.w, c.h, RADIUS);
+    ctx.fill();
+    ctx.strokeStyle = strokeOf(hue);
+    ctx.lineWidth = bw;
+    ctx.beginPath();
+    ctx.roundRect(c.x + inset, c.y + inset, c.w - bw, c.h - bw, r);
+    ctx.stroke();
+    i++;
+  }
+}
+
+const median = (xs) => xs.slice().sort((a, b) => a - b)[xs.length >> 1];
+const worst = (xs) => xs.reduce((a, b) => (b > a ? b : a), 0);
+
+async function run(app, cards, bw) {
+  const pixmap = app.createPixmap({ ...SURFACE, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+
+  // warm up: solid pictures for every colour, then glyph uploads, GCs and
+  // whatever the server caches on first use
+  await warmColors(app, ctx);
+  for (let i = 0; i < 3; i++) {
+    drawFrame(ctx, cards, bw, i);
+    await app.X.sync();
+  }
+  ctx.shapeStats.hits = 0;
+  for (const k of Object.keys(ctx.shapeStats.misses)) delete ctx.shapeStats.misses[k];
+
+  const paint = [];
+  const wall = [];
+  const seq0 = app.X.seq_num;
+  const bytes0 = app.X.pack_stream.stats.bytes;
+  for (let i = 0; i < FRAMES; i++) {
+    const t0 = performance.now();
+    drawFrame(ctx, cards, bw, i);
+    const t1 = performance.now();
+    await app.X.sync();
+    const t2 = performance.now();
+    paint.push(t1 - t0);
+    wall.push(t2 - t0);
+  }
+  const requests = (app.X.seq_num - seq0) / FRAMES;
+  const kb = (app.X.pack_stream.stats.bytes - bytes0) / FRAMES / 1024;
+
+  const stats = ctx.shapeStats;
+  const misses = Object.entries(stats.misses);
+  const fallbacks = misses.reduce((a, [, n]) => a + n, 0);
+  const out = {
+    bw,
+    r: RADIUS - bw / 2,
+    paint: median(paint),
+    wall: median(wall),
+    wallMax: worst(wall),
+    requests,
+    kb,
+    fast: stats.hits / FRAMES,
+    fallbacks: fallbacks / FRAMES,
+    why: misses.map(([k, n]) => `${k} x${(n / FRAMES).toFixed(0)}`).join(', ')
+  };
+  ctx.destroy();
+  pixmap.destroy();
+  return out;
+}
+
+const { app, target } = await connect();
+const cards = makeCards();
+console.log(`target: ${target}`);
+console.log(
+  `scene: ${CARDS} cards, radius ${RADIUS}, fill + inset border, ` +
+    `all recoloured every frame, ${FRAMES} frames per width\n`
+);
+
+// prime the JIT on every width before measuring any of them, so the row
+// that happens to run first is not also the one that compiles the code
+{
+  const pixmap = app.createPixmap({ ...SURFACE, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  await warmColors(app, ctx);
+  for (const bw of WIDTHS) {
+    for (let i = 0; i < 2; i++) drawFrame(ctx, cards, bw, i);
+    await app.X.sync();
+  }
+  ctx.destroy();
+  pixmap.destroy();
+}
+
+const rows = [];
+for (const bw of WIDTHS) rows.push(await run(app, cards, bw));
+
+const head =
+  ' border  path r   paint    frame   worst   requests   wire/frame   boxes fast/fallback';
+console.log(head);
+console.log('-'.repeat(head.length));
+for (const r of rows) {
+  console.log(
+    `  ${String(r.bw).padStart(2)}px` +
+      `  ${String(r.r).padStart(7)}` +
+      `  ${r.paint.toFixed(2).padStart(7)}` +
+      `  ${r.wall.toFixed(2).padStart(7)}` +
+      `  ${r.wallMax.toFixed(1).padStart(6)}` +
+      `  ${r.requests.toFixed(0).padStart(9)}` +
+      `  ${r.kb.toFixed(1).padStart(9)} KB` +
+      `   ${r.fast.toFixed(0)} / ${r.fallbacks.toFixed(0)}` +
+      (r.why ? `  (${r.why})` : '')
+  );
+}
+console.log('\n(paint / frame / worst are ms; frame includes the round trip)');
+
+const odd = rows.filter((r) => r.bw % 2 === 1);
+const even = rows.filter((r) => r.bw % 2 === 0);
+const avg = (xs, k) => xs.reduce((a, r) => a + r[k], 0) / xs.length;
+const ratio = (k) => avg(odd, k) / avg(even, k);
+console.log(
+  `\nodd vs even border widths: ${ratio('paint').toFixed(1)}x the paint, ` +
+    `${ratio('requests').toFixed(1)}x the requests, ${ratio('kb').toFixed(1)}x the wire, ` +
+    `${ratio('wall').toFixed(1)}x the frame`
+);
+const stuck = rows.filter((r) => r.fallbacks > 0);
+console.log(
+  stuck.length
+    ? `still on the polygon route: ${stuck.map((r) => `${r.bw}px`).join(', ')}`
+    : 'every width is on the glyph route'
+);
+
+await app.close();

--- a/test/shape-glyphs.test.js
+++ b/test/shape-glyphs.test.js
@@ -288,7 +288,17 @@ const STROKE_CASES = [
   ['r=8 bw=2', { x: 20, y: 20, w: 110, h: 50, r: 8, bw: 2 }],
   ['r=6 bw=1 half-integer path', { x: 30.5, y: 30.5, w: 89, h: 29, r: 6, bw: 1 }],
   ['r=12 bw=4', { x: 20, y: 20, w: 110, h: 60, r: 12, bw: 4 }],
-  ['pill r=12 bw=2', { x: 40, y: 40, w: 100, h: 24, r: 12, bw: 2 }]
+  ['pill r=12 bw=2', { x: 40, y: 40, w: 100, h: 24, r: 12, bw: 2 }],
+  // an odd border inset by bw/2 nests inside a background corner of radius R
+  // with a path radius of R - bw/2 — half-integer, and the case issue #217
+  // was about. The outer band still lands on integers, which is the only
+  // alignment the route needs.
+  ['R=8 bw=1, path r=7.5', { x: 20.5, y: 20.5, w: 119, h: 59, r: 7.5, bw: 1 }],
+  ['R=8 bw=3, path r=6.5', { x: 21.5, y: 21.5, w: 117, h: 57, r: 6.5, bw: 3 }],
+  ['R=23 bw=1, path r=22.5', { x: 20.5, y: 20.5, w: 159, h: 119, r: 22.5, bw: 1 }],
+  // a fractional radius that is not even half-integer: the glyph box is cut
+  // at ceil(r + bw/2), and out to that cut the band is its straight run
+  ['R=12.2 bw=1, path r=11.7', { x: 20.5, y: 20.5, w: 119, h: 59, r: 11.7, bw: 1 }]
 ];
 
 for (const [name, g] of STROKE_CASES) {
@@ -331,6 +341,76 @@ for (const [name, g] of STROKE_CASES) {
     }
   });
 }
+
+// The assertion that carries the decomposition, checked where a border is
+// most likely to break it — an odd width, whose path radius is half-integer
+// and whose glyph box is cut a fraction outside the arc's tangent point. A
+// translucent border over white: a pixel covered once by ink at alpha 0.5 is
+// 128; a pixel the glyph and the FillRectangles both claimed would be 64.
+for (const bw of [1, 2, 3, 4, 5]) {
+  test(`an inset ${bw}px border paints no pixel twice`, async () => {
+    app.shapePolicy = null;
+    const ctx = freshCtx();
+    ctx.strokeStyle = 'rgba(0,0,0,0.5)';
+    ctx.lineWidth = bw;
+    ctx.beginPath();
+    // background corner radius 10, so the inset path radius is 10 - bw/2
+    ctx.roundRect(20 + bw / 2, 20 + bw / 2, 150 - bw, 110 - bw, 10 - bw / 2);
+    ctx.stroke();
+    assert.equal(ctx.shapeStats.hits, 1, 'took the fast path');
+    const img = await ctx.getImageData(0, 0, W, H);
+    let min = 255;
+    let at = null;
+    for (let py = 0; py < H; py++) {
+      for (let px = 0; px < W; px++) {
+        const v = img.data[(py * W + px) * 4];
+        if (v < min) {
+          min = v;
+          at = `${px},${py}`;
+        }
+      }
+    }
+    assert.ok(min <= 129, `the band is there (darkest pixel ${min})`);
+    assert.ok(min >= 127, `no pixel painted twice (${min} at ${at}, doubled would be ~64)`);
+    // and the straight runs are whole rows: bw rows of full coverage at the
+    // top edge, nothing spilling above or below them
+    const midX = 20 + 75;
+    for (let row = 0; row < bw; row++) {
+      assert.ok(
+        Math.abs(img.data[((20 + row) * W + midX) * 4] - 128) <= 1,
+        `top band row ${row} fully covered`
+      );
+    }
+    assert.equal(img.data[((20 - 1) * W + midX) * 4], 255, 'nothing above the band');
+    assert.equal(img.data[((20 + bw) * W + midX) * 4], 255, 'nothing below the band');
+  });
+}
+
+test('a fractional lineWidth falls back even on an integer band', async () => {
+  // x = 0.75 with bw = 1.5 puts the outer band on integers, so the band tests
+  // pass; the straight runs would need fractional FillRectangles extents,
+  // which the wire cannot carry, so the width itself has to be integral
+  const draw = (ctx) => {
+    ctx.strokeStyle = 'black';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.roundRect(20.75, 20.75, 98.5, 58.5, 8);
+    ctx.stroke();
+  };
+  const { fast, slow, fastImg, slowImg } = await bothRoutes(draw);
+  assert.equal(fast.shapeStats.hits, 0, 'no fast path for a fractional width');
+  assert.equal(fast.shapeStats.misses.fractional, 1);
+  assert.equal(slow.shapeStats.hits, 0);
+  // both runs are the polygon route now, so the half-covered row survives
+  const { max } = diff(fastImg, slowImg);
+  assert.equal(max, 0, 'identical: both took the polygon route');
+  // the band's top edge is y = 20, so row 20 is full ink and row 21 half —
+  // the row the fast path used to drop
+  const mid = 70;
+  assert.ok(fastImg.data[(20 * W + mid) * 4] < 32, 'the full row is drawn');
+  const half = fastImg.data[(21 * W + mid) * 4];
+  assert.ok(half > 64 && half < 192, `the half-covered row is drawn (${half})`);
+});
 
 test('strokeRect lowers to four rectangles and squares every corner', async () => {
   app.shapePolicy = null;


### PR DESCRIPTION
Fixes #217. The stroke recognizer tested the *path* radius for integrality
while everything around it was written in outer-band terms, so a border
inset by `bw/2` — the correct way to draw one, and the way the docstring
blesses — bailed as `fractional` at every odd width. Its path radius is
`R - bw/2`. A 1px border, the most common border a UI draws, went out as
polygons while the fill underneath it took the glyph route.

## The invariant the route actually needs

Not an integer radius — pixel-aligned **ink**:

- the band's four outer edges on integers, which the four tests beside it
  already say (`X0 = x - bw/2`, `W = w + bw`);
- an integer `lineWidth`, so the straight runs are whole rows and columns
  of `FillRectangles`.

The path radius plays no part. The corner glyph box is cut at
`K = ceil(r + bw/2)`, and from the arc's tangent point out to that cut the
band is already its own straight continuation — `bw` whole rows — so the
cut lands where the band's pixels are fully covered whatever half-pixel the
arc ends on. A fractional radius rides inside the glyph, which rasterizes
on the device pixel grid, exactly as the polygon route does. So the clause
becomes:

```diff
-      !Number.isInteger(r)
+      !Number.isInteger(bw)
```

This is wider than #217 proposed and deliberately so. `Number.isInteger(r + bw / 2)`
would have **regressed** the case that works today — an integer path radius
with an odd width, whose outer radius is half-integer. Both
`test/shape-glyphs.test.js`'s `r=6 bw=1 half-integer path` and its steady-state
request-count test are exactly that shape. `Number.isInteger(bw)` subsumes
both cases and is the condition the geometry actually asks for.

## It also closes a hole

The `bw` clause is not just defensive. A fractional `lineWidth` on an
integer band — `x = 0.75` with `bw = 1.5` — passed every current test, took
the fast path, and emitted `FillRectangles` with fractional extents: 410
pixels wrong against the polygon route, max channel diff 255, the
half-covered row of ink dropped entirely. It now falls back, with a test
pinning it.

## Benchmark

`scripts/bench-odd-border.mjs` (first commit) sweeps a wall of bordered
cards by border width alone — same geometry, same radius, all recoloured
every frame, so the only thing moving between rows is the parity of `bw`.
24 cards, radius 10, 20 frames, Xorg 21.1 over glamor, local socket:

| border | paint  | frame  | worst   | requests | wire    | boxes fast/fallback |
| ------ | -----: | -----: | ------: | -------: | ------: | ------------------- |
| 1px    | 1.4 ms | 775 ms | 783 ms  |       74 | 25.9 KB | 24 / 24             |
| 2px    | 0.8 ms | 1.2 ms | 1.6 ms  |       98 |  5.9 KB | 48 / 0              |
| 3px    | 1.0 ms | 767 ms | 1341 ms |       74 | 25.9 KB | 24 / 24             |
| 4px    | 0.4 ms | 0.9 ms | 1.1 ms  |       98 |  5.9 KB | 48 / 0              |

With this change:

| border | paint  | frame  | worst  | requests | wire   | boxes fast/fallback |
| ------ | -----: | -----: | -----: | -------: | -----: | ------------------- |
| 1px    | 0.7 ms | 1.2 ms | 4.3 ms |       98 | 5.9 KB | 48 / 0              |
| 2px    | 0.6 ms | 0.8 ms | 1.4 ms |       98 | 5.9 KB | 48 / 0              |
| 3px    | 0.5 ms | 0.7 ms | 3.5 ms |       98 | 5.9 KB | 48 / 0              |
| 4px    | 0.4 ms | 0.8 ms | 1.2 ms |       98 | 5.9 KB | 48 / 0              |

4.4x the wire and a ~650x frame time, gone; the odd widths land exactly on
the even ones. The worst frame is the number to look at — 1341 ms is a
visible hitch, not a throughput figure. Hermetic run for anyone without a
slow server: `--js` gives 14.3 ms/frame before, 1.4 ms after.

## Parity

The odd widths now meet the assertions the even ones already met.
`STROKE_CASES` gains `R=8 bw=1` (path r 7.5), `R=8 bw=3` (6.5),
`R=23 bw=1` (22.5) and a radius that is not even half-integer,
`r=11.7 bw=1` — each compared pixel-by-pixel against the polygon route
with the same bounds as before: corner drift within 64/255, and every diff
above one alpha step confined to the corner boxes, so the straight runs
stay pixel-exact.

And the assertion that carries the whole decomposition, at widths 1
through 5: a translucent border paints **no pixel twice**. Over white at
alpha 0.5 a pixel covered once is 128 and one both the glyph and the
`FillRectangles` claimed would be 64; the darkest pixel is 128 in every
case, the top band is exactly `bw` full rows, and nothing spills above or
below it. I also swept 381 (radius, width) combinations off-branch while
settling the predicate — partition exact in all of them.

Full suite green (748 tests). Docs updated: the stroke bullet in
`docs/context-2d.md` said the old condition, and its "1px border drawn the
correct way passes" sentence was not in fact true.
