### PR TITLE
feat(app): default the frame interval to the display's refresh rate

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -62,6 +62,21 @@ const app2 = await createClient({ display: ':1' });
   ([context-2d.md](context-2d.md#swapping-the-rasterizer))
 - `app.rasterPolicy` — the thresholds for that choice, merged over
   `DEFAULT_RASTER_POLICY`
+- `app.refreshRate` — the fastest refresh rate any active output is running
+  at, in Hz; `null` until the display has been asked, and on a server with no
+  RandR or no mode worth pacing to
+- `app.frameInterval` — that rate as a period in ms, which is what windows on
+  this connection take as their default `frameInterval` (see
+  [window.md](window.md#frames-coalescing-and-slow-connections)); `null`
+  alongside `refreshRate`
+
+The rate is probed once per connection, in the background, when the first
+window is created — three RandR round trips that no window waits for. Windows
+built before the answer lands adopt it when it does, unless they were given a
+`frameInterval` of their own. The *fastest* output rather than the one a given
+window sits on, because what this feeds is a rate ceiling: a window paced
+faster than its own monitor is bounded by the next gate along, whereas one
+paced slower can never reach the rate its display offers.
 
 ## Methods
 

--- a/docs/window.md
+++ b/docs/window.md
@@ -62,10 +62,12 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 - `frameClock: 'fence'` — keep the round-trip clock on a window that presents
   (see [What ends a frame](#what-ends-a-frame))
 - `frameInterval: ms` — minimum time between paced frames, and the minimum
-  time between blits (default `16`, ~60 fps; `0` disables both gates). Under
-  the vblank clock this is a *cap* on top of the display's rate and the
-  default does not apply — see [What ends a frame](#what-ends-a-frame). Also
-  writable later as `wnd.frameInterval`.
+  time between blits. Defaults to the display's own period where the
+  connection could find it out — `app.refreshRate`, see [app.md](app.md) — and
+  to `16` until it has; `0` disables both gates. Under the vblank clock this
+  is a *cap* on top of the display's rate and the default does not apply —
+  see [What ends a frame](#what-ends-a-frame). Also writable later as
+  `wnd.frameInterval`.
 - `syncRequest: true` — let the window manager pace interactive resizes to
   this window's repaint rate (see
   [Resize synchronization](#resize-synchronization--syncrequest--enablesyncrequest))
@@ -220,7 +222,8 @@ frames**, gated by three independent mechanisms:
   automatically degrade to one per round-trip — the latest state is always
   the next thing drawn, and no backlog builds up. Disable with
   `frameSync: false`.
-- **a timer** — at most one paced frame per `frameInterval` ms (default 16),
+- **a timer** — at most one paced frame per `frameInterval` ms, which defaults
+  to the display's own period (`app.refreshRate`, `16` until that is known),
   so a local server isn't asked to redraw at input-device rate. Under the
   vblank clock the display sets the rate instead, and this is only what runs
   the next frame when one drew nothing at all (there is no present to report

--- a/lib/app.js
+++ b/lib/app.js
@@ -9,6 +9,41 @@ import FontManager from './text/fontmanager.js';
 import Window from './window.js';
 
 /**
+ * Frame interval used before the display has been asked, in ms — and the one
+ * kept on a server that cannot answer.
+ */
+const DEFAULT_FRAME_INTERVAL = 16;
+
+/**
+ * The range a refresh rate has to fall in to be paced against, in Hz. Below
+ * this a display is not something a UI should be throttled to, and above it
+ * the numbers are not describing a display at all.
+ */
+const MIN_REFRESH_RATE = 20;
+const MAX_REFRESH_RATE = 1000;
+
+/**
+ * A RandR mode's vertical refresh rate in Hz, or 0 when it does not describe
+ * one.
+ *
+ * `dot_clock / (h_total * v_total)`, with the two flags that make a frame
+ * something other than one pass down the mode, exactly as xrandr computes it:
+ * an interlaced mode paints half the lines per pass, a doublescan mode paints
+ * each line twice.
+ *
+ * The zero check is not defensive: a virtual output has no pixel clock to
+ * report and Xvfb — which is what CI runs against — fills all three fields
+ * with zeroes, so the arithmetic yields NaN rather than a rate.
+ */
+function modeRate(mode) {
+  if (!mode || !mode.dot_clock || !mode.h_total || !mode.v_total) return 0;
+  let vTotal = mode.v_total;
+  if (mode.modeflags & 0x10) vTotal /= 2; // Interlace
+  if (mode.modeflags & 0x20) vTotal *= 2; // DoubleScan
+  return mode.dot_clock / (mode.h_total * vTotal);
+}
+
+/**
  * A connection to an X server. Owns the underlying node-x11 client
  * (`app.X`) and acts as a factory for windows and pixmaps.
  */
@@ -57,6 +92,79 @@ export default class App {
       if (this.options.onXError) this.options.onXError(err);
       else console.warn(`ntk: unhandled X error: ${err.message} (opcode ${err.majorOpcode}, seq ${err.seq})`);
     });
+  }
+
+  /**
+   * The fastest refresh rate any active output is running at, in Hz, or
+   * `null` until the display has been asked — and on a server with no RandR
+   * or no mode worth pacing to.
+   *
+   * The fastest rather than the one this or that window is on, because what
+   * it feeds is a rate *ceiling* (see `frameInterval`), and a window paced
+   * faster than its own monitor is bounded by the next gate along rather than
+   * drawing more than anyone can see. Tracking which output every window
+   * overlaps would cost a per-window RandR lookup plus change tracking, to
+   * make a ceiling slightly tighter.
+   */
+  get refreshRate() {
+    if (this._refreshProbe === undefined) this._probeRefreshRate();
+    return this._refreshRate ?? null;
+  }
+
+  /**
+   * The frame interval windows on this connection take by default, in ms:
+   * the display's own period rather than a guess, so an animation loop on a
+   * 165Hz output is not held to the 62.5fps a hardcoded 16 implies. `null`
+   * until the probe has answered; windows created before then start on the
+   * default and adopt this when it lands.
+   *
+   * A window that presents takes its rate from the display directly and needs
+   * none of this — see docs/window.md "What ends a frame". This is what the
+   * fence clock paces to, which is every window on a server without Present,
+   * and every window before its first frames have been shown.
+   */
+  get frameInterval() {
+    const rate = this.refreshRate;
+    return rate ? 1000 / rate : null;
+  }
+
+  /**
+   * Ask RandR what the outputs are running at, once per connection, in the
+   * background.
+   *
+   * Not on the connect path: `createClient` is already four round trips deep
+   * and this is three more, for something no window needs before its first
+   * frame. Failures are silent by design — every one of them means "no rate
+   * to be had", which is exactly what the default covers.
+   */
+  _probeRefreshRate() {
+    this._refreshProbe = null; // in progress; only ever started once
+    const X = this.X;
+    X.require('randr', (err, R) => {
+      if (err || !R) return;
+      const root = this.display.screen[0].root;
+      R.GetScreenResourcesCurrent(root, (resourcesError, resources) => {
+        if (resourcesError || !resources?.crtcs?.length) return;
+        const modes = new Map(resources.modeinfos.map((mode) => [mode.id, mode]));
+        let pending = resources.crtcs.length;
+        let best = 0;
+        for (const crtc of resources.crtcs) {
+          R.GetCrtcInfo(crtc, resources.config_timestamp, (crtcError, info) => {
+            // a crtc with no mode is one that is switched off
+            if (!crtcError && info) best = Math.max(best, modeRate(modes.get(info.mode)));
+            if (--pending) return;
+            if (best < MIN_REFRESH_RATE || best > MAX_REFRESH_RATE) return;
+            this._refreshRate = best;
+            this._adoptFrameInterval(1000 / best);
+          });
+        }
+      });
+    });
+  }
+
+  /** hand the measured default to the windows that are still on the guess */
+  _adoptFrameInterval(ms) {
+    for (const wnd of Window._cacheFor(this).values()) wnd._adoptDefaultFrameInterval(ms);
   }
 
   /** the text API entry point: font matching/loading, shaping, layout */

--- a/lib/window.js
+++ b/lib/window.js
@@ -447,7 +447,11 @@ export default class Window extends Drawable {
     // decides its meaning under the vblank clock — an explicit value caps the
     // frame rate, an unasked-for default must not (see _armTimer). Assigning
     // the property later is the caller setting it, hence the accessor.
-    this._frameInterval = args.frameInterval ?? 16;
+    //
+    // The default is the display's own period where the connection has found
+    // it out, and DEFAULT_FRAME_INTERVAL until it has: a window built before
+    // that probe answers adopts the result when it lands.
+    this._frameInterval = args.frameInterval ?? app.frameInterval ?? DEFAULT_FRAME_INTERVAL;
     this._frameIntervalExplicit = args.frameInterval !== undefined;
     this.frameLatency = null;
     this._frame = {
@@ -1047,6 +1051,16 @@ export default class Window extends Drawable {
   set frameInterval(ms) {
     this._frameInterval = ms;
     this._frameIntervalExplicit = true;
+  }
+
+  /**
+   * Take the connection's measured default, if this window is still on the
+   * guess. Called when the RandR probe answers, which is normally a few
+   * round trips after the first window was built — see App#_probeRefreshRate.
+   */
+  _adoptDefaultFrameInterval(ms) {
+    if (this._frameIntervalExplicit || this._destroyed) return;
+    this._frameInterval = ms;
   }
 
   /**

--- a/test/refresh-rate.test.js
+++ b/test/refresh-rate.test.js
@@ -1,0 +1,163 @@
+// The default frame interval, taken from the display instead of guessed
+// (lib/app.js). One RandR probe per connection finds the fastest active
+// output, and windows still on the built-in default adopt its period —
+// so an animation loop on a 165Hz screen is not held to the 62.5fps that a
+// hardcoded 16ms implies.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import App from '../lib/app.js';
+
+let nextId = 0xd000;
+
+/** A 165Hz mode, as RandR describes one. */
+const MODE_165 = {
+  id: 1,
+  dot_clock: 585_360_000,
+  h_total: 2400,
+  v_total: 1478,
+  modeflags: 0
+};
+/** 60Hz, for the second output. */
+const MODE_60 = {
+  id: 2,
+  dot_clock: 148_500_000,
+  h_total: 2200,
+  v_total: 1125,
+  modeflags: 0
+};
+/** What Xvfb reports: a mode with no pixel clock at all. */
+const MODE_VIRTUAL = { id: 3, dot_clock: 0, h_total: 0, v_total: 0, modeflags: 0 };
+
+/** every reply lands a tick later, the way a real server's does */
+const reply = (cb, ...args) => setImmediate(() => cb(...args));
+
+/** long enough for the probe's chain of round trips to finish */
+async function settle() {
+  for (let i = 0; i < 6; i++) await tick();
+}
+
+function makeApp({ randr = true, modeinfos = [MODE_165], crtcs = { 10: 1 } } = {}) {
+  const Randr = {
+    GetScreenResourcesCurrent(root, cb) {
+      reply(cb, null, { config_timestamp: 1, crtcs: Object.keys(crtcs).map(Number), modeinfos });
+    },
+    GetCrtcInfo(crtc, ts, cb) {
+      reply(cb, null, { mode: crtcs[crtc], width: 100, height: 100 });
+    }
+  };
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    atoms: {},
+    on() {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    ChangeProperty() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea() {},
+    GetInputFocus() {},
+    InternAtom(o, name, cb) {
+      cb(null, 1);
+    },
+    require(name, cb) {
+      if (name === 'randr') return randr ? reply(cb, null, Randr) : reply(cb, new Error('no randr'));
+      reply(cb, new Error(`no ${name}`));
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return new App(display, {});
+}
+
+test('a window takes the display period, not a hardcoded 16ms', async () => {
+  const app = makeApp();
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  assert.equal(wnd.frameInterval, 16, 'the guess, until the display has answered');
+
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 165) < 0.5, `165Hz: ${app.refreshRate}`);
+  assert.ok(
+    Math.abs(wnd.frameInterval - 1000 / 165) < 0.01,
+    `adopted by a window that predates the probe: ${wnd.frameInterval}`
+  );
+  const later = app.createWindow({ width: 100, height: 100 });
+  assert.equal(later.frameInterval, wnd.frameInterval, 'and by one created after it');
+  wnd.destroy();
+  later.destroy();
+});
+
+test('an interval the caller asked for is never overwritten', async () => {
+  const app = makeApp();
+  const pinned = app.createWindow({ width: 100, height: 100, frameInterval: 50 });
+  const assigned = app.createWindow({ width: 100, height: 100 });
+  assigned.frameInterval = 40;
+
+  await settle();
+  assert.ok(app.refreshRate, 'the probe did answer');
+  assert.equal(pinned.frameInterval, 50, 'passed as an option');
+  assert.equal(assigned.frameInterval, 40, 'or assigned afterwards');
+  pinned.destroy();
+  assigned.destroy();
+});
+
+test('the fastest active output is the one that sets the ceiling', async () => {
+  // a laptop panel next to a fast external monitor: the ceiling has to clear
+  // the faster of them, since it only bounds the rate rather than setting it
+  const app = makeApp({ modeinfos: [MODE_165, MODE_60], crtcs: { 10: 2, 11: 1 } });
+  app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 165) < 0.5, `165, not 60: ${app.refreshRate}`);
+});
+
+test('a crtc that is switched off is not a display', async () => {
+  const app = makeApp({ modeinfos: [MODE_60], crtcs: { 10: 0, 11: 2 } });
+  app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 60) < 0.5, `the enabled one: ${app.refreshRate}`);
+});
+
+test('a mode with no pixel clock leaves the default alone', async () => {
+  // Xvfb reports dot_clock, h_total and v_total all zero — which is CI, so
+  // this is the path the test suite itself runs on
+  const app = makeApp({ modeinfos: [MODE_VIRTUAL], crtcs: { 10: 3 } });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.equal(app.refreshRate, null, 'no rate to be had');
+  assert.equal(app.frameInterval, null);
+  assert.equal(wnd.frameInterval, 16, 'so the window keeps the default');
+  wnd.destroy();
+});
+
+test('a server without RandR leaves the default alone', async () => {
+  const app = makeApp({ randr: false });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.equal(app.refreshRate, null);
+  assert.equal(wnd.frameInterval, 16);
+  wnd.destroy();
+});
+
+test('the probe runs once per connection, however many windows ask', async () => {
+  let probes = 0;
+  const app = makeApp();
+  const inner = app.X.require.bind(app.X);
+  app.X.require = (name, cb) => {
+    if (name === 'randr') probes++;
+    inner(name, cb);
+  };
+  app.createWindow({ width: 100, height: 100 });
+  app.createWindow({ width: 100, height: 100 });
+  void app.refreshRate;
+  void app.frameInterval;
+  await settle();
+  assert.equal(probes, 1);
+});


### PR DESCRIPTION
Stacked on #220, which is where the vblank clock lands. This is the other
half: what a window paces to when the display is *not* the clock — no Present
extension, `frameClock: 'fence'`, or simply the frames before the first
completions have arrived.

That path defaulted to a hardcoded 16ms, which is 62.5fps on every display
ever made. `app.refreshRate` now asks RandR what the outputs are actually
running at and windows take its period instead, so a 165Hz screen gets 6.06ms
rather than a number chosen in 2006. Verified against this machine's panel:
74.980Hz from `dot_clock / h_total * v_total`, matching xrandr's own figure to
three decimals, adopted as a 13.337ms interval by windows that predate the
probe and by ones created after it.

Details worth stating:

- **the fastest active output sets it, not the one the window sits on.** What
  this feeds is a rate *ceiling*: a window paced faster than its own monitor
  is bounded by the next gate along, whereas one paced slower can never reach
  the rate its display offers. Tracking which output each window overlaps
  would cost a per-window RandR lookup plus change tracking, to tighten a
  ceiling.
- **probed once per connection, in the background, on the first window.**
  `createClient` is already four round trips deep and this is three more, for
  something no window needs before its first frame. Windows built before the
  answer arrives adopt it when it does.
- **an interval the caller asked for is never overwritten**, whether passed as
  an option or assigned to the property afterwards.
- **failure is silent and lands on the old default**, because every way this
  can fail means "no rate to be had". Xvfb is the case that matters: it
  reports dot_clock, h_total and v_total all zero, so the arithmetic yields
  NaN rather than a rate — and Xvfb is what CI runs on, so that path is
  exercised by the suite itself rather than reasoned about.

Seven tests cover the adoption, the pinning, the multi-output choice, a
switched-off crtc, the zero-clock mode, a server with no RandR, and that the
probe runs once however many windows ask.
