### PR TITLE
feat(window)!: present by default, and clock frames on the display

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -62,6 +62,21 @@ const app2 = await createClient({ display: ':1' });
   ([context-2d.md](context-2d.md#swapping-the-rasterizer))
 - `app.rasterPolicy` — the thresholds for that choice, merged over
   `DEFAULT_RASTER_POLICY`
+- `app.refreshRate` — the fastest refresh rate any active output is running
+  at, in Hz; `null` until the display has been asked, and on a server with no
+  RandR or no mode worth pacing to
+- `app.frameInterval` — that rate as a period in ms, which is what windows on
+  this connection take as their default `frameInterval` (see
+  [window.md](window.md#frames-coalescing-and-slow-connections)); `null`
+  alongside `refreshRate`
+
+The rate is probed once per connection, in the background, when the first
+window is created — three RandR round trips that no window waits for. Windows
+built before the answer lands adopt it when it does, unless they were given a
+`frameInterval` of their own. The *fastest* output rather than the one a given
+window sits on, because what this feeds is a rate ceiling: a window paced
+faster than its own monitor is bounded by the next gate along, whereas one
+paced slower can never reach the rate its display offers.
 
 ## Methods
 

--- a/docs/window.md
+++ b/docs/window.md
@@ -56,9 +56,9 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
   [Frames, coalescing and slow connections](#frames-coalescing-and-slow-connections))
 - `frameSync: false` — don't pace frames on the server at all: no round-trip
   fence, and no waiting for the display either
-- `present: true` — blit with the Present extension instead of `CopyArea`,
-  and take the frame clock from the display
-  (see [Blitting with Present](#blitting-with-present--present-true))
+- `present: false` — blit with `CopyArea` instead of the Present extension,
+  and keep the frame clock off the display
+  (see [Blitting with Present](#blitting-with-present))
 - `frameClock: 'fence'` — keep the round-trip clock on a window that presents
   (see [What ends a frame](#what-ends-a-frame))
 - `frameInterval: ms` — minimum time between paced frames, and the minimum
@@ -144,19 +144,28 @@ automatically (opt out with `createWindow({ backingStore: false })`):
 Foreign windows (`{ id }`) and windows drawing via the `'opengl'` or
 `'x11'` contexts are not double-buffered.
 
-### Blitting with Present — `present: true`
+### Blitting with Present
 
-By default a frame's dirty rectangles go out as one `CopyArea` each, and
-because each rectangle costs a request, scattered damage is collapsed into
-the box around it when the split stops paying for itself (see
-`scrollRegion` above and the note on blit lists). With
-`createWindow({ present: true })` the frame becomes a single `PresentPixmap`
-carrying an update region instead:
+A double-buffered window blits through the Present extension: a frame's dirty
+rectangles become a single `PresentPixmap` carrying an update region. The
+alternative — and the fallback wherever Present is unavailable — is one
+`CopyArea` per rectangle, where because each rectangle costs a request,
+scattered damage is collapsed into the box around it when the split stops
+paying for itself (see `scrollRegion` above and the note on blit lists).
+
+This is set up when the window gets its backing store, so a window drawing
+through the `'opengl'` or `'x11'` contexts never pays for it. Nothing is
+required of the caller:
 
 ```js
-const wnd = app.createWindow({ width: 800, height: 600, present: true });
-// or, to know whether it took effect:
+const wnd = app.createWindow({ width: 800, height: 600 });
+wnd.getContext('2d'); // presents from here on
+
+// to know whether it took effect, or to have it up before the first paint:
 await wnd.enablePresent();
+
+// to stay on CopyArea:
+const plain = app.createWindow({ width: 800, height: 600, present: false });
 ```
 
 Two things follow. A frame is a fixed two requests however fragmented the
@@ -243,14 +252,16 @@ frames**, gated by three independent mechanisms:
 
 ### What ends a frame
 
-A window that presents (`present: true`) takes its frame clock from the
-display. Every frame goes out as a `PresentPixmap`, and the server sends back
-a `CompleteNotify` when it has *executed* that copy, at a vertical blank —
+A window that presents — which is every double-buffered window unless it
+opted out — takes its frame clock from the display. Every frame goes out as
+a `PresentPixmap`, and the server sends back a `CompleteNotify` when it has
+*executed* that copy, at a vertical blank —
 so that event, rather than a timer or a socket round-trip, is what starts the
 next frame:
 
 ```js
-const wnd = app.createWindow({ width: 800, height: 600, present: true });
+const wnd = app.createWindow({ width: 800, height: 600 });
+wnd.getContext('2d');
 // wnd.frameClock === 'present' once the extension has answered
 ```
 
@@ -296,7 +307,7 @@ back to the fence, and the next completion to arrive takes it again.
 how you ask for less than the display offers:
 
 ```js
-const wnd = app.createWindow({ present: true, frameInterval: 33 }); // ~30 fps
+const wnd = app.createWindow({ frameInterval: 33 }); // ~30 fps on any display
 wnd.frameInterval = 0; // back to the display's rate
 ```
 
@@ -398,7 +409,8 @@ for the display to report back, so those frames fall back to the timer, at
 `refreshInterval` where one has been measured.
 
 ```js
-const wnd = app.createWindow({ width: 800, height: 600, present: true });
+const wnd = app.createWindow({ width: 800, height: 600 });
+const ctx = wnd.getContext('2d');
 const step = () => {
   draw(); // your painting; the blit goes out with the frame
   wnd.requestAnimationFrame(step);

--- a/docs/window.md
+++ b/docs/window.md
@@ -62,10 +62,12 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 - `frameClock: 'fence'` — keep the round-trip clock on a window that presents
   (see [What ends a frame](#what-ends-a-frame))
 - `frameInterval: ms` — minimum time between paced frames, and the minimum
-  time between blits (default `16`, ~60 fps; `0` disables both gates). Under
-  the vblank clock this is a *cap* on top of the display's rate and the
-  default does not apply — see [What ends a frame](#what-ends-a-frame). Also
-  writable later as `wnd.frameInterval`.
+  time between blits. Defaults to the display's own period where the
+  connection could find it out — `app.refreshRate`, see [app.md](app.md) — and
+  to `16` until it has; `0` disables both gates. Under the vblank clock this
+  is a *cap* on top of the display's rate and the default does not apply —
+  see [What ends a frame](#what-ends-a-frame). Also writable later as
+  `wnd.frameInterval`.
 - `syncRequest: true` — let the window manager pace interactive resizes to
   this window's repaint rate (see
   [Resize synchronization](#resize-synchronization--syncrequest--enablesyncrequest))
@@ -220,7 +222,8 @@ frames**, gated by three independent mechanisms:
   automatically degrade to one per round-trip — the latest state is always
   the next thing drawn, and no backlog builds up. Disable with
   `frameSync: false`.
-- **a timer** — at most one paced frame per `frameInterval` ms (default 16),
+- **a timer** — at most one paced frame per `frameInterval` ms, which defaults
+  to the display's own period (`app.refreshRate`, `16` until that is known),
   so a local server isn't asked to redraw at input-device rate. Under the
   vblank clock the display sets the rate instead, and this is only what runs
   the next frame when one drew nothing at all (there is no present to report

--- a/lib/app.js
+++ b/lib/app.js
@@ -9,6 +9,41 @@ import FontManager from './text/fontmanager.js';
 import Window from './window.js';
 
 /**
+ * Frame interval used before the display has been asked, in ms — and the one
+ * kept on a server that cannot answer.
+ */
+const DEFAULT_FRAME_INTERVAL = 16;
+
+/**
+ * The range a refresh rate has to fall in to be paced against, in Hz. Below
+ * this a display is not something a UI should be throttled to, and above it
+ * the numbers are not describing a display at all.
+ */
+const MIN_REFRESH_RATE = 20;
+const MAX_REFRESH_RATE = 1000;
+
+/**
+ * A RandR mode's vertical refresh rate in Hz, or 0 when it does not describe
+ * one.
+ *
+ * `dot_clock / (h_total * v_total)`, with the two flags that make a frame
+ * something other than one pass down the mode, exactly as xrandr computes it:
+ * an interlaced mode paints half the lines per pass, a doublescan mode paints
+ * each line twice.
+ *
+ * The zero check is not defensive: a virtual output has no pixel clock to
+ * report and Xvfb — which is what CI runs against — fills all three fields
+ * with zeroes, so the arithmetic yields NaN rather than a rate.
+ */
+function modeRate(mode) {
+  if (!mode || !mode.dot_clock || !mode.h_total || !mode.v_total) return 0;
+  let vTotal = mode.v_total;
+  if (mode.modeflags & 0x10) vTotal /= 2; // Interlace
+  if (mode.modeflags & 0x20) vTotal *= 2; // DoubleScan
+  return mode.dot_clock / (mode.h_total * vTotal);
+}
+
+/**
  * A connection to an X server. Owns the underlying node-x11 client
  * (`app.X`) and acts as a factory for windows and pixmaps.
  */
@@ -57,6 +92,79 @@ export default class App {
       if (this.options.onXError) this.options.onXError(err);
       else console.warn(`ntk: unhandled X error: ${err.message} (opcode ${err.majorOpcode}, seq ${err.seq})`);
     });
+  }
+
+  /**
+   * The fastest refresh rate any active output is running at, in Hz, or
+   * `null` until the display has been asked — and on a server with no RandR
+   * or no mode worth pacing to.
+   *
+   * The fastest rather than the one this or that window is on, because what
+   * it feeds is a rate *ceiling* (see `frameInterval`), and a window paced
+   * faster than its own monitor is bounded by the next gate along rather than
+   * drawing more than anyone can see. Tracking which output every window
+   * overlaps would cost a per-window RandR lookup plus change tracking, to
+   * make a ceiling slightly tighter.
+   */
+  get refreshRate() {
+    if (this._refreshProbe === undefined) this._probeRefreshRate();
+    return this._refreshRate ?? null;
+  }
+
+  /**
+   * The frame interval windows on this connection take by default, in ms:
+   * the display's own period rather than a guess, so an animation loop on a
+   * 165Hz output is not held to the 62.5fps a hardcoded 16 implies. `null`
+   * until the probe has answered; windows created before then start on the
+   * default and adopt this when it lands.
+   *
+   * A window that presents takes its rate from the display directly and needs
+   * none of this — see docs/window.md "What ends a frame". This is what the
+   * fence clock paces to, which is every window on a server without Present,
+   * and every window before its first frames have been shown.
+   */
+  get frameInterval() {
+    const rate = this.refreshRate;
+    return rate ? 1000 / rate : null;
+  }
+
+  /**
+   * Ask RandR what the outputs are running at, once per connection, in the
+   * background.
+   *
+   * Not on the connect path: `createClient` is already four round trips deep
+   * and this is three more, for something no window needs before its first
+   * frame. Failures are silent by design — every one of them means "no rate
+   * to be had", which is exactly what the default covers.
+   */
+  _probeRefreshRate() {
+    this._refreshProbe = null; // in progress; only ever started once
+    const X = this.X;
+    X.require('randr', (err, R) => {
+      if (err || !R) return;
+      const root = this.display.screen[0].root;
+      R.GetScreenResourcesCurrent(root, (resourcesError, resources) => {
+        if (resourcesError || !resources?.crtcs?.length) return;
+        const modes = new Map(resources.modeinfos.map((mode) => [mode.id, mode]));
+        let pending = resources.crtcs.length;
+        let best = 0;
+        for (const crtc of resources.crtcs) {
+          R.GetCrtcInfo(crtc, resources.config_timestamp, (crtcError, info) => {
+            // a crtc with no mode is one that is switched off
+            if (!crtcError && info) best = Math.max(best, modeRate(modes.get(info.mode)));
+            if (--pending) return;
+            if (best < MIN_REFRESH_RATE || best > MAX_REFRESH_RATE) return;
+            this._refreshRate = best;
+            this._adoptFrameInterval(1000 / best);
+          });
+        }
+      });
+    });
+  }
+
+  /** hand the measured default to the windows that are still on the guess */
+  _adoptFrameInterval(ms) {
+    for (const wnd of Window._cacheFor(this).values()) wnd._adoptDefaultFrameInterval(ms);
   }
 
   /** the text API entry point: font matching/loading, shaping, layout */

--- a/lib/window.js
+++ b/lib/window.js
@@ -593,10 +593,17 @@ export default class Window extends Drawable {
       // the earliest. `await wnd.enableSyncRequest()` when that is too close.
       this.enableSyncRequest().catch((err) => this.app.options.onXError?.(err));
     }
+    // Presenting is what a double-buffered window does unless it says
+    // otherwise, so the decision is deferred to the point one gets a backing
+    // store (see _enableBackingStore): a window drawing through 'opengl' or
+    // 'x11' has no pixmap to present and would only be paying for an update
+    // region and an event selection it never uses. `present: true` is still
+    // honoured eagerly, for a caller who wants it up before the first paint.
+    this._presentOptOut = args.present === false;
     if (args.present && !args.id) {
       // fire and forget: until the extensions answer, blits use CopyArea,
       // which is what they would have done anyway
-      this.enablePresent().catch((err) => this.app.options.onXError?.(err));
+      this.enablePresent().catch((err) => this.app.options?.onXError?.(err));
     }
 
     X.event_consumers[this.id] = this;
@@ -767,6 +774,12 @@ export default class Window extends Drawable {
     this._dirty = false;
     this._backingValid = false;
     this._presentScheduled = false;
+    // Now there is a pixmap to present. Inert where the extensions are
+    // missing, so this costs a window on such a server two extension queries
+    // that node-x11 answers from its cache after the first.
+    if (!this._presentOptOut && !this._foreign) {
+      this.enablePresent().catch((err) => this.app.options?.onXError?.(err));
+    }
 
     this._presentGc = this.X.AllocID();
     this.X.CreateGC(this._presentGc, this.id, { graphicsExposures: 0 });

--- a/lib/window.js
+++ b/lib/window.js
@@ -447,7 +447,11 @@ export default class Window extends Drawable {
     // decides its meaning under the vblank clock — an explicit value caps the
     // frame rate, an unasked-for default must not (see _armTimer). Assigning
     // the property later is the caller setting it, hence the accessor.
-    this._frameInterval = args.frameInterval ?? 16;
+    //
+    // The default is the display's own period where the connection has found
+    // it out, and DEFAULT_FRAME_INTERVAL until it has: a window built before
+    // that probe answers adopts the result when it lands.
+    this._frameInterval = args.frameInterval ?? app.frameInterval ?? DEFAULT_FRAME_INTERVAL;
     this._frameIntervalExplicit = args.frameInterval !== undefined;
     this.frameLatency = null;
     this._frame = {
@@ -1047,6 +1051,16 @@ export default class Window extends Drawable {
   set frameInterval(ms) {
     this._frameInterval = ms;
     this._frameIntervalExplicit = true;
+  }
+
+  /**
+   * Take the connection's measured default, if this window is still on the
+   * guess. Called when the RandR probe answers, which is normally a few
+   * round trips after the first window was built — see App#_probeRefreshRate.
+   */
+  _adoptDefaultFrameInterval(ms) {
+    if (this._frameIntervalExplicit || this._destroyed) return;
+    this._frameInterval = ms;
   }
 
   /**

--- a/test/present-blit.test.js
+++ b/test/present-blit.test.js
@@ -179,7 +179,10 @@ test('falls back to CopyArea when XFixes is missing', async () => {
   wnd.destroy();
 });
 
-test('a window that did not opt in keeps using CopyArea', async () => {
+test('a blit before the extension has answered uses CopyArea', async () => {
+  // enablePresent is asynchronous, so the first frames of a window's life can
+  // land before it resolves — they have to be correct anyway, which is the
+  // property that lets the two paths alternate at all
   const { app, calls } = makeMockApp();
   const wnd = new Window(app, { width: 200, height: 100 });
   wnd.width = 200;
@@ -190,6 +193,52 @@ test('a window that did not opt in keeps using CopyArea', async () => {
   await tick();
   assert.deepEqual(calls.presents, []);
   assert.equal(calls.copies.length, 1);
+  wnd.destroy();
+});
+
+test('a double-buffered window presents without being asked', async () => {
+  // the decision rides on the backing store, so it is taken where one is
+  // created rather than in the constructor
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100 });
+  assert.equal(calls.selects.length, 0, 'nothing before there is a pixmap to present');
+  wnd._enableBackingStore();
+  await tick();
+  assert.ok(wnd._presentExt, 'the extension is up');
+  assert.equal(wnd.frameClock, 'present', 'and the display is the clock');
+
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.presents.length, 1, 'blits go out as presents');
+  assert.deepEqual(calls.copies, []);
+  wnd.destroy();
+});
+
+test('present: false opts out of both the blit and the clock', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100, present: false });
+  wnd._enableBackingStore();
+  await tick();
+  assert.equal(wnd._presentExt, null, 'no extension');
+  assert.equal(wnd.frameClock, 'fence');
+
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.deepEqual(calls.presents, []);
+  assert.equal(calls.copies.length, 1, 'CopyArea, as before');
+  wnd.destroy();
+});
+
+test('a window with no backing store pays nothing for the default', async () => {
+  // an 'opengl' or 'x11' context draws to the window directly: there is no
+  // pixmap to present, so an update region and an event selection would be
+  // bought and never used
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { width: 200, height: 100 });
+  await tick();
+  assert.equal(wnd._presentExt, null);
+  assert.deepEqual(calls.selects, []);
+  assert.deepEqual(calls.regions, []);
   wnd.destroy();
 });
 

--- a/test/refresh-rate.test.js
+++ b/test/refresh-rate.test.js
@@ -1,0 +1,163 @@
+// The default frame interval, taken from the display instead of guessed
+// (lib/app.js). One RandR probe per connection finds the fastest active
+// output, and windows still on the built-in default adopt its period —
+// so an animation loop on a 165Hz screen is not held to the 62.5fps that a
+// hardcoded 16ms implies.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import App from '../lib/app.js';
+
+let nextId = 0xd000;
+
+/** A 165Hz mode, as RandR describes one. */
+const MODE_165 = {
+  id: 1,
+  dot_clock: 585_360_000,
+  h_total: 2400,
+  v_total: 1478,
+  modeflags: 0
+};
+/** 60Hz, for the second output. */
+const MODE_60 = {
+  id: 2,
+  dot_clock: 148_500_000,
+  h_total: 2200,
+  v_total: 1125,
+  modeflags: 0
+};
+/** What Xvfb reports: a mode with no pixel clock at all. */
+const MODE_VIRTUAL = { id: 3, dot_clock: 0, h_total: 0, v_total: 0, modeflags: 0 };
+
+/** every reply lands a tick later, the way a real server's does */
+const reply = (cb, ...args) => setImmediate(() => cb(...args));
+
+/** long enough for the probe's chain of round trips to finish */
+async function settle() {
+  for (let i = 0; i < 6; i++) await tick();
+}
+
+function makeApp({ randr = true, modeinfos = [MODE_165], crtcs = { 10: 1 } } = {}) {
+  const Randr = {
+    GetScreenResourcesCurrent(root, cb) {
+      reply(cb, null, { config_timestamp: 1, crtcs: Object.keys(crtcs).map(Number), modeinfos });
+    },
+    GetCrtcInfo(crtc, ts, cb) {
+      reply(cb, null, { mode: crtcs[crtc], width: 100, height: 100 });
+    }
+  };
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    atoms: {},
+    on() {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    ChangeProperty() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea() {},
+    GetInputFocus() {},
+    InternAtom(o, name, cb) {
+      cb(null, 1);
+    },
+    require(name, cb) {
+      if (name === 'randr') return randr ? reply(cb, null, Randr) : reply(cb, new Error('no randr'));
+      reply(cb, new Error(`no ${name}`));
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return new App(display, {});
+}
+
+test('a window takes the display period, not a hardcoded 16ms', async () => {
+  const app = makeApp();
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  assert.equal(wnd.frameInterval, 16, 'the guess, until the display has answered');
+
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 165) < 0.5, `165Hz: ${app.refreshRate}`);
+  assert.ok(
+    Math.abs(wnd.frameInterval - 1000 / 165) < 0.01,
+    `adopted by a window that predates the probe: ${wnd.frameInterval}`
+  );
+  const later = app.createWindow({ width: 100, height: 100 });
+  assert.equal(later.frameInterval, wnd.frameInterval, 'and by one created after it');
+  wnd.destroy();
+  later.destroy();
+});
+
+test('an interval the caller asked for is never overwritten', async () => {
+  const app = makeApp();
+  const pinned = app.createWindow({ width: 100, height: 100, frameInterval: 50 });
+  const assigned = app.createWindow({ width: 100, height: 100 });
+  assigned.frameInterval = 40;
+
+  await settle();
+  assert.ok(app.refreshRate, 'the probe did answer');
+  assert.equal(pinned.frameInterval, 50, 'passed as an option');
+  assert.equal(assigned.frameInterval, 40, 'or assigned afterwards');
+  pinned.destroy();
+  assigned.destroy();
+});
+
+test('the fastest active output is the one that sets the ceiling', async () => {
+  // a laptop panel next to a fast external monitor: the ceiling has to clear
+  // the faster of them, since it only bounds the rate rather than setting it
+  const app = makeApp({ modeinfos: [MODE_165, MODE_60], crtcs: { 10: 2, 11: 1 } });
+  app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 165) < 0.5, `165, not 60: ${app.refreshRate}`);
+});
+
+test('a crtc that is switched off is not a display', async () => {
+  const app = makeApp({ modeinfos: [MODE_60], crtcs: { 10: 0, 11: 2 } });
+  app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 60) < 0.5, `the enabled one: ${app.refreshRate}`);
+});
+
+test('a mode with no pixel clock leaves the default alone', async () => {
+  // Xvfb reports dot_clock, h_total and v_total all zero — which is CI, so
+  // this is the path the test suite itself runs on
+  const app = makeApp({ modeinfos: [MODE_VIRTUAL], crtcs: { 10: 3 } });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.equal(app.refreshRate, null, 'no rate to be had');
+  assert.equal(app.frameInterval, null);
+  assert.equal(wnd.frameInterval, 16, 'so the window keeps the default');
+  wnd.destroy();
+});
+
+test('a server without RandR leaves the default alone', async () => {
+  const app = makeApp({ randr: false });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.equal(app.refreshRate, null);
+  assert.equal(wnd.frameInterval, 16);
+  wnd.destroy();
+});
+
+test('the probe runs once per connection, however many windows ask', async () => {
+  let probes = 0;
+  const app = makeApp();
+  const inner = app.X.require.bind(app.X);
+  app.X.require = (name, cb) => {
+    if (name === 'randr') probes++;
+    inner(name, cb);
+  };
+  app.createWindow({ width: 100, height: 100 });
+  app.createWindow({ width: 100, height: 100 });
+  void app.refreshRate;
+  void app.frameInterval;
+  await settle();
+  assert.equal(probes, 1);
+});


### PR DESCRIPTION
Stacked on #221, which is stacked on #220. Those two build the machinery; this
one turns it on for everyone.

A double-buffered window now blits through the Present extension and takes its
frame clock from the display without being asked. `present: true` becomes the
default rather than an opt-in, and `present: false` is how you decline.

BREAKING CHANGE: `present: true` was opt-in and is now the default for
double-buffered windows, which changes both how a frame is sent and what paces
it. Pass `present: false` for the old behaviour, or `frameClock: 'fence'` to
keep the old clock while still presenting.

What a window gets for free:

- frames at the output's own rate, phase-locked to it, instead of the 62.5fps
  a 16ms interval implies
- exact damage rectangles in one request instead of one CopyArea each
- an animation loop that stops running when nobody can see the window. A
  Wayland compositor answers an occluded window about once a second, so its
  frames come about once a second, against the ~56 a second the same loop
  costs on the fence clock

The decision rides on the backing store rather than the constructor: it is
taken in `_enableBackingStore`, so a window drawing through the 'opengl' or
'x11' contexts — which has no pixmap to present — never buys an update region
and an event selection it cannot use. An explicit `present: true` still takes
effect eagerly, for a caller who wants the extension up before the first
paint, and `await wnd.enablePresent()` still reports whether it took.

Everything degrades the way it already did. Where Present or XFixes is
missing, blits fall back to CopyArea and frames to the fence; a completion
that never arrives falls back after two seconds and is taken up again when
one does. The one new cost on a server without Present is two extension
queries per connection, which node-x11 answers from its cache after the
first.

Verified on a live server: a plain window with a 2d context reports
`frameClock: 'present'`, a `present: false` window reports `fence` and blits
with CopyArea, and a window that never asks for a 2d context allocates
neither region nor event context.
