### PR TITLE
perf(window): clock frames on Present's CompleteNotify

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -54,11 +54,17 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
   ```
 - `coalesceEvents: false` — deliver every noisy event individually (see
   [Frames, coalescing and slow connections](#frames-coalescing-and-slow-connections))
-- `frameSync: false` — don't pace frames with a server round-trip fence
-- `present: true` — blit with the Present extension instead of `CopyArea`
+- `frameSync: false` — don't pace frames on the server at all: no round-trip
+  fence, and no waiting for the display either
+- `present: true` — blit with the Present extension instead of `CopyArea`,
+  and take the frame clock from the display
   (see [Blitting with Present](#blitting-with-present--present-true))
+- `frameClock: 'fence'` — keep the round-trip clock on a window that presents
+  (see [What ends a frame](#what-ends-a-frame))
 - `frameInterval: ms` — minimum time between paced frames, and the minimum
-  time between blits (default `16`, ~60 fps; `0` disables both gates). Also
+  time between blits (default `16`, ~60 fps; `0` disables both gates). Under
+  the vblank clock this is a *cap* on top of the display's rate and the
+  default does not apply — see [What ends a frame](#what-ends-a-frame). Also
   writable later as `wnd.frameInterval`.
 - `syncRequest: true` — let the window manager pace interactive resizes to
   this window's repaint rate (see
@@ -168,8 +174,11 @@ are for, and ntk implements the basic form only.
 
 Opt-in, and inert unless both Present and XFixes are available — blits fall
 back to `CopyArea`, which stays correct at all times, so the two paths can
-even alternate. The frame clock is unchanged: frames are still paced by the
-fence and the interval, not by the display's refresh.
+even alternate.
+
+Presenting also changes what ends a frame: the server reports each present
+back when it has executed it, and that report becomes this window's frame
+clock. See [What ends a frame](#what-ends-a-frame).
 
 ### `wnd.scrollRegion(rect, dx, dy)` → boolean
 
@@ -204,15 +213,18 @@ stale intermediate states — most visibly over ssh-forwarded / networked
 displays. ntk therefore delivers noisy events and repaints in **paced
 frames**, gated by three independent mechanisms:
 
-- **a fence** — after each frame the library sends a cheap request with a
-  reply (`GetInputFocus`). X processes requests strictly in order, so the
-  reply confirms the server has consumed everything the frame drew. At most
-  one fence is ever in flight: on a fast local connection this costs
-  nothing, on a slow link frames automatically degrade to one per
-  round-trip — the latest state is always the next thing drawn, and no
-  backlog builds up. Disable with `frameSync: false`.
+- **the end of the last frame** — either the display reporting that it showed
+  it, or a server round-trip confirming it was consumed. Which one is
+  [below](#what-ends-a-frame). At most one frame is ever outstanding: on a
+  fast local connection this costs nothing, on a slow link frames
+  automatically degrade to one per round-trip — the latest state is always
+  the next thing drawn, and no backlog builds up. Disable with
+  `frameSync: false`.
 - **a timer** — at most one paced frame per `frameInterval` ms (default 16),
-  so a local server isn't asked to redraw at input-device rate.
+  so a local server isn't asked to redraw at input-device rate. Under the
+  vblank clock the display sets the rate instead, and this is only what runs
+  the next frame when one drew nothing at all (there is no present to report
+  back), or a cap you asked for explicitly.
 - **a minimum inter-blit interval** — also `frameInterval`. Blits that are
   *not* part of a paced frame (the one at the end of a discrete event's
   handler, below) skip the timer for latency, and used to be bounded only by
@@ -221,7 +233,69 @@ frames**, gated by three independent mechanisms:
   a compositor every blit is a texture-from-pixmap recomposite. The first blit
   after a quiet moment is still immediate; any that follow within
   `frameInterval` are held back and coalesce into one. `frameInterval: 0`
-  turns this off with the timer gate.
+  turns this off with the timer gate. The vblank clock needs no such interval
+  and does not apply the default one — a frame the display has not shown yet
+  is a truer statement of "too soon" than any number of milliseconds, and it
+  does not make a click wait 16 ms on a 165 Hz screen.
+
+### What ends a frame
+
+A window that presents (`present: true`) takes its frame clock from the
+display. Every frame goes out as a `PresentPixmap`, and the server sends back
+a `CompleteNotify` when it has *executed* that copy, at a vertical blank —
+so that event, rather than a timer or a socket round-trip, is what starts the
+next frame:
+
+```js
+const wnd = app.createWindow({ width: 800, height: 600, present: true });
+// wnd.frameClock === 'present' once the extension has answered
+```
+
+Frames then run at the output's own rate, phase-locked to it, whatever that
+rate is — 60 fps on a 60 Hz panel and 165 on a 165 Hz one, with nothing to
+configure and no rate written down anywhere. A fixed `frameInterval` cannot
+do this: 16 ms is 62.5 fps on any display, and even set to 5.5 ms it would
+free-run against a 180 Hz output rather than lock to it, because Node's
+timers have millisecond granularity and no knowledge of when a vertical blank
+actually is.
+
+Everything else follows from the display being honest about what it showed:
+
+- **the refresh period is measured, not queried.** Completions carry the time
+  and frame count of the presentation, so consecutive ones give the period
+  directly. `wnd.refreshInterval` reports it in ms (`null` until known), and
+  it follows the window to another monitor or through a mode change on its
+  own.
+- **a window nobody can see stops rendering.** A Wayland compositor answers
+  an occluded window about once a second, so its animation loop runs about
+  once a second — measured at ~1 fps under Mutter, against the ~56 fps the
+  same loop burns on the fence clock. Nothing is dropped: the frame that was
+  drawn is still the one shown when the window comes back.
+- **frames the display went through without you are counted.**
+  `wnd.droppedFrames` grows when the frame counter skips, on servers whose
+  counter tracks vertical blanks. Where it counts presents instead
+  (Xwayland), a miss is not observable and it stays at 0 rather than guessing.
+- **the backing store is not redrawn under a copy in progress.** A present
+  with `Option.Copy` owns the pixmap until the copy executes; waiting for the
+  completion is also waiting for it to be handed back.
+
+The fence — a cheap request with a reply (`GetInputFocus`), whose in-order
+answer confirms the server consumed the frame — is what ends a frame
+everywhere else: no Present extension, `frameClock: 'fence'`, or a blit that
+fell back to `CopyArea`. It is also the fallback when completions stop
+arriving: a present the server never executes would otherwise leave the window
+permanently stale, so one that goes unanswered for two seconds hands the clock
+back to the fence, and the next completion to arrive takes it again.
+`wnd.frameClock` reads `'present'` or `'fence'` accordingly, and is assignable
+(`'auto'` / `'fence'`) if you want to pin it.
+
+`frameInterval` still applies as a cap when you set one explicitly, which is
+how you ask for less than the display offers:
+
+```js
+const wnd = app.createWindow({ present: true, frameInterval: 33 }); // ~30 fps
+wnd.frameInterval = 0; // back to the display's rate
+```
 
 While a frame is pending, noisy events **coalesce** instead of queueing:
 
@@ -252,12 +326,13 @@ handler's own requests rather than on the next paced frame — a click's
 `:active` flip is one paint of a few hundred microseconds, and waiting a
 frame interval for it buys nothing. `wnd.frameInFlight()` is the gate to
 make that decision with: `false` means no blit is queued and drawing now
-costs nothing extra, `true` means one already is — because the fence is
-unanswered or because the minimum inter-blit interval is still running — and
-a paint now would only coalesce into it. Both gates are reported, since which
-one bites depends on the connection: the fence on a slow one, the inter-blit
-interval on a fast local server, where the fence for one wheel notch is
-answered before the next notch is even read. Gating on it saves the
+costs nothing extra, `true` means one already is — because the last frame is
+unanswered (its fence unreplied, or its present not yet on the display) or
+because the minimum inter-blit interval is still running — and a paint now
+would only coalesce into it. Every gate is reported, since which one bites
+depends on the connection: the fence on a slow one, the inter-blit interval
+on a fast local server, where the fence for one wheel notch is answered
+before the next notch is even read. Gating on it saves the
 *painting* work in a burst — the blit itself is bounded either way, since the
 minimum inter-blit interval already folds a burst's followers into one
 catch-up frame (the first wheel notch still paints immediately).
@@ -271,28 +346,34 @@ wnd.on('mousedown', (ev) => {
 
 Escape hatches, from mildest to rawest:
 
-- `frameInterval = 0` — fence-only pacing (fastest delivery that cannot
-  fall behind the server), and unpaced blits
-- `frameSync: false` — timer-only pacing, for frames and for blits
+- `frameClock: 'fence'` — the round-trip clock on a window that presents
+- `frameInterval = 0` — no timer gate and no inter-blit interval (fastest
+  delivery that cannot fall behind the server)
+- `frameSync: false` — timer-only pacing, for frames and for blits: no fence,
+  and no waiting on the display either
 - `coalesceEvents: false` — per-event delivery, no merging at all
 - `wnd.on('event', ev => ...)` — the raw X event stream for this window,
   before any name mapping or coalescing
 
-`wnd.frameLatency` reports the last measured fence round-trip in
-milliseconds (`null` until the first frame) — a live estimate of connection
-+ server latency, useful for adapting rendering quality or animation rates.
-Note that with request buffering on (the default, see
-[app.md](app.md)) the fence reply
-also waits for the server to work through the frame it flushed, so this
-reads higher than it did when every request was written on its own — the
-frame *period* is what did not change.
+`wnd.frameLatency` reports how long the last frame took to be answered, in
+milliseconds (`null` until the first one) — useful for adapting rendering
+quality or animation rates. On the fence clock that is a round-trip, a live
+estimate of connection + server latency; on the vblank clock it is the time
+from the frame's requests going out to the server reporting it on the
+display, which *includes* the wait for the next vertical blank and so reads
+around one refresh period even on an idle local connection. Note also that
+with request buffering on (the default, see [app.md](app.md)) the fence reply
+waits for the server to work through the frame it flushed, so this reads
+higher than it did when every request was written on its own — the frame
+*period* is what did not change.
 
 A frame is emitted in one synchronous run, and the fence is a request with a
 reply, which is exactly what makes node-x11 flush: **one socket write per
 frame**, with no explicit flush call anywhere. A 200-rectangle frame is 203
 requests and 1 write; unbuffered it was 203 writes. `frameSync: false` gives
-up the fence, and the flush then happens when the event loop is about to
-poll — still one write per frame.
+up the fence, and so does the vblank clock (a completion is an event, not a
+reply); the flush then happens when the event loop is about to poll — still
+one write per frame.
 
 ### requestAnimationFrame
 
@@ -304,17 +385,39 @@ wnd.cancelAnimationFrame(id);
 ```
 
 The callback runs on the window's next paced frame (`now` is a
-`performance.now()` timestamp). A re-registering animation loop renders at
-~`1000/frameInterval` fps locally and self-throttles to one frame per
-round-trip on slow connections — write the loop once, it behaves everywhere.
+`performance.now()` timestamp). A re-registering animation loop renders one
+frame per vertical blank on a window that presents, at ~`1000/frameInterval`
+fps otherwise, and self-throttles to one frame per round-trip on slow
+connections — write the loop once, it behaves everywhere.
+
+A loop whose callback draws nothing at all still runs: there is no present
+for the display to report back, so those frames fall back to the timer, at
+`refreshInterval` where one has been measured.
+
+```js
+const wnd = app.createWindow({ width: 800, height: 600, present: true });
+const step = () => {
+  draw(); // your painting; the blit goes out with the frame
+  wnd.requestAnimationFrame(step);
+};
+wnd.requestAnimationFrame(step); // now runs at the display's rate
+```
 
 ## Properties
 
 - `wnd.id` — X window id
 - `wnd.width`, `wnd.height`, `wnd.x`, `wnd.y` — geometry, kept in sync on `resize`
-- `wnd.frameLatency` — last fence round-trip, ms (`null` before the first frame)
-- `wnd.frameInterval` — minimum ms between paced frames, and between blits
-  (writable)
+- `wnd.frameLatency` — how long the last frame took to be answered, ms
+  (`null` before the first frame; see above for what it measures on each clock)
+- `wnd.frameInterval` — minimum ms between paced frames, and between blits;
+  a cap on top of the display's rate under the vblank clock (writable)
+- `wnd.frameClock` — which clock is ending this window's frames, `'present'`
+  or `'fence'`; assignable as `'auto'` / `'fence'`
+- `wnd.refreshInterval` — measured display refresh period in ms; `null` on the
+  fence clock, and until two frames have landed one vertical blank apart —
+  so a window capped below the display's rate never measures it
+- `wnd.droppedFrames` — vertical blanks the display went through without a
+  frame from this window, where the server's counter can tell
 - `wnd.app`, `wnd.X`, `wnd.display` — owning app / raw client shortcuts
 
 ## Methods

--- a/lib/window.js
+++ b/lib/window.js
@@ -41,6 +41,63 @@ const SPLIT_SAVING = 0.75;
  */
 const BACKING_GRANULARITY = 128;
 
+/**
+ * Frame period assumed before anything better is known, in ms.
+ *
+ * The fence clock's rate limit, and the vblank clock's placeholder until the
+ * display has reported its own period (see _sampleRefresh).
+ */
+const DEFAULT_FRAME_INTERVAL = 16;
+
+/**
+ * The range a measured vblank period has to fall in to be believed, in ms.
+ *
+ * Completion timestamps come from the server's clock and its idea of a frame
+ * counter, neither of which is guaranteed to mean what it does on a physical
+ * output — a window with no CRTC behind it gets a synthesized msc, and an idle
+ * gap between two presents inflates the period derived from them. A sample
+ * outside 1000Hz..10Hz is not a refresh rate and is dropped.
+ */
+const MIN_REFRESH_INTERVAL = 1;
+const MAX_REFRESH_INTERVAL = 100;
+
+/**
+ * How many recent completion intervals the refresh estimate is drawn from,
+ * and how far up their sorted order it reads.
+ *
+ * Near the bottom rather than the middle, because what the msc counts is not
+ * the same everywhere. Where it counts vertical blanks a one-blank gap is
+ * exactly one period and every sample agrees; where it counts *presents* —
+ * Xwayland advances it once per frame the compositor takes — a slow frame
+ * reports its own duration as if it were the display's, and only the quick
+ * frames are telling the truth. Not the outright minimum, because a
+ * timer-driven fake vblank (Xvfb) jitters in both directions and a single
+ * short gap should not become the answer. A history, rather than a running
+ * value, is what lets the estimate rise again after a mode change to a slower
+ * rate.
+ */
+const REFRESH_SAMPLES = 16;
+const REFRESH_QUANTILE = 0.25;
+
+/**
+ * How long a frame may stay outstanding before the vblank clock is abandoned
+ * for the fence, in ms.
+ *
+ * Deliberately far above any frame rate: this is a deadlock breaker, not a
+ * pacer, and the rate a window is *legitimately* given can be very low. A
+ * Wayland compositor throttles a window nobody can see — measured at ~1Hz for
+ * an occluded window under Mutter — by simply not sending the frame callback
+ * that completes its present, and that window is right to stop rendering.
+ * Waking it up to run frames at fence rate would burn CPU on pixels no one
+ * sees, so the timeout has to sit above the slowest honest answer.
+ *
+ * A server that never completes anything is a different case and worth
+ * catching quickly, so the first present a window ever sends is given the
+ * shorter deadline — nothing has proved it will be answered yet.
+ */
+const STALL_TIMEOUT = 2000;
+const STALL_TIMEOUT_FIRST = 250;
+
 function rectArea(r) {
   return Math.max(0, r.w) * Math.max(0, r.h);
 }
@@ -359,6 +416,10 @@ export default class Window extends Drawable {
     // (see docs/window.md "Frames, coalescing and slow connections")
     this._coalesce = args.coalesceEvents !== false;
     this._frameSyncEnabled = args.frameSync !== false;
+    // which signal ends a frame (see _clockOnPresent): 'auto' takes the
+    // display's own vblank where the Present path can supply it and the fence
+    // everywhere else, 'fence' pins the round-trip clock
+    this._frameClockPref = args.frameClock ?? 'auto';
     // _NET_WM_SYNC_REQUEST (see enableSyncRequest): the counter the window
     // manager watches, the value it last asked for, and the watchdog that
     // guarantees an answer even when nothing repaints
@@ -373,13 +434,30 @@ export default class Window extends Drawable {
     this._fixesExt = null;
     this._updateRegion = 0;
     this._presentSerial = 0;
-    this.frameInterval = args.frameInterval ?? 16;
+    this._presentEid = 0;
+    // The vblank clock (see _onPresentComplete): the period learnt from
+    // completion events, the samples it is drawn from, and the latch the
+    // watchdog sets when completions stop arriving.
+    this.refreshInterval = null;
+    this.droppedFrames = 0;
+    this._refreshSamples = [];
+    this._lastComplete = null;
+    this._clockStalled = false;
+    // `frameInterval` is a plain number, but whether the caller set it is what
+    // decides its meaning under the vblank clock — an explicit value caps the
+    // frame rate, an unasked-for default must not (see _armTimer). Assigning
+    // the property later is the caller setting it, hence the accessor.
+    this._frameInterval = args.frameInterval ?? 16;
+    this._frameIntervalExplicit = args.frameInterval !== undefined;
     this.frameLatency = null;
     this._frame = {
       pending: new Map(), // coalescible event name -> merged event
       rafCbs: [],
       rafId: 0,
       inFlight: false, // fence round-trip awaiting the server's reply
+      presentInFlight: false, // present awaiting the display's CompleteNotify
+      presentAt: 0, // when that present was sent, for frameLatency
+      stallTimer: null,
       timer: null,
       scheduled: false,
       needsRedraw: false,
@@ -519,6 +597,15 @@ export default class Window extends Drawable {
 
     X.event_consumers[this.id] = this;
     this.on('event', (ev) => {
+      // Present speaks in X Generic Events, which carry an extension opcode
+      // and a sub-type where a core event carries its code — the name table
+      // below cannot see them, and they are not events user code asked for
+      if (ev.type === 35) {
+        if (this._presentExt && ev.extension === this._presentExt.majorOpcode) {
+          this._handlePresentEvent(ev);
+        }
+        return;
+      }
       const ntkev = ev; // todo: clone
       ntkev.window = this;
       ntkev.target = this;
@@ -640,7 +727,7 @@ export default class Window extends Drawable {
     this.on('destroy', () => {
       this._destroyed = true;
       this._forget();
-      this._teardownFrame();
+      this._teardownFrame(false); // the server has already taken the window
       // the server frees window-backed pictures with the window — let
       // contexts drop their wrappers without issuing FreePicture
       this.emit('_destroyed');
@@ -897,37 +984,108 @@ export default class Window extends Drawable {
 
   /*
    * Frame clock. Noisy events (see events_map coalesce), synthetic redraws
-   * and requestAnimationFrame callbacks are delivered in "frames", paced by
-   * two independent gates:
+   * and requestAnimationFrame callbacks are delivered in "frames". What ends
+   * a frame — and so what paces the next one — is one of two signals:
    *
-   *  - a fence: a cheap request with a reply (GetInputFocus) sent after each
-   *    frame; X processes requests in order, so its reply confirms the
-   *    server consumed everything the frame drew. At most one fence is in
-   *    flight — on a slow connection frames degrade to one per round-trip
-   *    instead of queueing a trail of stale updates.
-   *  - a timer: at most one paced frame per `frameInterval` ms, so a fast
-   *    local server doesn't get redraws at input-device rate.
+   *  - the display, on a window presenting through the Present extension: the
+   *    CompleteNotify for the frame's PresentPixmap, which the server sends
+   *    when it has executed the copy at a vertical blank. Frames then run at
+   *    the output's own rate, phase-locked to it, whatever that rate is.
+   *  - a fence, everywhere else: a cheap request with a reply
+   *    (GetInputFocus) sent after each frame; X processes requests in order,
+   *    so its reply confirms the server consumed everything the frame drew.
+   *
+   * Either way at most one is outstanding, which is what bounds the work in
+   * flight: on a slow connection frames degrade to one per round-trip instead
+   * of queueing a trail of stale updates.
+   *
+   * A timer backs both up. Under the fence it is the rate limit — at most one
+   * frame per `frameInterval` ms, so a fast local server isn't asked to redraw
+   * at input-device rate. Under the vblank clock the display is the rate
+   * limit, and the timer only covers frames that drew nothing: those produce
+   * no present, so no completion is coming and something else has to run the
+   * next frame (`refreshInterval` is the period there, so a compute-only
+   * animation loop still runs at display rate).
    *
    * Discrete events (mousedown, keydown, ...) bypass the timer for latency:
    * the first blit after a quiet moment goes out with the handler's own
-   * requests. Their blits are still bounded, by the fence and by a minimum
-   * inter-blit interval (also `frameInterval`) — see _present(). Without that
-   * interval a stream of discrete events blits at round-trip rate, which on a
-   * local server is several hundred per second, and under a compositor every
-   * blit is a recomposite.
+   * requests. Their blits are still bounded, by whichever clock is running and
+   * by a minimum inter-blit interval (`frameInterval` again) — see _present().
+   * Without that interval a stream of discrete events blits at round-trip
+   * rate, which on a local server is several hundred per second, and under a
+   * compositor every blit is a recomposite. The vblank clock has no need of
+   * it: a present outstanding already means the display has not caught up.
    */
   _scheduleFrame() {
     const f = this._frame;
-    if (f.scheduled || f.inFlight || f.timer) return;
+    if (f.scheduled || f.inFlight || f.presentInFlight || f.timer) return;
     f.scheduled = true;
     setImmediate(() => {
       f.scheduled = false;
       // gates may have been armed after this got scheduled (work queued
       // from inside a running frame, e.g. a rAF loop re-registering) —
-      // the fence reply / timer expiry will reschedule then
-      if (f.inFlight || f.timer) return;
+      // the completion / fence reply / timer expiry will reschedule then
+      if (f.inFlight || f.presentInFlight || f.timer) return;
       this._runFrame();
     });
+  }
+
+  /**
+   * Minimum ms between paced frames, and between blits.
+   *
+   * Under the vblank clock an *explicit* value is a cap on top of the
+   * display's rate — `frameInterval: 33` renders at 30fps on any output,
+   * which is a real ask on battery — while the default must not cap anything,
+   * or a 165Hz display would be held to the 62.5fps that 16ms implies.
+   * Assigning the property counts as explicit, which is why this is an
+   * accessor: `wnd.frameInterval = 33` has to mean the same as passing it.
+   */
+  get frameInterval() {
+    return this._frameInterval;
+  }
+
+  set frameInterval(ms) {
+    this._frameInterval = ms;
+    this._frameIntervalExplicit = true;
+  }
+
+  /**
+   * Which clock is ending this window's frames right now: 'present' when the
+   * display is, 'fence' when the server round-trip is. Assignable with
+   * 'auto' (prefer the display) or 'fence' (never use it).
+   */
+  get frameClock() {
+    return this._clockOnPresent() ? 'present' : 'fence';
+  }
+
+  set frameClock(mode) {
+    this._frameClockPref = mode === 'present' ? 'auto' : mode;
+    if (this._frameClockPref !== 'fence') this._selectPresentInput();
+  }
+
+  /**
+   * Is the display ending frames on this window, rather than the socket?
+   *
+   * Needs the Present path up (there is no completion event without it) and
+   * the frame sync the caller may have turned off — `frameSync: false` asks
+   * for pacing that never waits on the server, and a completion is the
+   * strongest wait there is. `_clockStalled` is the watchdog's latch: a
+   * completion that never came drops the window back to the fence until one
+   * does, so a clock that stops cannot stop the window with it.
+   *
+   * `_presentFlipped` is the one-way door — a server that has flipped a copy
+   * present is off this path for good, and its blits no longer produce the
+   * completions the clock is made of.
+   */
+  _clockOnPresent() {
+    return (
+      this._frameClockPref !== 'fence' &&
+      this._frameSyncEnabled &&
+      !this._clockStalled &&
+      !this._presentFlipped &&
+      !!this._presentExt &&
+      !!this._presentEid
+    );
   }
 
   _runFrame() {
@@ -966,7 +1124,10 @@ export default class Window extends Drawable {
     // covers a window with no backing store, and a resize that changed
     // nothing: _presentNow did not run, but the frame is still "handled"
     this._ackSyncRequest();
-    this._armFence();
+    // A frame that presented is already clocked — its completion ends it. One
+    // that drew nothing has to fall back to the timer, or nothing would ever
+    // run the next frame.
+    if (!this._clockOnPresent()) this._armFence();
     this._armTimer();
   }
 
@@ -1063,29 +1224,209 @@ export default class Window extends Drawable {
       this.X.GetInputFocus(() => {
         f.inFlight = false;
         this.frameLatency = performance.now() - start;
-        if (this._presentPending) {
-          // a blit deferred while the fence was in flight: show it as soon as
-          // the minimum inter-blit interval allows (immediately when the last
-          // blit is already older than that, which is the common case)
-          this._present();
-        }
-        if ((f.pending.size || f.rafCbs.length || f.needsRedraw) && !f.timer) this._scheduleFrame();
+        this._frameEnded();
       });
     });
   }
 
+  /**
+   * Present's events, which are the ones the core event table cannot name:
+   * they arrive as X Generic Events (type 35), carrying an extension opcode
+   * and a sub-type instead of an event code.
+   */
+  _handlePresentEvent(ev) {
+    const P = this._presentExt;
+    if (!P || ev.evtype !== P.events.CompleteNotify) return;
+    if (ev.kind !== P.CompleteKind.Pixmap) return; // not a frame of ours
+    if (ev.mode === P.CompleteMode.Flip) {
+      // The server took the pixmap for scanout instead of copying it, and
+      // keeps it until some later present — but ntk has one grow-only backing
+      // pixmap and is about to draw into it, which would now paint the screen
+      // directly. Option.Copy is passed on every present precisely so this
+      // cannot happen (presentproto: "'pixmap' will be idle ... as soon as the
+      // operation occurs"), so a server doing it anyway is one whose Present
+      // path we cannot use at all.
+      this._presentFlipped = true;
+      this.app.options.onXError?.(
+        new Error(
+          'ntk: the X server flipped a present sent with Option.Copy, which leaves it ' +
+            "owning the window's backing pixmap — falling back to CopyArea blits"
+        )
+      );
+      this._stallClock();
+      return;
+    }
+    this._onPresentComplete(ev);
+  }
+
+  /**
+   * A frame reached the display: the server executed the copy, at a vblank.
+   *
+   * This is `_armFence`'s reply callback with a better trigger behind it. The
+   * fence proves the server *read* the frame's requests; this proves it *ran*
+   * them, on the output, which is both a stronger flow-control signal and the
+   * moment the backing pixmap is ours to draw into again.
+   */
+  _onPresentComplete(ev) {
+    const f = this._frame;
+    const now = performance.now();
+    this._clearStallWatchdog();
+    // completions are arriving again, whatever the watchdog concluded before
+    this._clockStalled = false;
+    if (!f.presentInFlight) return; // a completion we are not clocking on
+    f.presentInFlight = false;
+    this.frameLatency = now - f.presentAt;
+    this._sampleRefresh(ev, now);
+    this._frameEnded();
+  }
+
+  /**
+   * What both clocks do when a frame ends: send the blit that was held back
+   * behind it, then run the next frame if anything is waiting for one.
+   */
+  _frameEnded() {
+    const f = this._frame;
+    if (this._presentPending) {
+      // a blit deferred while the frame was outstanding: show it as soon as
+      // the pacing allows, which under the vblank clock is now
+      this._present();
+    }
+    if ((f.pending.size || f.rafCbs.length || f.needsRedraw) && !f.timer) this._scheduleFrame();
+  }
+
+  /**
+   * Learn the display's refresh period from the frame that just landed.
+   *
+   * Two completions give it without asking anyone: `ust` is when the
+   * presentation happened (microseconds, on the server's clock) and `msc`
+   * counts the frames between them, so their ratio is one vblank. Nothing is
+   * configured, nothing is queried, and it follows the window to another
+   * monitor or through a mode change on its own — where a RandR lookup would
+   * need change-tracking to keep up.
+   *
+   * Only differences are read from the server clock, never an absolute time,
+   * and a sample is believed only if it lands in the range a refresh rate can
+   * be in — which is also what keeps a window the compositor has throttled to
+   * a frame a second from being mistaken for a 1Hz display.
+   */
+  _sampleRefresh(ev, now) {
+    const prev = this._lastComplete;
+    this._lastComplete = { msc: ev.msc, ust: ev.ust, at: now };
+    if (!prev || !(ev.msc > prev.msc)) return;
+    const frames = ev.msc - prev.msc;
+    // Frames the display went through without one of ours. Counted from the
+    // msc, which is the only place the information exists: where the counter
+    // tracks presents rather than vblanks the gap is always 1 and a miss is
+    // simply not observable, and reporting nothing beats inferring it from
+    // elapsed time on a server whose timing is synthetic to begin with.
+    //
+    // Only across a gap short enough to have been a frame at all. A window
+    // that sat idle between two clicks also let the counter run, and that is
+    // not a dropped frame; past a tenth of a second the two are anyway
+    // indistinguishable, and under-reporting is the right way for a
+    // diagnostic to be wrong.
+    if (now - prev.at <= MAX_REFRESH_INTERVAL) this.droppedFrames += frames - 1;
+    // Only a single-frame gap measures a frame's length. A longer one spans a
+    // miss, and dividing it out assumes the msc advanced for the same reason
+    // in each — true of a hardware counter, false of one driven off a timer,
+    // where it makes a late frame look like a *faster* display.
+    if (frames !== 1) return;
+    // ust is the server's clock and local receipt is ours; they measure the
+    // same interval, so the local one stands in when ust is not usable (a
+    // synthesized msc can carry a ust that does not move with it)
+    const byUst = (ev.ust - prev.ust) / 1000;
+    const sample = byUst >= MIN_REFRESH_INTERVAL ? byUst : now - prev.at;
+    if (!(sample >= MIN_REFRESH_INTERVAL && sample <= MAX_REFRESH_INTERVAL)) return;
+    const samples = this._refreshSamples;
+    samples.push(sample);
+    if (samples.length > REFRESH_SAMPLES) samples.shift();
+    const sorted = [...samples].sort((a, b) => a - b);
+    this.refreshInterval = sorted[Math.floor(REFRESH_QUANTILE * (sorted.length - 1))];
+  }
+
+  /**
+   * Guarantee that a frame ends even if its completion does not arrive.
+   *
+   * A fence is a request with a reply and the server always sends one. A
+   * completion is an event about work the server may never do: an unmapped
+   * window, a compositor changing its mind about redirection, or simply a
+   * server whose Present is a stub. `_presentPending` has exactly one wakeup,
+   * so a completion that never comes would be a window that never updates
+   * again — a permanently stale window, which is the trap #195 hit.
+   *
+   * See STALL_TIMEOUT for why the deadline is measured in seconds rather than
+   * in frames: a slow answer is usually the display being honest about how
+   * often this window is worth drawing.
+   */
+  _armStallWatchdog() {
+    const f = this._frame;
+    if (f.stallTimer) return;
+    const timeout = this._lastComplete ? STALL_TIMEOUT : STALL_TIMEOUT_FIRST;
+    f.stallTimer = setTimeout(() => {
+      f.stallTimer = null;
+      if (f.presentInFlight) this._stallClock();
+    }, timeout);
+    if (typeof f.stallTimer.unref === 'function') f.stallTimer.unref();
+  }
+
+  _clearStallWatchdog() {
+    const f = this._frame;
+    if (!f.stallTimer) return;
+    clearTimeout(f.stallTimer);
+    f.stallTimer = null;
+  }
+
+  /**
+   * Give up on the display as a clock, for now. The fence takes over, and the
+   * next completion to arrive hands it back (see _onPresentComplete) — a
+   * window that is merely unmapped for a while must not be left on the slower
+   * clock forever.
+   */
+  _stallClock() {
+    const f = this._frame;
+    this._clockStalled = true;
+    f.presentInFlight = false;
+    this._clearStallWatchdog();
+    // nothing else needs re-arming: an idle window wants no clock, and the
+    // frame _frameEnded schedules will arm the fence on its way out
+    this._frameEnded();
+  }
+
+  /**
+   * The timer gate, whose period depends on what it is standing in for.
+   *
+   * Under the fence it is the rate limit and `frameInterval` is the period.
+   * Under the vblank clock it is the fallback for a frame that presented
+   * nothing — there is no completion coming for a frame that drew nothing —
+   * so the period is the display's, and a frame that *did* present arms no
+   * timer at all: the completion is closer and more accurate than any timer,
+   * and arming one would only cap the rate the display just set. An explicit
+   * `frameInterval` is honoured in both, since a cap the caller asked for
+   * applies whatever ends the frame.
+   */
   _armTimer() {
-    if (!(this.frameInterval > 0)) return;
     const f = this._frame;
     if (f.timer) return;
+    let period = this.frameInterval;
+    if (this._clockOnPresent() && !this._frameIntervalExplicit) {
+      if (f.presentInFlight) return;
+      period = this.refreshInterval ?? DEFAULT_FRAME_INTERVAL;
+    }
+    if (!(period > 0)) return;
     f.timer = setTimeout(() => {
       f.timer = null;
       if (f.pending.size || f.rafCbs.length || f.needsRedraw) this._scheduleFrame();
-    }, this.frameInterval);
+    }, period);
     if (typeof f.timer.unref === 'function') f.timer.unref();
   }
 
-  _teardownFrame() {
+  /**
+   * @param {boolean} [windowAlive] false when the server has already destroyed
+   *   the window (a DestroyNotify), which takes its Present event context with
+   *   it — deleting one explicitly then is a request against a window id that
+   *   no longer exists, i.e. a BadWindow for the app's error hook to explain.
+   */
+  _teardownFrame(windowAlive = true) {
     const f = this._frame;
     if (f.timer) {
       clearTimeout(f.timer);
@@ -1094,6 +1435,18 @@ export default class Window extends Drawable {
     if (f.presentTimer) {
       clearTimeout(f.presentTimer);
       f.presentTimer = null;
+    }
+    this._clearStallWatchdog();
+    if (this._presentEid) {
+      const eid = this._presentEid;
+      const P = this._presentExt;
+      this._presentEid = 0;
+      f.presentInFlight = false;
+      safeRelease(this.X, () => {
+        // an empty mask deletes the event context (presentproto)
+        if (windowAlive && P) P.SelectInput(eid, this.id, P.EventMask.NoEvent);
+        this.X.ReleaseID(eid);
+      });
     }
     if (this._syncWatchdog) {
       clearTimeout(this._syncWatchdog);
@@ -1129,9 +1482,10 @@ export default class Window extends Drawable {
 
   /**
    * DOM-style requestAnimationFrame: `cb(now)` runs on this window's next
-   * paced frame — at most once per `frameInterval` ms and with at most one
-   * frame's requests unacknowledged by the server, so animation loops adapt
-   * to connection latency instead of flooding a slow link.
+   * paced frame — one per vertical blank where the display is the clock (see
+   * _clockOnPresent), otherwise at most once per `frameInterval` ms — and
+   * always with at most one frame outstanding, so animation loops adapt to
+   * the output's rate and to connection latency instead of flooding either.
    * Returns an id for cancelAnimationFrame().
    */
   requestAnimationFrame(cb) {
@@ -1150,8 +1504,9 @@ export default class Window extends Drawable {
 
   /**
    * Whether a blit this window already owes is still waiting to go out —
-   * because the fence for the last frame is unanswered, or because a present
-   * is deferred behind the minimum inter-blit interval.
+   * because the last frame is unanswered (its fence unreplied, or its present
+   * not yet on the display), or because a present is deferred behind the
+   * minimum inter-blit interval.
    *
    * The one bit of frame-clock state worth publishing, because it is the
    * difference between the two ways a toolkit can answer a discrete input.
@@ -1173,24 +1528,29 @@ export default class Window extends Drawable {
    * "draw it now" to every notch — the precise work this gate exists to skip.
    *
    * `false` whenever nothing gates blits at all: `frameSync: false` sends no
-   * fence and `frameInterval: 0` keeps no interval, so a caller who asked for
-   * both gets the unpaced behaviour those options ask for.
+   * fence and takes the vblank clock with it (a completion is a wait on the
+   * server too), and `frameInterval: 0` keeps no interval, so a caller who
+   * asked for both gets the unpaced behaviour those options ask for.
    */
   frameInFlight() {
-    return this._frame.inFlight || this._presentPending;
+    return this._frame.inFlight || this._frame.presentInFlight || this._presentPending;
   }
 
   _present() {
     if (!this._backing) return;
+    const f = this._frame;
     const wait = this._presentWait();
-    if (this._frame.inFlight || wait > 0) {
-      // the server hasn't confirmed the previous frame yet, or the last blit
-      // was too recent — defer, and leave a wakeup behind
+    if (f.inFlight || f.presentInFlight || wait > 0) {
+      // the server hasn't confirmed the previous frame yet, the display hasn't
+      // shown it, or the last blit was too recent — defer, leaving a wakeup
       this._deferPresent(wait);
       return;
     }
     this._presentNow();
-    this._armFence();
+    // the fence is what ends this blit's frame unless the display is doing
+    // it — which is decided by _presentNow, since a blit that fell back to
+    // CopyArea gets no completion however the clock is configured
+    if (!f.presentInFlight) this._armFence();
   }
 
   /**
@@ -1199,8 +1559,16 @@ export default class Window extends Drawable {
    * The gate is `frameInterval`, the same knob that paces frames, so
    * `frameInterval: 0` keeps the old fence-only behaviour — a caller who asked
    * for no timer gate gets none here either.
+   *
+   * The vblank clock needs no such gate and must not inherit the default one:
+   * an outstanding present already means the display has not caught up, and
+   * that is a truer statement of the same thing than any interval. Holding a
+   * click's repaint for a 16ms default on a 165Hz output is exactly the
+   * latency this gate was careful not to add. An explicit interval still
+   * applies — a cap the caller asked for is a cap.
    */
   _presentWait() {
+    if (this._clockOnPresent() && !this._frameIntervalExplicit) return 0;
     const min = this.frameInterval;
     if (!(min > 0)) return 0;
     const since = performance.now() - this._frame.lastPresentAt;
@@ -1211,16 +1579,17 @@ export default class Window extends Drawable {
    * Hold a blit back, and guarantee it still happens.
    *
    * This is the only place `_presentPending` is set, because every deferral has
-   * to leave a wakeup behind: the fence reply when the fence is what we are
-   * waiting on, this timer when the interval is. Nothing else reschedules a
-   * present — `_scheduleFrame()` bails while a frame timer is armed, and
-   * neither reschedule condition (in `_armFence`'s reply or `_armTimer`'s
-   * callback) looks at the present. Without the timer the last blit of a burst
-   * would simply never go out, leaving stale pixels on screen.
+   * to leave a wakeup behind: the end of the frame we are waiting on (its
+   * fence reply, or its completion), this timer when the interval is what we
+   * are waiting on. Nothing else reschedules a present — `_scheduleFrame()`
+   * bails while a frame timer is armed, and no reschedule condition
+   * (`_frameEnded`, `_armTimer`'s callback) looks at the present. Without the
+   * timer the last blit of a burst would simply never go out, leaving stale
+   * pixels on screen.
    */
   _deferPresent(wait) {
     this._presentPending = true;
-    if (wait <= 0) return; // waiting on the fence: its reply blits this
+    if (wait <= 0) return; // waiting on the frame: its end blits this
     const f = this._frame;
     if (f.presentTimer) return; // already armed
     f.presentTimer = setTimeout(() => {
@@ -1228,9 +1597,9 @@ export default class Window extends Drawable {
       if (!this._presentPending && !this._dirty) return; // someone blitted it
       const again = this._presentWait();
       if (again > 0) return this._deferPresent(again); // a paced frame re-stamped
-      if (f.inFlight) return; // the fence ack is closer; it will blit
+      if (f.inFlight || f.presentInFlight) return; // the frame's end is closer
       this._presentNow();
-      this._armFence();
+      if (!f.presentInFlight) this._armFence();
     }, wait);
     if (typeof f.presentTimer.unref === 'function') f.presentTimer.unref();
   }
@@ -1263,16 +1632,48 @@ export default class Window extends Drawable {
    */
   enablePresent() {
     if (this._presentExt || this._destroyed) return Promise.resolve(this);
+    // Memoized because `createWindow({ present: true })` starts this and
+    // `await wnd.enablePresent()` is the documented way to find out whether it
+    // took — doing both is the normal thing to write, and two runs in flight
+    // at once would each allocate an update region, orphaning one on the
+    // server for the life of the window.
+    if (this._presentPromise) return this._presentPromise;
     const X = this.X;
     const need = (name) =>
       new Promise((resolve) => X.require(name, (err, ext) => resolve(err ? null : ext)));
-    return Promise.all([need('present'), need('fixes')]).then(([present, fixes]) => {
+    this._presentPromise = Promise.all([need('present'), need('fixes')]).then(([present, fixes]) => {
       if (!present || !fixes || this._destroyed) return this; // stay on CopyArea
       this._updateRegion = X.AllocID();
       safeRelease(X, () => fixes.CreateRegion(this._updateRegion, []));
       this._presentExt = present;
       this._fixesExt = fixes;
+      this._selectPresentInput();
       return this;
+    });
+    return this._presentPromise;
+  }
+
+  /**
+   * Ask for the completion events the vblank clock runs on.
+   *
+   * CompleteNotify only; IdleNotify would say the same thing twice, since
+   * every present ntk sends carries Option.Copy and the spec makes such a
+   * pixmap idle "as soon as the operation occurs" — the moment the completion
+   * reports. Nothing is selected for a window pinned to the fence, so a
+   * caller who opted out is not sent events it will not read.
+   */
+  _selectPresentInput() {
+    const P = this._presentExt;
+    if (!P || this._presentEid || this._destroyed) return;
+    if (this._frameClockPref === 'fence' || !this._frameSyncEnabled) return;
+    const eid = this.X.AllocID();
+    // the id is only recorded once the request is really on its way: the
+    // clock's whole contract is that a completion will arrive, and a
+    // selection that never left (a connection closing under us) promises
+    // nothing. Failing this way leaves the window on the fence, which works.
+    safeRelease(this.X, () => {
+      P.SelectInput(eid, this.id, P.EventMask.CompleteNotify);
+      this._presentEid = eid;
     });
   }
 
@@ -1284,6 +1685,7 @@ export default class Window extends Drawable {
   _presentWithExtension(rects) {
     const P = this._presentExt;
     if (!P || !this._fixesExt || !this._updateRegion) return false;
+    if (this._presentFlipped) return false; // see _handlePresentEvent
     safeRelease(this.X, () => {
       this._fixesExt.SetRegion(
         this._updateRegion,
@@ -1329,10 +1731,20 @@ export default class Window extends Drawable {
     // Stamped here rather than at the call sites so it is a true inter-blit
     // interval across all three of them, and only when pixels really move — a
     // present that copies nothing must not push the next one out.
-    this._frame.lastPresentAt = performance.now();
+    const f = this._frame;
+    f.lastPresentAt = performance.now();
     // Present sends the exact rectangles in one request, so the bounding-box
     // collapse — which trades pixels for fewer requests — has nothing to buy
-    if (!this._presentWithExtension(clamped)) {
+    if (this._presentWithExtension(clamped)) {
+      // This frame is now the display's to end. Only a present through the
+      // extension can be: a CopyArea reports nothing back, so a window that
+      // fell back to it must keep the fence even with the clock configured.
+      if (this._clockOnPresent()) {
+        f.presentInFlight = true;
+        f.presentAt = f.lastPresentAt;
+        this._armStallWatchdog();
+      }
+    } else {
       const rects = this._blitList(clamped);
       // a paced frame can fire after the connection started closing
       safeRelease(this.X, () => {

--- a/test/present-blit.test.js
+++ b/test/present-blit.test.js
@@ -11,11 +11,19 @@ import Window from '../lib/window.js';
 let nextId = 0xe000;
 
 function makeMockApp({ present = true, fixes = true } = {}) {
-  const calls = { copies: [], presents: [], regions: [], destroyedRegions: [] };
+  const calls = { copies: [], presents: [], regions: [], destroyedRegions: [], selects: [] };
   const Present = {
+    majorOpcode: 145,
     Option: { None: 0, Async: 1, Copy: 2, UST: 4, Suboptimal: 8 },
+    EventMask: { NoEvent: 0, ConfigureNotify: 1, CompleteNotify: 2, IdleNotify: 4 },
+    CompleteKind: { Pixmap: 0, NotifyMSC: 1 },
+    CompleteMode: { Copy: 0, Flip: 1, Skip: 2, SuboptimalCopy: 3 },
+    events: { ConfigureNotify: 0, CompleteNotify: 1, IdleNotify: 2 },
     Pixmap(window, pixmap, opts) {
       calls.presents.push({ window, pixmap, opts });
+    },
+    SelectInput(eid, window, eventMask) {
+      calls.selects.push({ eid, window, eventMask });
     }
   };
   const Fixes = {
@@ -64,9 +72,28 @@ function makeMockApp({ present = true, fixes = true } = {}) {
   return { app: { X, display, options: {} }, calls };
 }
 
+/**
+ * The CompleteNotify the server sends when it has executed a present, which
+ * is what ends a frame on a window using the vblank clock — a mock server
+ * that never sent one would hold the window at one frame forever.
+ */
+function complete(wnd, { msc = 1, ust = 1e6, mode = 0, kind = 0 } = {}) {
+  wnd.emit('event', {
+    type: 35,
+    extension: 145,
+    evtype: 1, // CompleteNotify
+    kind,
+    mode,
+    serial: wnd._presentSerial,
+    ust,
+    msc,
+    wid: wnd.id
+  });
+}
+
 async function presentWindow(opts) {
   const { app, calls } = makeMockApp(opts);
-  const wnd = new Window(app, { width: 200, height: 100 });
+  const wnd = new Window(app, { width: 200, height: 100, ...opts?.args });
   wnd.width = 200;
   wnd.height = 100;
   wnd._backing = { id: 0xb200, width: 200, height: 100, destroy() {} };
@@ -120,7 +147,7 @@ test('a second frame reuses the same region and bumps the serial', async () => {
   const { wnd, calls } = await presentWindow();
   wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
   await tick();
-  wnd._frame.lastPresentAt = -Infinity; // let the next blit through the pacer
+  complete(wnd); // the display consumed the first frame; the next may go out
   wnd._markDirty({ x: 20, y: 20, w: 10, h: 10 });
   await tick();
 

--- a/test/present-clock.test.js
+++ b/test/present-clock.test.js
@@ -1,0 +1,422 @@
+// The frame clock running on the display instead of on the socket
+// (lib/window.js). A window presenting through the Present extension ends its
+// frames on CompleteNotify — the event the server sends when it has executed
+// the copy at a vertical blank — so frames run at the output's rate whatever
+// that rate is. Completions are injected by hand here, which lets one test
+// model a 180Hz display and the next a server that never answers at all.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick, setTimeout as sleep } from 'node:timers/promises';
+
+import Window from '../lib/window.js';
+
+let nextId = 0xf000;
+
+const PRESENT_OPCODE = 145;
+
+function makeMockApp({ present = true, fixes = true } = {}) {
+  const calls = { copies: 0, presents: [], selects: [], fences: [] };
+  const Present = {
+    majorOpcode: PRESENT_OPCODE,
+    Option: { None: 0, Async: 1, Copy: 2, UST: 4, Suboptimal: 8 },
+    EventMask: { NoEvent: 0, ConfigureNotify: 1, CompleteNotify: 2, IdleNotify: 4 },
+    CompleteKind: { Pixmap: 0, NotifyMSC: 1 },
+    CompleteMode: { Copy: 0, Flip: 1, Skip: 2, SuboptimalCopy: 3 },
+    events: { ConfigureNotify: 0, CompleteNotify: 1, IdleNotify: 2 },
+    Pixmap(window, pixmap, opts) {
+      calls.presents.push({ window, pixmap, opts });
+    },
+    SelectInput(eid, window, eventMask) {
+      calls.selects.push({ eid, window, eventMask });
+    }
+  };
+  const Fixes = {
+    CreateRegion() {},
+    SetRegion() {},
+    DestroyRegion() {}
+  };
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    atoms: {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    ChangeProperty() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea() {
+      calls.copies++;
+    },
+    // held, not answered: a test that wants the fence clock to advance
+    // releases them, and one that does not can tell a fence was even sent
+    GetInputFocus(cb) {
+      calls.fences.push(cb);
+    },
+    InternAtom(o, name, cb) {
+      cb(null, 1);
+    },
+    require(name, cb) {
+      if (name === 'present') return present ? cb(null, Present) : cb(new Error('no present'));
+      if (name === 'fixes') return fixes ? cb(null, Fixes) : cb(new Error('no fixes'));
+      cb(new Error(`no ${name}`));
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display, options: {} }, calls };
+}
+
+async function presentWindow(args = {}, mock = {}) {
+  const { app, calls } = makeMockApp(mock);
+  const wnd = new Window(app, { width: 200, height: 100, ...args });
+  wnd.width = 200;
+  wnd.height = 100;
+  wnd._backing = { id: 0xb200, width: 200, height: 100, destroy() {} };
+  wnd._presentGc = 0xc200;
+  await wnd.enablePresent();
+  return { wnd, calls, app };
+}
+
+/** The server reporting that a frame reached the display. */
+function complete(wnd, { msc = 1, ust = 1_000_000, mode = 0, kind = 0, serial } = {}) {
+  wnd.emit('event', {
+    type: 35,
+    extension: PRESENT_OPCODE,
+    evtype: 1, // CompleteNotify
+    kind,
+    mode,
+    serial: serial ?? wnd._presentSerial,
+    ust,
+    msc,
+    wid: wnd.id
+  });
+}
+
+/** A repainting animation loop, of the shape an app actually writes. */
+function animate(wnd, state = { frames: 0 }) {
+  const step = () => {
+    state.frames++;
+    wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+    wnd.requestAnimationFrame(step);
+  };
+  wnd.requestAnimationFrame(step);
+  return state;
+}
+
+test('a window on the Present path selects for the completions it clocks on', async () => {
+  const { wnd, calls } = await presentWindow();
+  assert.equal(calls.selects.length, 1, 'one PresentSelectInput');
+  assert.equal(calls.selects[0].window, wnd.id);
+  assert.equal(calls.selects[0].eventMask, 2, 'CompleteNotify, and not IdleNotify');
+  assert.equal(wnd.frameClock, 'present', 'and reports the clock it is on');
+  wnd.destroy();
+});
+
+test('frames run one per completion, not one per frameInterval', async () => {
+  const { wnd, calls } = await presentWindow();
+  const state = animate(wnd);
+  await tick();
+  assert.equal(state.frames, 1, 'the first frame runs immediately');
+  assert.equal(calls.presents.length, 1);
+
+  // nothing from the display: the loop stays where it is, however long we wait
+  await sleep(60);
+  assert.equal(state.frames, 1, 'no completion, no frame — not even after 3 frameIntervals');
+  assert.equal(calls.fences.length, 0, 'and no fence: the display is the clock');
+
+  complete(wnd, { msc: 1 });
+  await tick();
+  assert.equal(state.frames, 2, 'the completion is what runs the next frame');
+  assert.equal(calls.presents.length, 2);
+  wnd.destroy();
+});
+
+test('a 180Hz display drives 180 frames a second, unconfigured', async () => {
+  const { wnd, calls } = await presentWindow();
+  const state = animate(wnd);
+  await tick();
+
+  // 180Hz is 5.555ms; ust is microseconds on the server's clock
+  const PERIOD_US = 1_000_000 / 180;
+  for (let i = 1; i <= 20; i++) {
+    complete(wnd, { msc: i, ust: 1_000_000 + Math.round(i * PERIOD_US) });
+    await tick();
+  }
+
+  assert.equal(state.frames, 21, 'one frame per vblank, none skipped');
+  assert.equal(calls.presents.length, 21);
+  assert.ok(
+    Math.abs(wnd.refreshInterval - 1000 / 180) < 0.05,
+    `learnt the period from the display: ${wnd.refreshInterval} ms`
+  );
+  assert.equal(wnd.droppedFrames, 0);
+  // the default frameInterval must not have capped any of this
+  assert.equal(wnd.frameInterval, 16);
+  wnd.destroy();
+});
+
+test('the refresh estimate reads the quick frames, not the average one', async () => {
+  // On Xwayland the msc counts presents rather than vblanks, so a frame that
+  // took 40ms reports 40ms between consecutive mscs — the display's period is
+  // what the frames that kept up report, never the mean of them.
+  const { wnd } = await presentWindow();
+  animate(wnd);
+  await tick();
+
+  // the first completion has nothing to measure against, so the first gap
+  // here is the one that establishes the period
+  const gaps = [16_666, 16_666, 40_000, 16_666, 33_000, 16_666, 16_666, 50_000];
+  let ust = 1_000_000;
+  for (let i = 0; i < gaps.length; i++) {
+    ust += gaps[i];
+    complete(wnd, { msc: i + 1, ust });
+    await tick();
+  }
+  assert.ok(
+    Math.abs(wnd.refreshInterval - 16.666) < 0.01,
+    `60Hz, not the 24ms average: ${wnd.refreshInterval}`
+  );
+  wnd.destroy();
+});
+
+test('a vblank the display went through without us is a dropped frame', async () => {
+  const { wnd } = await presentWindow();
+  animate(wnd);
+  await tick();
+  // a hardware msc counts vertical blanks, so a gap of 3 is two the window
+  // was not ready for
+  complete(wnd, { msc: 10, ust: 1_000_000 });
+  await tick();
+  assert.equal(wnd.droppedFrames, 0, 'the first frame had nothing to be late against');
+  complete(wnd, { msc: 11, ust: 1_016_666 });
+  await tick();
+  assert.equal(wnd.droppedFrames, 0, 'kept up');
+  complete(wnd, { msc: 14, ust: 1_066_664 });
+  await tick();
+  assert.equal(wnd.droppedFrames, 2, 'missed two');
+  // and a gap that spans a miss does not get divided out into a fast display
+  assert.ok(
+    Math.abs(wnd.refreshInterval - 16.666) < 0.01,
+    `still 60Hz, not 16.6ms: ${wnd.refreshInterval}`
+  );
+  wnd.destroy();
+});
+
+test('an idle gap between frames is not a dropped frame', async () => {
+  const { wnd } = await presentWindow();
+  // one frame, then quiet, then another — a click, a pause, another click.
+  // The display's counter ran the whole time; the window was not late.
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  complete(wnd, { msc: 1, ust: 1_000_000 });
+  await tick();
+
+  await sleep(150);
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  complete(wnd, { msc: 10, ust: 1_150_000 });
+  await tick();
+  assert.equal(wnd.droppedFrames, 0, 'the app was idle, not late');
+  wnd.destroy();
+});
+
+test('a frame that draws nothing still runs the next one', async () => {
+  // No drawing means no present, so no completion is coming — the timer has
+  // to cover it, or a compute-only rAF loop would stop after one frame (and,
+  // with no gate left, a naive implementation would spin instead).
+  const { wnd, calls } = await presentWindow();
+  let frames = 0;
+  const step = () => {
+    frames++;
+    wnd.requestAnimationFrame(step);
+  };
+  wnd.requestAnimationFrame(step);
+
+  await sleep(70);
+  assert.equal(calls.presents.length, 0, 'nothing was drawn, so nothing was presented');
+  assert.ok(frames > 2, `the loop kept running: ${frames} frames`);
+  assert.ok(frames < 60, `and was paced rather than spinning: ${frames} frames in 70ms`);
+  wnd.destroy();
+});
+
+test('a completion that never comes falls back to the fence', async () => {
+  const { wnd, calls } = await presentWindow();
+  const state = animate(wnd);
+  await tick();
+  assert.equal(state.frames, 1);
+  assert.equal(wnd.frameClock, 'present');
+
+  // the server takes the present and says nothing — a Present that is a stub.
+  // Nothing has answered this window yet, so it is given the short deadline.
+  await sleep(300);
+  assert.equal(wnd.frameClock, 'fence', 'the watchdog gave up on the display');
+  assert.ok(state.frames > 1, `and frames resumed: ${state.frames}`);
+  assert.ok(calls.fences.length > 0, 'on the fence clock');
+
+  // ... and hands the clock back the moment a completion arrives
+  for (const fence of calls.fences.splice(0)) fence(null, {});
+  await tick();
+  complete(wnd, { msc: 1 });
+  await tick();
+  assert.equal(wnd.frameClock, 'present', 'completions are arriving again');
+  wnd.destroy();
+});
+
+test('a window the compositor is throttling is not treated as stalled', async () => {
+  // A Wayland compositor answers an occluded window about once a second, by
+  // simply not sending the frame callback that completes its present. That
+  // window is right to stop rendering, and a watchdog that fired at frame
+  // rate would wake it back up to draw pixels nobody can see.
+  const { wnd, calls } = await presentWindow();
+  animate(wnd);
+  await tick();
+  complete(wnd, { msc: 1, ust: 1_000_000 });
+  await tick();
+
+  await sleep(300);
+  assert.equal(wnd.frameClock, 'present', 'still the display clock, just a slow one');
+  assert.equal(calls.fences.length, 0, 'and no fence went out to hurry it along');
+  wnd.destroy();
+});
+
+test("frameClock: 'fence' keeps the round-trip clock and asks for no events", async () => {
+  const { wnd, calls } = await presentWindow({ frameClock: 'fence' });
+  assert.deepEqual(calls.selects, [], 'no completions selected for a window that will not read them');
+  assert.equal(wnd.frameClock, 'fence');
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.presents.length, 1, 'still presents — the request shape is unrelated');
+  assert.equal(calls.fences.length, 1, 'and is clocked by the fence');
+  wnd.destroy();
+});
+
+test('frameSync: false turns the vblank clock off with the fence', async () => {
+  // "pacing that never waits on the server" has to include waiting for the
+  // server to put a frame on the display.
+  const { wnd, calls } = await presentWindow({ frameSync: false, frameInterval: 25 });
+  assert.deepEqual(calls.selects, []);
+  assert.equal(wnd.frameClock, 'fence');
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.fences.length, 0, 'no fence either');
+  wnd.destroy();
+});
+
+test('an explicit frameInterval still caps the display', async () => {
+  const { wnd, calls } = await presentWindow({ frameInterval: 40 });
+  const state = animate(wnd);
+  await tick();
+  assert.equal(state.frames, 1);
+
+  // a 60Hz display would offer 4 frames in this window; the cap allows one
+  for (let i = 1; i <= 4; i++) {
+    complete(wnd, { msc: i, ust: 1_000_000 + i * 16_666 });
+    await tick();
+  }
+  assert.equal(state.frames, 1, 'held at the cap, not at the display rate');
+  await sleep(60);
+  assert.ok(state.frames > 1, `and released by it: ${state.frames}`);
+  assert.ok(state.frames < 4, 'but not up to the display rate');
+  wnd.destroy();
+});
+
+test('assigning frameInterval later counts as asking for a cap', async () => {
+  const { wnd } = await presentWindow();
+  assert.equal(wnd._frameIntervalExplicit, false, 'the default is not a cap');
+  wnd.frameInterval = 33;
+  assert.equal(wnd.frameInterval, 33);
+  assert.equal(wnd._frameIntervalExplicit, true, 'but an assignment is');
+  wnd.destroy();
+});
+
+test('a discrete input repaints immediately, and a second one coalesces', async () => {
+  // The inter-blit interval exists to stop a burst blitting at round-trip
+  // rate; an outstanding present says the same thing more accurately, and
+  // without holding the first repaint for a frame of nothing.
+  const { wnd, calls } = await presentWindow();
+  assert.equal(wnd.frameInFlight(), false);
+
+  wnd.emit('event', { type: 4, x: 1, y: 1 }); // mousedown
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.presents.length, 1, 'painted with the handler, not a frame later');
+  assert.equal(wnd.frameInFlight(), true, 'and the display now owes us the frame');
+
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.presents.length, 1, 'the next one folds into the outstanding frame');
+
+  complete(wnd, { msc: 1 });
+  await tick();
+  assert.equal(calls.presents.length, 2, 'and goes out when the display has caught up');
+  assert.equal(wnd.frameInFlight(), true, 'which is itself a frame the display owes');
+
+  complete(wnd, { msc: 2 });
+  await tick();
+  assert.equal(wnd.frameInFlight(), false, 'and nothing is owed once that lands');
+  wnd.destroy();
+});
+
+test('a server that flips a Copy present is dropped back to CopyArea', async () => {
+  // Option.Copy is what guarantees the backing pixmap is ours again after the
+  // completion. A server that flips it anyway owns the pixmap we are about to
+  // draw into, which would paint the screen directly.
+  const errors = [];
+  const { wnd, calls } = await presentWindow();
+  wnd.app.options.onXError = (err) => errors.push(err);
+
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.presents.length, 1);
+
+  complete(wnd, { msc: 1, mode: 1 }); // CompleteMode.Flip
+  assert.equal(errors.length, 1, 'and says so');
+  assert.match(errors[0].message, /flipped/);
+
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  // back on the fence clock, so back behind its inter-blit interval too
+  await sleep(40);
+  assert.equal(calls.presents.length, 1, 'no further presents');
+  assert.ok(calls.copies > 0, 'blits go through CopyArea instead');
+  assert.equal(wnd.frameClock, 'fence');
+  wnd.destroy();
+});
+
+test('a completion for a frame we are not clocking on is ignored', async () => {
+  const { wnd } = await presentWindow();
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  complete(wnd, { msc: 1, ust: 1_000_000 });
+  const period = wnd.refreshInterval;
+  // a stray completion (another client presenting to this window) must not
+  // sample the clock or end a frame that is not outstanding
+  complete(wnd, { msc: 9, ust: 9_000_000 });
+  assert.equal(wnd.refreshInterval, period, 'the estimate is untouched');
+  wnd.destroy();
+});
+
+test('destroy deletes the event context', async () => {
+  const { wnd, calls } = await presentWindow();
+  const eid = calls.selects[0].eid;
+  wnd.destroy();
+  const deleted = calls.selects.filter((s) => s.eventMask === 0);
+  assert.equal(deleted.length, 1, 'an empty mask deletes it');
+  assert.equal(deleted[0].eid, eid);
+});
+
+test('a DestroyNotify leaves the event context to the server', async () => {
+  // the window is already gone: deleting the context explicitly would be a
+  // request against an id that no longer exists
+  const { wnd, calls } = await presentWindow();
+  wnd.emit('event', { type: 17, wid: wnd.id }); // DestroyNotify
+  assert.deepEqual(
+    calls.selects.filter((s) => s.eventMask === 0),
+    []
+  );
+});


### PR DESCRIPTION
Closes #199. A window created with `present: true` now ends its frames on
the display rather than on the socket: the server reports each PresentPixmap
back with a CompleteNotify once it has executed the copy at a vertical blank,
and that event starts the next frame.

Frames therefore run at the output's own rate, phase-locked to it, with
nothing configured — 60fps on a 60Hz panel and 180 on a 180Hz one. A fixed
`frameInterval` cannot do this: 16ms is 62.5fps on any display, and even set
to 5.5ms it would free-run against a 180Hz output rather than lock to it,
because Node's timers have millisecond granularity and no idea when a
vertical blank is. Measured under Xvfb, the same animation loop goes from
57.7fps on the fence clock to 60.3fps locked to the fake vblank, with a
median frame time of 16.78ms against a 16.8ms completion cadence.

Three things follow from the display being honest about what it showed:

- the refresh period is measured, not queried. Completions carry the time
  and frame count of the presentation, so consecutive ones give the period
  directly, and it follows the window to another monitor or through a mode
  change on its own. Published as `wnd.refreshInterval`.
- a window nobody can see stops rendering. A Wayland compositor throttles an
  occluded window by not sending the frame callback that completes its
  present, measured at ~1fps under Mutter against the ~56fps the same loop
  burns on the fence clock.
- the backing store is not redrawn under a copy in progress. A present with
  Option.Copy owns the pixmap until the copy executes, and waiting for the
  completion is also waiting for it to be handed back.

What the issue asked to be careful about:

- `frameInterval` keeps its meaning where it had one and is promoted, not
  redefined, where it did not: under the vblank clock an explicit value is a
  rate cap and the unasked-for default of 16 does not apply, since it would
  hold a 165Hz display to 62.5fps. Assigning the property counts as explicit,
  so the accessor.
- the minimum inter-blit interval is not applied under the vblank clock. An
  outstanding present says the same thing more accurately, and without making
  a click wait 16ms on a fast display.
- a completion is an event, not a reply, so nothing guarantees one arrives.
  A frame outstanding for two seconds hands the clock back to the fence, and
  the next completion to arrive takes it again. The deadline is in seconds
  because a slow answer is usually a compositor being honest about how often
  this window is worth drawing.
- the `_NET_WM_SYNC_REQUEST` acknowledgement still goes out when the present
  is *queued*, never on its completion, so a resize cannot stall behind a
  frame the display never shows.

`frameSync: false` now turns the vblank clock off along with the fence, since
a completion is a wait on the server too. `frameClock: 'fence'` pins the old
clock on a window that presents; `wnd.frameClock` reads back whichever is
live. `wnd.droppedFrames` counts vertical blanks the display went through
without us, where the server's counter can tell.

Two fixes found on the way, both in the Present path this builds on:

- a server that flips a present sent with Option.Copy would own the backing
  pixmap while ntk drew into it, painting the screen directly. Such a server
  is now dropped back to CopyArea blits with an error explaining why.
- `createWindow({ present: true })` starts `enablePresent` and awaiting it is
  the documented way to find out whether it took. Doing both ran it twice and
  orphaned an XFixes region on the server; the promise is now memoized.

The protocol assumptions were verified against a live Xorg server rather than
read off the spec, which is how two of them turned out to be wrong.
PresentNotifyMSC with divisor 1 and remainder 0 returns immediately rather
than at the next vertical blank, and on Xwayland the msc does not advance
unless something is being presented — so a frame that draws nothing falls
back to the timer, at the measured refresh period, instead of asking for a
vblank tick that would never come. Dividing a multi-frame gap by its msc
delta also under-reports the period where the counter is driven off a timer,
so only single-vblank gaps are sampled.
