### PR TITLE
docs: measure and document what the display's clock costs

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -311,6 +311,27 @@ const wnd = app.createWindow({ frameInterval: 33 }); // ~30 fps on any display
 wnd.frameInterval = 0; // back to the display's rate
 ```
 
+#### What the display's clock costs
+
+A present holds the backing store until the server executes the copy, so a
+repaint raised *part-way* through a frame — a click during a scroll, a
+keystroke while something is moving — cannot go out until the completion
+arrives. On the fence clock it went out immediately and reached the same
+vertical blank; here it can miss that blank and land on the next one.
+
+Measured end to end on a ~15 ms refresh, with an animation running so there
+is always a frame in flight to be caught behind, that is worth **2–4 ms at
+the median** — a fraction of a period rather than a whole one, because a
+repaint raised early in a frame still catches the same blank. It scales with
+the period, so it shrinks on a faster display. `scripts/bench-present-latency.mjs`
+measures it per machine; the numbers move by ~1.5 ms between runs, so read
+the difference between the two clocks rather than either column.
+
+Worth knowing about rather than worth avoiding: `frameClock: 'fence'` buys
+those milliseconds back and gives up rate-matching, phase-locking and the
+throttling of windows nobody can see. If the latency matters more than any of
+that — a drawing surface tracking a stylus, say — it is the escape hatch.
+
 While a frame is pending, noisy events **coalesce** instead of queueing:
 
 - `resize`, `mousemove` — the newest event wins. Every merged raw event is
@@ -357,6 +378,16 @@ wnd.on('mousedown', (ev) => {
   if (!wnd.frameInFlight()) paint(); // else leave it to the frame clock
 });
 ```
+
+The same gate is what keeps drawing off a backing store the server is busy
+with. A present owns the pixmap until the copy executes (see
+[What the display's clock costs](#what-the-displays-clock-costs)), and ntk
+holds back the blits it controls — the one after an event handler, the one
+ending a frame — until it is handed back. Drawing raised from neither place,
+a bare `setTimeout` that paints, is outside that and can land in a pixmap
+mid-copy. Paint from an event handler or a `requestAnimationFrame` callback
+and this never arises; if you must paint from a timer, gate it on
+`frameInFlight()` the same way.
 
 Escape hatches, from mildest to rawest:
 

--- a/scripts/bench-present-latency.mjs
+++ b/scripts/bench-present-latency.mjs
@@ -1,0 +1,144 @@
+// How long does a repaint take to reach the display, when it is triggered
+// part-way through a frame rather than at one? (issue #223)
+//
+//   node scripts/bench-present-latency.mjs [samples] [--quiet]     # default 60
+//
+// A present with Option.Copy leaves the server owning the backing pixmap
+// until it executes the copy at a vertical blank, so a repaint raised in
+// between — a click during a scroll, a keystroke while something moves —
+// waits for the completion before its pixels can go out. That wait is up to
+// one refresh period, and this measures it against the fence clock, which
+// does not wait but also cannot say when the pixels landed.
+//
+// The measurement is end to end: from the moment the repaint is made, to the
+// server reporting that the frame carrying it was executed on the display.
+// Each present's serial is matched to the CompleteNotify that reports it, so
+// nothing is inferred from timers. The fence-clocked window selects for
+// completions too — it just does not pace on them — so both arms are
+// measured the same way.
+//
+// Needs a real X server ($DISPLAY). Under a Wayland compositor, run it on a
+// window you can see: a compositor answers an occluded window about once a
+// second, and the numbers then describe the throttle rather than the clock.
+//
+// Read the difference, not either column: both arms pay for the wait for a
+// vertical blank and only one of them pays the extra wait, so the absolute
+// numbers carry a period's worth of offset that is not the thing being
+// measured. And read it from enough samples — the spread between runs is
+// around 1.5 ms at 60 samples, so a single short run cannot resolve a
+// difference of that size, and an early draft of this bench reported a
+// penalty 2.5x the reproducible one from 26 samples.
+import { performance } from 'node:perf_hooks';
+
+import { createClient } from '../lib/index.js';
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const SAMPLES = Math.max(20, Number(args[0]) || 60);
+const QUIET = process.argv.includes('--quiet');
+
+if (!process.env.DISPLAY) {
+  console.error('bench-present-latency: needs $DISPLAY (try: xvfb-run -a node scripts/bench-present-latency.mjs)');
+  process.exit(1);
+}
+
+const percentile = (sorted, q) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))];
+
+async function measure(label, args) {
+  const app = await createClient();
+  const wnd = app.createWindow({ width: 400, height: 300, ...args });
+  wnd.map();
+  const ctx = wnd.getContext('2d');
+  await wnd.enablePresent();
+  const present = wnd._presentExt;
+  if (!present) {
+    console.log(`${label.padEnd(18)} no Present extension on this server`);
+    await app.close();
+    return;
+  }
+  // A fence-clocked window asks for no completions of its own, so give it
+  // an event context here — it reports the same landings, it just isn't
+  // waiting on them.
+  if (!wnd._presentEid) {
+    present.SelectInput(app.X.AllocID(), wnd.id, present.EventMask.CompleteNotify);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  // Something has to be animating, or there is no frame in flight to be
+  // caught in the middle of and both clocks answer immediately.
+  let tick = 0;
+  const spin = () => {
+    tick++;
+    ctx.fillStyle = tick % 2 ? '#202030' : '#202032';
+    ctx.fillRect(0, 0, 400, 40);
+    wnd.requestAnimationFrame(spin);
+  };
+  wnd.requestAnimationFrame(spin);
+
+  const waiting = new Map(); // present serial -> when the repaint was made
+  let raisedAt = null;
+  const sendPixmap = present.Pixmap.bind(present);
+  present.Pixmap = (win, pixmap, opts) => {
+    if (raisedAt !== null) {
+      waiting.set(opts.serial, raisedAt);
+      raisedAt = null;
+    }
+    return sendPixmap(win, pixmap, opts);
+  };
+
+  const samples = [];
+  wnd.on('event', (ev) => {
+    // CompleteNotify for a PresentPixmap: evtype 1, kind 0
+    if (ev.type !== 35 || ev.evtype !== 1 || ev.kind !== 0) return;
+    const at = waiting.get(ev.serial);
+    if (at === undefined) return;
+    waiting.delete(ev.serial);
+    samples.push(performance.now() - at);
+  });
+
+  for (let i = 0; i < SAMPLES; i++) {
+    // varying the gap walks the repaint across the frame's phase, which is
+    // the whole point: a repaint that lands on a frame boundary waits for
+    // nothing on either clock
+    await new Promise((resolve) => setTimeout(resolve, 7 + (i % 5)));
+    raisedAt = performance.now();
+    ctx.fillStyle = '#e0b040';
+    ctx.fillRect(100, 100, 60, 60);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  samples.sort((a, b) => a - b);
+  if (!samples.length) {
+    console.log(`${label.padEnd(18)} no frames landed — is the window visible?`);
+  } else {
+    const ms = (v) => v.toFixed(2).padStart(6);
+    console.log(
+      `${label.padEnd(18)} n=${String(samples.length).padStart(3)}  ` +
+        `median ${ms(percentile(samples, 0.5))}  p90 ${ms(percentile(samples, 0.9))}  ` +
+        `max ${ms(samples.at(-1))}   ` +
+        `clock=${wnd.frameClock} refresh=${wnd.refreshInterval?.toFixed(1) ?? 'n/a'} dropped=${wnd.droppedFrames}`
+    );
+  }
+  if (wnd.refreshInterval) vblankPeriod = wnd.refreshInterval.toFixed(1);
+  wnd.destroy();
+  await app.close();
+  return samples;
+}
+
+if (!QUIET) {
+  console.log(
+    '\nrepaint raised mid-frame -> reported on the display, in ms\n' +
+      'the gap between the two is what a second backing pixmap would buy back (#223)\n'
+  );
+}
+let vblankPeriod = null;
+const vblank = await measure('vblank clock', {});
+const fence = await measure('fence clock', { frameClock: 'fence' });
+
+if (!QUIET && vblank?.length && fence?.length) {
+  const delta = percentile(vblank, 0.5) - percentile(fence, 0.5);
+  console.log(
+    `\npenalty at the median: ${delta.toFixed(2)} ms` +
+      ` — against a ${vblankPeriod ?? '?'} ms refresh period. Runs vary by around 1.5 ms;\n` +
+      'take a difference smaller than that as no difference.\n'
+  );
+}


### PR DESCRIPTION
Follow-up to #223. A present holds the backing store until the server
executes the copy, so a repaint raised part-way through a frame waits for
the completion before it can go out — on the fence clock it went out
immediately and caught the same vertical blank. That cost was known when
#220 landed but never quantified or written down, which left the one real
downside of the new clock undocumented.

`scripts/bench-present-latency.mjs` measures it end to end: from the moment
a repaint is made to the server reporting the frame carrying it as executed,
with each present's serial matched to the CompleteNotify that reports it, so
nothing is inferred from timers. Both arms select for completions — the
fence-clocked window simply does not pace on them — so the two are measured
the same way, and an animation runs throughout, since with no frame in
flight there is nothing to be caught behind and both clocks answer at once.

On Xvfb at a ~15 ms period the penalty is 2.2 to 3.7 ms at the median, which
extrapolates to roughly 1 ms at 180Hz. Notably not the half-period that
uniform input phase would predict: a repaint raised early in a frame still
makes the same blank, and only a late one slips.

The bench is written to resist the mistake made while building it. An early
draft reported 7.2 ms from 26 samples, which three runs at 60 samples then
contradicted — the spread between runs is around 1.5 ms, so a short run
cannot resolve a difference of that size. The default sample count is 60,
the summary prints the refresh period the penalty should be read against,
and the header says to treat anything under the spread as nothing.

Documented in docs/window.md as a subsection of "What ends a frame", along
with the escape hatch, since `frameClock: 'fence'` buys those milliseconds
back at the cost of rate-matching and of throttling windows nobody can see.

Also documents the hazard behind the same mechanism: ntk holds back the
blits it controls until the pixmap is handed back, but drawing raised from
neither an event handler nor a frame callback — a bare timer that paints —
is outside that and can land in a pixmap mid-copy. `frameInFlight()` is the
gate for code that has to do it anyway.
