### PR TITLE
fix(text): an animated axis is churn, and the router could not see it

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -108,10 +108,19 @@ So `drawGlyphRuns` routes each run (issue #45):
   at the exact size, decomposed into trapezoids (`lib/trapezoid.js`) and
   rendered server-side with one batched `AddTraps` + `Composite` through a
   shared scratch a8 mask per draw. Nothing is cached server-side;
-- **in between** — bitmaps, unless the size is fractional or a small
-  per-face ring of recently drawn sizes shows no reuse (an animation in
-  flight). Both signals route to vector, and an animation that settles
-  flips back to bitmaps on the next frame.
+- **in between** — bitmaps, unless the size is fractional or a small ring of
+  what the face has drawn recently shows no reuse (an animation in flight).
+  Both signals route to vector, and an animation that settles flips back to
+  bitmaps on the next frame.
+
+The ring is keyed by **face** and records the `(instance, size)` pairs a
+glyph page is keyed by, which is what has to repeat for caching to pay for
+itself. For a variable font the face is the one the instances were cut from,
+not the instances: every point on an axis is a `Font` of its own, so an
+animated axis would otherwise hand the router a fresh empty ring on every
+step — eight unrelated faces each drawn once, no churn to see — and stay on
+the bitmap path allocating a glyph page per step. A sweep of the `wght` axis
+and a sweep of the size are the same event, and read as one.
 
 Vector-path positioning is *not* rounded to whole pixels, so fractional
 sizes and fractional pen positions animate smoothly (the bitmap path rounds

--- a/lib/text/glyphs.js
+++ b/lib/text/glyphs.js
@@ -232,17 +232,32 @@ export function routeGlyphSize(app, font, size, policy = policyOf(app)) {
   if (size <= policy.bitmapMax) return 'bitmap';
   if (size > policy.vectorFrom) return 'vector';
 
+  // The ring answers "is this face being drawn at something it has drawn
+  // recently, or is it churning?" — so it has to be keyed by the thing that
+  // stays put while the churn happens.
+  //
+  // For a variable font that is the *base* face, not the instance: every
+  // point on an axis is a Font of its own, with its own key, so an animated
+  // axis handed each step a fresh empty ring and the churn was invisible —
+  // it read as eight unrelated faces each drawn once. Keyed by the base and
+  // recording the instance alongside the size, an axis sweep and a size
+  // sweep look like what they both are, and a page of static text at one
+  // weight still reuses its entry on every frame.
   if (!app._sizeRings) app._sizeRings = new Map();
-  let ring = app._sizeRings.get(font.key);
+  const face = font.variationOf?.key ?? font.key;
+  let ring = app._sizeRings.get(face);
   if (!ring) {
     ring = [];
-    app._sizeRings.set(font.key, ring);
+    app._sizeRings.set(face, ring);
   }
-  const reused = ring.includes(size);
+  // what a glyph page is keyed by, which is exactly what has to repeat for
+  // caching to pay for itself
+  const entry = `${font.key}@${size}`;
+  const reused = ring.includes(entry);
   // dedupe consecutive entries so one frame drawing many runs at one size
   // occupies a single slot — the ring then spans ~8 distinct frames
-  if (ring[ring.length - 1] !== size) {
-    ring.push(size);
+  if (ring[ring.length - 1] !== entry) {
+    ring.push(entry);
     if (ring.length > 8) ring.shift();
   }
 

--- a/test/glyph-route-churn.test.js
+++ b/test/glyph-route-churn.test.js
@@ -1,0 +1,120 @@
+// Which glyph path a run takes when a face is being *animated*.
+//
+// Between `bitmapMax` and `vectorFrom` the router watches a small ring of
+// what a face has drawn recently: text that reuses its glyphs wants the
+// server-side cache, and text that never draws the same thing twice wants
+// the vector path, where nothing is cached and nothing leaks.
+//
+// A variable font broke the premise. Every point on an axis is a Font of
+// its own, with its own key and its own glyph page, so an animated axis
+// handed the router a fresh empty ring on every step: eight unrelated faces
+// each drawn once, no churn to see. It stayed on the bitmap path and
+// allocated a glyph page per step — the exact cost the ring exists to
+// avoid, invisible to it.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+import FontManager from '../lib/text/fontmanager.js';
+import { StaticFontSource } from '../lib/text/fontsource.js';
+import { DEFAULT_TEXT_POLICY, routeGlyphSize } from '../lib/text/glyphs.js';
+
+const VF = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'MonelogicsSubset[wght].ttf'
+);
+
+// squarely inside the band the ring governs
+const MID = Math.round((DEFAULT_TEXT_POLICY.bitmapMax + DEFAULT_TEXT_POLICY.vectorFrom) / 2);
+
+function fonts() {
+  const source = new StaticFontSource();
+  source.add(readFileSync(VF), { family: 'VF' });
+  return new FontManager({ source });
+}
+
+/** routeGlyphSize only reads `_sizeRings` off the app; nothing else. */
+const newApp = () => ({});
+
+test('an animated axis at one size routes to vector', () => {
+  const app = newApp();
+  const manager = fonts();
+  const routes = [];
+  for (let wght = 400; wght < 412; wght++) {
+    routes.push(routeGlyphSize(app, manager.match('VF', { weight: wght }), MID));
+  }
+  // the first few are allowed to be bitmap — the ring has to fill before it
+  // can call it churn — but it must not stay there
+  assert.ok(
+    routes.slice(6).every((r) => r === 'vector'),
+    `an axis sweep should settle on vector, got ${routes.join(' ')}`
+  );
+});
+
+test('an animated size on one face still routes to vector', () => {
+  const app = newApp();
+  const font = fonts().match('VF', { weight: 400 });
+  const routes = [];
+  for (let i = 0; i < 12; i++) routes.push(routeGlyphSize(app, font, MID + i));
+  assert.ok(
+    routes.slice(6).every((r) => r === 'vector'),
+    `a size sweep should settle on vector, got ${routes.join(' ')}`
+  );
+});
+
+test('text that redraws the same thing stays on the cached path', () => {
+  const app = newApp();
+  const font = fonts().match('VF', { weight: 400 });
+  const routes = [];
+  for (let frame = 0; frame < 20; frame++) routes.push(routeGlyphSize(app, font, MID));
+  assert.ok(
+    routes.every((r) => r === 'bitmap'),
+    'a static paragraph must keep its glyph cache'
+  );
+});
+
+test('a handful of fixed weights is a design system, not an animation', () => {
+  const app = newApp();
+  const manager = fonts();
+  const weights = [400, 500, 700];
+  const routes = [];
+  // several frames drawing the same three weights at the same size
+  for (let frame = 0; frame < 8; frame++) {
+    for (const weight of weights) {
+      routes.push(routeGlyphSize(app, manager.match('VF', { weight }), MID));
+    }
+  }
+  // the ring fills once, then every draw is a reuse
+  assert.ok(
+    routes.slice(weights.length * 2).every((r) => r === 'bitmap'),
+    `three repeating weights should keep the cache, got ${routes.join(' ')}`
+  );
+});
+
+test('instances of one base share a ring; unrelated faces do not', () => {
+  const app = newApp();
+  const manager = fonts();
+  routeGlyphSize(app, manager.match('VF', { weight: 400 }), MID);
+  routeGlyphSize(app, manager.match('VF', { weight: 700 }), MID);
+  assert.equal(
+    app._sizeRings.size,
+    1,
+    'two points on one axis are one face churning, not two faces'
+  );
+});
+
+test('below bitmapMax the cache always wins, animated or not', () => {
+  const app = newApp();
+  const manager = fonts();
+  const small = DEFAULT_TEXT_POLICY.bitmapMax - 20;
+  const routes = [];
+  for (let wght = 400; wght < 412; wght++) {
+    routes.push(routeGlyphSize(app, manager.match('VF', { weight: wght }), small));
+  }
+  // deliberate: at small sizes a glyph page is cheap and re-rasterizing every
+  // draw is not. An app that wants exact positions here asks for them.
+  assert.ok(routes.every((r) => r === 'bitmap'), `got ${routes.join(' ')}`);
+});


### PR DESCRIPTION
Between `bitmapMax` and `vectorFrom` the router watches a small ring of what a face has drawn recently: text that reuses its glyphs wants the server-side cache, text that never draws the same thing twice wants the vector path, where nothing is cached and nothing leaks.

A variable font broke the premise the ring rests on. Every point on an axis is a `Font` of its own, with its own key and its own glyph page — and the ring was keyed by that key. So an animated axis handed the router a fresh empty ring on every step: eight unrelated faces each drawn once, no churn to see.

```
--- animating the SIZE of one face (what the ring was built for) ---
routes: bitmap vector vector vector vector vector vector vector vector vector vector vector

--- animating an AXIS at one size (before) ---
routes: vector bitmap bitmap bitmap bitmap bitmap bitmap bitmap bitmap bitmap bitmap bitmap
```

It stayed on the bitmap path and allocated a glyph page per step — exactly the cost the ring exists to avoid, invisible to it.

## The fix

Key the ring by the **base** face, and record the `(instance, size)` pair a glyph page is keyed by rather than the size alone. That is what has to repeat for caching to pay for itself, so a sweep of the `wght` axis and a sweep of the size become the same event and read as one.

```
--- animating an AXIS at one size (after) ---
routes: vector vector vector vector vector vector vector vector vector vector vector vector
```

## Scope, stated plainly

This does **not** touch the `size <= bitmapMax` early return, so display text at 96px still takes the cached path however hard its axis is driven — the ring is never consulted down there.

That is deliberate: at small sizes a glyph page is cheap and re-rasterizing every draw is not, and widening the heuristic would risk pushing ordinary UI text onto the slow path. It is also why an app that wants exact glyph positions at a size it chooses needs a way to *say so* rather than hope a heuristic infers it. That property is the next PR; this one is just the heuristic doing what it already claimed to do.

## Tests

Six cases in `test/glyph-route-churn.test.js`. Two are the fix and fail on the parent commit:

- an animated axis at one size settles on vector
- two points of one axis share a ring, rather than reading as two faces

Four are controls that pass either way, and would catch the obvious over-corrections:

- an animated **size** on one face still routes to vector (the original behaviour)
- a static paragraph redrawn 20 times keeps its glyph cache
- three fixed weights across eight frames is a design system, not an animation — fills the ring once, then hits it
- below `bitmapMax` the cache wins however the axis moves

`npm test`: 817/817.
