### PR TITLE
fix(app): give each connection its own atom table

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,6 +9,15 @@ import FontManager from './text/fontmanager.js';
 import Window from './window.js';
 
 /**
+ * The highest predefined atom id in the core protocol, `XA_WM_TRANSIENT_FOR`.
+ *
+ * Atoms 1 to 68 are named by the protocol itself, so every server agrees on
+ * them and no server ever frees them. Anything above is interned at runtime
+ * and belongs to the connection that asked for it — see `_isolateAtoms`.
+ */
+const PREDEFINED_ATOM_MAX = 68;
+
+/**
  * Frame interval used before the display has been asked, in ms — and the one
  * kept on a server that cannot answer.
  */
@@ -76,6 +85,7 @@ export default class App {
     this.display = display;
     this.X = display.client;
     this.options = options;
+    this._isolateAtoms();
     this._fonts = null;
     this._clipboard = null;
     this._cursors = null;
@@ -92,6 +102,47 @@ export default class App {
       if (this.options.onXError) this.options.onXError(err);
       else console.warn(`ntk: unhandled X error: ${err.message} (opcode ${err.majorOpcode}, seq ${err.seq})`);
     });
+  }
+
+  /**
+   * Give this connection an atom table of its own.
+   *
+   * node-x11 hands every client the *same* table object — `this.atoms =
+   * stdatoms` in xcore, assigned rather than copied — and `InternAtom`
+   * answers out of it without a round trip when the name is already there.
+   * So an id interned on one connection is handed to every other connection
+   * in the process, which have never asked the server for it.
+   *
+   * That is safe only while something keeps the server alive. An X server
+   * frees every atom it holds when its **last** client disconnects, and
+   * hands the same ids out again to whatever is interned next. A process
+   * that opens connections in sequence — a test suite, a tool that runs a
+   * few apps, anything under Xvfb with no window manager holding the server
+   * open — therefore writes properties with ids the server has forgotten.
+   * The visible half of that is `BadAtom` on a `ChangeProperty` naming an
+   * atom the app never chose; the quiet half is worse, because once the id
+   * has been reissued to a different name the write lands under *that* atom
+   * and no error is reported at all.
+   *
+   * Keeping only the predefined atoms is what makes the copy correct: ids 1
+   * to 68 are fixed by the core protocol, identical on every server, and
+   * never freed. Everything above that has to be interned per connection,
+   * which now happens because this table starts without it. Within one
+   * connection the caching still works, and it is still correct, because a
+   * live connection is exactly what stops the server resetting.
+   */
+  _isolateAtoms() {
+    const shared = this.X.atoms;
+    if (!shared) return;
+    const own = {};
+    const names = {};
+    for (const [name, id] of Object.entries(shared)) {
+      if (id > PREDEFINED_ATOM_MAX) continue;
+      own[name] = id;
+      names[id] = name;
+    }
+    this.X.atoms = own;
+    this.X.atom_names = names;
   }
 
   /**

--- a/lib/window.js
+++ b/lib/window.js
@@ -1902,8 +1902,9 @@ export default class Window extends Drawable {
 
   /**
    * Intern several atoms and hand them to `cb` as an object keyed by name.
-   * node-x11 caches interned atoms per connection, so a repeated call
-   * costs no round trip. Same deferred-chain hazards as setTitle: by the
+   * Interned atoms are cached per connection — which is true because App
+   * makes it true, see `_isolateAtoms` — so a repeated call costs no round
+   * trip. Same deferred-chain hazards as setTitle: by the
    * time the replies land the window may be gone, so callers re-check
    * `this._destroyed`.
    */
@@ -3371,8 +3372,9 @@ export default class Window extends Drawable {
 
   _emitCloseRequest(ev) {
     if (ev.format !== 32 || !this.listenerCount('close')) return;
-    // node-x11 caches interned atoms per connection, so these are the ids
-    // the 'close' listener's addProtocol already interned
+    // interned atoms are cached per connection (App#_isolateAtoms), so these
+    // are the ids this window's own addProtocol interned — an id another
+    // connection happened to intern would not be one this server still knows
     const X = this.X;
     if (!X.atoms.WM_PROTOCOLS || ev.message_type !== X.atoms.WM_PROTOCOLS) return;
     if (!X.atoms.WM_DELETE_WINDOW || ev.data?.[0] !== X.atoms.WM_DELETE_WINDOW) return;

--- a/test/atom-isolation.test.js
+++ b/test/atom-isolation.test.js
@@ -1,0 +1,98 @@
+// Each connection gets its own atom table (lib/app.js `_isolateAtoms`).
+//
+// node-x11 gives every client the same table object and answers InternAtom
+// out of it without a round trip, so an id interned on one connection is
+// handed to every other connection in the process. An X server frees every
+// atom it holds the moment its last client disconnects, and reissues the
+// same ids to whatever is interned next — so a process that opens
+// connections in sequence ends up writing properties with ids the server has
+// forgotten, or worse, ids it has since given to a different name.
+//
+// Against a live server the shape is:
+//
+//   xvfb-run -a node -e "... four Apps in sequence, each createWindow+map ..."
+//   ntk: unhandled X error: Bad atom (opcode 18, seq 12)   # one per app
+//
+// which needs a server nothing else is connected to — a window manager holds
+// the server open and hides the whole thing. These tests pin the invariant
+// instead, which holds everywhere.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import App from '../lib/app.js';
+
+/** node-x11's own predefined table: ids 1..68, fixed by the core protocol. */
+const PREDEFINED = { PRIMARY: 1, ATOM: 4, CARDINAL: 6, STRING: 31, WM_NAME: 39, WM_TRANSIENT_FOR: 68 };
+
+/**
+ * Two clients over one shared atoms object, the way node-x11 builds them.
+ * `stdatoms` is assigned rather than copied, so both start out pointing at
+ * the very same object.
+ */
+function makeConnections(count) {
+  const shared = { ...PREDEFINED };
+  const apps = [];
+  for (let i = 0; i < count; i++) {
+    const X = {
+      atoms: shared,
+      atom_names: Object.fromEntries(Object.entries(shared).map(([n, v]) => [v, n])),
+      on() {}
+    };
+    apps.push(new App({ client: X, screen: [{ root: 1 }] }, {}));
+  }
+  return { apps, shared };
+}
+
+test('an atom interned on one connection is not visible to the next', () => {
+  const { apps, shared } = makeConnections(2);
+  // the first connection interns something at runtime, as setPid does; the
+  // reply handler writes it into what node-x11 thinks is that client's table
+  apps[0].X.atoms._NET_WM_PID = 233;
+
+  assert.equal(
+    apps[1].X.atoms._NET_WM_PID,
+    undefined,
+    'the second connection must ask the server itself'
+  );
+  assert.equal(shared._NET_WM_PID, undefined, 'and the shared table is left alone');
+});
+
+test('predefined atoms are kept, because no server ever frees them', () => {
+  const { apps } = makeConnections(1);
+  const X = apps[0].X;
+  for (const [name, id] of Object.entries(PREDEFINED)) {
+    assert.equal(X.atoms[name], id, `${name} is fixed by the protocol`);
+  }
+});
+
+test('a runtime atom already in the shared table is dropped, not inherited', () => {
+  // the realistic case: something interned before this App was built — an
+  // earlier App in the same process, or a raw node-x11 client
+  const shared = { ...PREDEFINED, _NET_WM_PID: 233, WM_PROTOCOLS: 297 };
+  const X = { atoms: shared, atom_names: {}, on() {} };
+  const app = new App({ client: X, screen: [{ root: 1 }] }, {});
+
+  assert.equal(app.X.atoms._NET_WM_PID, undefined);
+  assert.equal(app.X.atoms.WM_PROTOCOLS, undefined);
+  assert.equal(app.X.atoms.CARDINAL, 6, 'while the predefined ones survive');
+});
+
+test('atom_names is rebuilt to match, so a stale id resolves to no name', () => {
+  const shared = { ...PREDEFINED, _NET_WM_PID: 233 };
+  const X = {
+    atoms: shared,
+    atom_names: Object.fromEntries(Object.entries(shared).map(([n, v]) => [v, n])),
+    on() {}
+  };
+  const app = new App({ client: X, screen: [{ root: 1 }] }, {});
+
+  assert.equal(app.X.atom_names[233], undefined, 'no name for an id we never interned');
+  assert.equal(app.X.atom_names[6], 'CARDINAL');
+});
+
+test('the table is the connection\'s own object, not the shared one', () => {
+  const { apps, shared } = makeConnections(2);
+  assert.notEqual(apps[0].X.atoms, shared);
+  assert.notEqual(apps[1].X.atoms, shared);
+  assert.notEqual(apps[0].X.atoms, apps[1].X.atoms);
+});


### PR DESCRIPTION
Running several ntk apps in sequence against a server nothing else is
connected to — Xvfb, or any display with no window manager — produced one
`ntk: unhandled X error: Bad atom (opcode 18, seq 12)` per app after the
first. The raw error named nothing the caller wrote, and the quiet half of
it was worse: `_NET_WM_PID` was silently never set on any of those windows,
so anything asking which process owns a window got no answer.

Two things combine. node-x11 hands every client the *same* atom table —
`this.atoms = stdatoms` in xcore, assigned rather than copied — and answers
`InternAtom` out of it without a round trip when the name is already there,
so an id interned on one connection is handed to every other connection in
the process. Meanwhile an X server frees every atom it holds the moment its
last client disconnects, and hands the same ids out again to whatever is
interned next. A process that opens connections in sequence therefore writes
properties with ids the server has forgotten.

Confirmed on the wire rather than reasoned about: with the last client gone,
interning a brand-new name returns 233 — the id the previous connection's
`_NET_WM_PID` held — which only happens if the table was reset. Holding one
spare connection open for the duration makes the whole thing disappear,
which is exactly why a desktop with a window manager never sees it.

App now copies the table, keeping only atoms 1 to 68. Those are named by the
core protocol, identical on every server and never freed; everything above
has to be interned per connection, which now happens because the table
starts without it. Caching within a connection still works and is still
correct, because a live connection is precisely what stops the server
resetting.

Worth stating what the failure mode would have been had the timing differed:
once a freed id is reissued to a *different* name, a write under the stale
id lands on that other atom and no error is reported at all. The visible
BadAtom was the lucky case.

The fix is defensive — the shared table is node-x11's to fix, since a wrong
id on the wire is something the server rejects. Doing it here as well means
ntk is correct against every published node-x11.

Tests pin the invariant hermetically, since reproducing the real thing needs
a server with no other client on it. Two comments claiming atoms are "cached
per connection" now point at what makes that true; they were describing an
intention rather than the behaviour.
