### PR TITLE
ci: let the release workflow be dispatched manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [master]
+  # A push that never reaches Actions — a throttled webhook during an incident,
+  # say — leaves master with releasable commits and no release PR, and GitHub
+  # does not backfill the run it dropped. Dispatch recovers without having to
+  # land an empty commit on master.
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
## Why

Release-please stopped producing release PRs after 7.0.0. The cause was not the commit messages — all three commits merged since then parse cleanly under `scripts/check-release-message.mjs` (`fix`, `feat`, `docs`, so 7.1.0 is due). The Release workflow simply never ran.

The [GitHub Actions incident](https://www.githubstatus.com/) that opened 2026-08-06 15:22:49 UTC throttled webhook triggers, "preventing many push and pull request events from triggering workflows". #226, #227 and #225 were merged at 22:40–22:42 UTC, inside that window. Their merge commits carry no `github-actions` check suite at all — only stuck third-party app suites — whereas 66c6a72 (release 7.0.0) has three, all green. CI and Deploy docs were dropped for those pushes too.

GitHub does not backfill runs it dropped, and `release.yml` was `push`-only, so there was no way to recover short of landing an empty commit on master.

## What

Adds `workflow_dispatch:` to the Release workflow, with a comment recording why it is there.

`release-please-action` reads the commit range from the API rather than the event payload, so a dispatched run proposes the same release PR a push would have.

Note that merging this PR is itself a push to master, so it doubles as the retrigger for the missed 7.1.0 release PR — assuming Actions has recovered by then. If it has not, the new dispatch trigger is the fallback.