### PR TITLE
feat(text): textRendering, so a run can name its own glyph path

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -126,6 +126,49 @@ Vector-path positioning is *not* rounded to whole pixels, so fractional
 sizes and fractional pen positions animate smoothly (the bitmap path rounds
 both, which is correct for static UI text).
 
+### `textRendering`
+
+Size is a guess at intent, and a good one for UI text. It cannot know that a
+word is a headline whose weight is under a slider. `textRendering` is how a
+run says so, taking CSS's property and its values:
+
+```js
+ctx.textRendering = 'geometricPrecision';
+app.fonts.layout(spans, { family: 'Inter', size: 96, textRendering: 'geometricPrecision' });
+```
+
+| value                | route              |                                                     |
+| -------------------- | ------------------ | --------------------------------------------------- |
+| `auto` (default)     | thresholds decide  | today's behaviour                                   |
+| `geometricPrecision` | always vector      | exact glyph origins, nothing cached                 |
+| `optimizeSpeed`      | always bitmap      | cached glyphs at any size                           |
+| `optimizeLegibility` | thresholds decide  | accepted, means `auto` — ntk has no hinting to turn on |
+
+**Why display text wants `geometricPrecision`.** On the bitmap path a glyph
+origin rounds to a whole pixel, because a cached bitmap can only land on
+one, and each glyph's advance is baked into the glyphset as an integer. Slide
+a variable font's `wght` and the true advances move by hundredths of a pixel;
+those hundredths accumulate along the line until one glyph crosses a rounding
+boundary and jumps a whole pixel on its own while its neighbours stand still.
+Same font, same size, only the pen origin sliding by a tenth of a pixel:
+
+```
+bitmap   ink centroid over an 0.1px sweep:  6 distinct positions in 11 samples
+vector   ink centroid over the same sweep: 11 distinct positions in 11 samples
+```
+
+It is a **per-span** property, so one paragraph can hold a headline that
+wants exact positions and body text that wants its glyph cache — the two are
+partitioned into separate composites, which is what already happens when a
+paragraph crosses a size threshold.
+
+The cost is real and worth stating: the vector path rasterizes outlines on
+every draw and caches nothing. That is the right trade for text being
+animated, and the wrong one for a paragraph that never changes.
+
+`textPolicy.textRendering` sets an app-wide default for a window that is all
+display text; a run that names its own always wins.
+
 The thresholds and the cache budget are per-app configurable:
 
 ```js

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -525,6 +525,7 @@ class RenderingContext2d {
       textStyle: this._textStyle,
       fontString: this._lastFontString,
       fontVariations: this._fontVariations,
+      textRendering: this._textRendering,
       textAlign: this.textAlign,
       textBaseline: this.textBaseline,
       m: this._m.slice(),
@@ -548,6 +549,7 @@ class RenderingContext2d {
     this._textStyle = s.textStyle;
     this._lastFontString = s.fontString;
     this._fontVariations = s.fontVariations;
+    this._textRendering = s.textRendering;
     this.textAlign = s.textAlign;
     this.textBaseline = s.textBaseline;
     this._m = s.m;
@@ -2339,7 +2341,12 @@ class RenderingContext2d {
     const positioned = [];
     let cursor = ox;
     for (const run of reorderRuns(shaped.runs)) {
-      positioned.push({ run, x: cursor, y: oy });
+      positioned.push({
+        run,
+        x: cursor,
+        y: oy,
+        textRendering: this._textRendering,
+      });
       cursor += run.width;
     }
     this.drawGlyphs(
@@ -2449,6 +2456,30 @@ class RenderingContext2d {
 
   get fontVariationSettings() {
     return this._fontVariations ?? null;
+  }
+
+  /**
+   * CSS's `text-rendering`: which glyph path this text takes, overriding the
+   * size thresholds in `app.textPolicy`.
+   *
+   * - `'geometricPrecision'` — outlines every draw, glyph origins **not**
+   *   rounded to whole pixels. What display text wants, and what any text
+   *   whose shape is being animated wants: a variable font's axis moves
+   *   advances by fractions of a pixel, and cached glyphs can only land on
+   *   whole ones, so those fractions accumulate until a glyph crosses a
+   *   rounding boundary and jumps a pixel on its own.
+   * - `'optimizeSpeed'` — cached server-side glyphs at any size.
+   * - `'auto'` (default) — the thresholds decide.
+   *
+   * `'optimizeLegibility'` is accepted and means `'auto'`; ntk has no
+   * hinting to turn on.
+   */
+  set textRendering(val) {
+    this._textRendering = val || undefined;
+  }
+
+  get textRendering() {
+    return this._textRendering ?? "auto";
   }
 
   // ------------------------------------------------------------------

--- a/lib/text/glyphs.js
+++ b/lib/text/glyphs.js
@@ -20,11 +20,17 @@ import { trapezoidize } from '../trapezoid.js';
  * - `cacheBytes` — LRU budget for uploaded glyph bitmaps per connection;
  *   least-recently-drawn (face, size) pages are freed server-side
  *   (FreeGlyphSet) so transient sizes don't accumulate.
+ * - `textRendering` — an app-wide default for the per-run property of the
+ *   same name (see `routeForRendering`). Left undefined the thresholds
+ *   decide, which is what almost every app wants; `'geometricPrecision'`
+ *   here is the blunt instrument for a window that is all display text.
+ *   A run that names its own always wins.
  */
 export const DEFAULT_TEXT_POLICY = {
   bitmapMax: 128,
   vectorFrom: 256,
-  cacheBytes: 8 << 20
+  cacheBytes: 8 << 20,
+  textRendering: undefined
 };
 
 function policyOf(app) {
@@ -228,7 +234,41 @@ export function positionGlyphs(positioned) {
  *
  * @returns {'bitmap'|'vector'}
  */
-export function routeGlyphSize(app, font, size, policy = policyOf(app)) {
+/**
+ * CSS's `text-rendering`, as far as it means anything here: a run's own
+ * answer to which glyph path it takes, overriding the size thresholds.
+ *
+ * - `geometricPrecision` — the vector path, always. Outlines are flattened
+ *   at the exact size and glyph origins are not rounded, so advances land
+ *   where shaping put them. This is what display text wants, and what any
+ *   text whose shape is being animated wants: a variable font's axis moves
+ *   advances by fractions of a pixel, and on the bitmap path those fractions
+ *   accumulate silently until a glyph crosses a rounding boundary and jumps
+ *   a whole pixel on its own. It is also the path that caches nothing, so
+ *   an axis under a slider stops minting a glyph page per step.
+ * - `optimizeSpeed` — the bitmap path, always. Cached server-side glyphs at
+ *   any size, for text that is large but static.
+ * - `auto` (the default, and anything unrecognized) — the size thresholds
+ *   and the churn ring decide, as before.
+ *
+ * `optimizeLegibility` is accepted and means `auto`: ntk has no hinting to
+ * turn on, so promising anything by it would be a lie.
+ */
+export function routeForRendering(textRendering) {
+  if (textRendering === 'geometricPrecision') return 'vector';
+  if (textRendering === 'optimizeSpeed') return 'bitmap';
+  return null; // auto: ask the thresholds
+}
+
+export function routeGlyphSize(app, font, size, policy = policyOf(app), textRendering) {
+  // Inlined rather than a call to `routeForRendering`: this is the first
+  // thing every run of every draw does, and the overwhelmingly common answer
+  // is "nobody asked". One `??` and one comparison get us past it.
+  const asked = textRendering ?? policy.textRendering;
+  if (asked !== undefined && asked !== 'auto') {
+    const route = routeForRendering(asked);
+    if (route) return route;
+  }
   if (size <= policy.bitmapMax) return 'bitmap';
   if (size > policy.vectorFrom) return 'vector';
 
@@ -244,15 +284,20 @@ export function routeGlyphSize(app, font, size, policy = policyOf(app)) {
   // sweep look like what they both are, and a page of static text at one
   // weight still reuses its entry on every frame.
   if (!app._sizeRings) app._sizeRings = new Map();
-  const face = font.variationOf?.key ?? font.key;
-  let ring = app._sizeRings.get(face);
+  // A face with no instances behind it keeps the old ring exactly: its key
+  // is already constant across the ring, so the size alone identifies a
+  // glyph page and the entries stay numbers. Only a variable instance pays
+  // for the composite key, and only in this band — text at or below
+  // `bitmapMax` returned above without touching any of it.
+  const base = font.variationOf;
+  let ring = app._sizeRings.get(base ? base.key : font.key);
   if (!ring) {
     ring = [];
-    app._sizeRings.set(face, ring);
+    app._sizeRings.set(base ? base.key : font.key, ring);
   }
   // what a glyph page is keyed by, which is exactly what has to repeat for
   // caching to pay for itself
-  const entry = `${font.key}@${size}`;
+  const entry = base ? `${font.key}@${size}` : size;
   const reused = ring.includes(entry);
   // dedupe consecutive entries so one frame drawing many runs at one size
   // occupies a single slot — the ring then spans ~8 distinct frames
@@ -284,7 +329,9 @@ export function drawGlyphRuns(app, op, srcId, dstId, positioned) {
   let vector = null;
   for (let i = 0; i < positioned.length; i++) {
     const { run } = positioned[i];
-    if (routeGlyphSize(app, run.font, run.size, policy) === 'vector') {
+    if (
+      routeGlyphSize(app, run.font, run.size, policy, positioned[i].textRendering) === 'vector'
+    ) {
       if (!vector) {
         vector = [];
         bitmap = positioned.slice(0, i);

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -67,6 +67,7 @@ export class TextLayout {
         weight: s.weight ?? style.weight,
         style: s.style ?? style.style,
         variations: s.variations ?? style.variations,
+        textRendering: s.textRendering ?? style.textRendering,
         features: s.features ?? style.features,
         language: s.language ?? style.language,
         color: s.color ?? style.color ?? null
@@ -497,7 +498,15 @@ export class TextLayout {
         const color = r.span.color;
         if (batch.length && color !== batchColor) flush();
         batchColor = color;
-        batch.push({ run: r.run, x: x + line.x + r.x, y: y + line.baseline });
+        batch.push({
+          run: r.run,
+          x: x + line.x + r.x,
+          y: y + line.baseline,
+          // per run, because it is a span property: one paragraph may hold
+          // a display word that wants exact positions and body text that
+          // wants its glyph cache. `drawGlyphRuns` already partitions.
+          textRendering: r.span.textRendering
+        });
       }
     }
     flush();

--- a/test/text-rendering.test.js
+++ b/test/text-rendering.test.js
@@ -1,0 +1,102 @@
+// `textRendering`: a run's own answer to which glyph path it takes.
+//
+// The thresholds in `textPolicy` are a guess from size, and a good one for
+// UI text. They cannot know that a word is a headline whose weight is under
+// a slider — and on the bitmap path that word's advances round to whole
+// pixels, so a fraction of drift accumulates silently until one glyph
+// crosses a boundary and jumps a pixel by itself while its neighbours stand
+// still. This is how an app says which it wants.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+import FontManager from '../lib/text/fontmanager.js';
+import { StaticFontSource } from '../lib/text/fontsource.js';
+import {
+  DEFAULT_TEXT_POLICY,
+  routeForRendering,
+  routeGlyphSize
+} from '../lib/text/glyphs.js';
+
+const VF = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'MonelogicsSubset[wght].ttf'
+);
+
+const SMALL = DEFAULT_TEXT_POLICY.bitmapMax - 20; // the thresholds say bitmap
+const HUGE = DEFAULT_TEXT_POLICY.vectorFrom + 100; // the thresholds say vector
+
+function font() {
+  const source = new StaticFontSource();
+  source.add(readFileSync(VF), { family: 'VF' });
+  return new FontManager({ source }).match('VF', { weight: 400 });
+}
+
+const newApp = () => ({});
+
+test('the values map to the two paths, and auto defers', () => {
+  assert.equal(routeForRendering('geometricPrecision'), 'vector');
+  assert.equal(routeForRendering('optimizeSpeed'), 'bitmap');
+  assert.equal(routeForRendering('auto'), null);
+  assert.equal(routeForRendering(undefined), null);
+  // no hinting to turn on, so it promises nothing
+  assert.equal(routeForRendering('optimizeLegibility'), null);
+  assert.equal(routeForRendering('nonsense'), null);
+});
+
+test('geometricPrecision wins where the thresholds say bitmap', () => {
+  const f = font();
+  assert.equal(routeGlyphSize(newApp(), f, SMALL), 'bitmap', 'the default');
+  assert.equal(
+    routeGlyphSize(newApp(), f, SMALL, undefined, 'geometricPrecision'),
+    'vector'
+  );
+});
+
+test('optimizeSpeed wins where the thresholds say vector', () => {
+  const f = font();
+  assert.equal(routeGlyphSize(newApp(), f, HUGE), 'vector', 'the default');
+  assert.equal(
+    routeGlyphSize(newApp(), f, HUGE, undefined, 'optimizeSpeed'),
+    'bitmap'
+  );
+});
+
+test('auto leaves every threshold exactly as it was', () => {
+  const f = font();
+  for (const size of [SMALL, HUGE]) {
+    assert.equal(
+      routeGlyphSize(newApp(), f, size, undefined, 'auto'),
+      routeGlyphSize(newApp(), f, size)
+    );
+  }
+});
+
+test('a policy default applies app-wide, and a run still overrides it', () => {
+  const f = font();
+  const app = { textPolicy: { textRendering: 'geometricPrecision' } };
+  assert.equal(routeGlyphSize(app, f, SMALL), 'vector', 'the app asked');
+  assert.equal(
+    routeGlyphSize(app, f, SMALL, undefined, 'optimizeSpeed'),
+    'bitmap',
+    'the run asked louder'
+  );
+});
+
+test('it overrides the churn heuristic too, in both directions', () => {
+  const f = font();
+  const mid = Math.round(
+    (DEFAULT_TEXT_POLICY.bitmapMax + DEFAULT_TEXT_POLICY.vectorFrom) / 2
+  );
+  // an app that has decided its large text is static keeps the cache even
+  // while the ring is calling it churn
+  const app = newApp();
+  const routes = [];
+  for (let i = 0; i < 12; i++) {
+    routes.push(routeGlyphSize(app, f, mid + i, undefined, 'optimizeSpeed'));
+  }
+  assert.ok(routes.every((r) => r === 'bitmap'), `got ${routes.join(' ')}`);
+});


### PR DESCRIPTION
Size is a guess at intent, and a good one for UI text. It cannot know that a word is a headline whose weight is under a slider.

On the bitmap path a glyph origin rounds to a whole pixel — a cached bitmap can only land on one — and each advance is baked into the glyphset as an integer. Slide a variable font's `wght` and the true advances move by hundredths of a pixel. Those hundredths accumulate along the line until one glyph crosses a rounding boundary and jumps a **whole pixel by itself** while its neighbours stand still.

Same font, same size, only the pen origin sliding 0.1px at a time:

```
bitmap  centroid: 268.96 269.02 269.02 269.43 269.43 269.69 269.78 269.78 269.78 269.78 269.96
        -> 6 distinct positions in 11 samples
vector  centroid: 269.00 269.08 269.16 269.26 269.36 269.47 269.56 269.66 269.75 269.86 270.00
        -> 11 distinct positions in 11 samples
```

And per glyph, sweeping `wght` 400→410 on `I I I I I I I I` — note stem 8 jumping a pixel between 400 and 401, and stem 7 doing it at 410:

```
bitmap  wght 400:  28.70  63.70  98.70 133.70 168.70 203.70 238.70 272.70
        wght 410:  28.78  63.78  98.78 133.78 168.78 203.78 239.78 274.78
        distinct positions per stem across 11 steps: 3 3 3 3 3 3 4 5

vector  wght 400:  28.70  63.62  98.55 133.48 168.41 203.34 238.25 273.17
        wght 410:  28.78  63.87  98.96 134.05 169.14 204.23 239.32 274.41
        distinct positions per stem across 11 steps: 3 11 11 11 11 11 11 11
```

## The property

CSS's, with CSS's values:

| value | route | |
| --- | --- | --- |
| `auto` (default) | thresholds decide | today's behaviour, unchanged |
| `geometricPrecision` | always vector | exact origins, nothing cached |
| `optimizeSpeed` | always bitmap | cached glyphs at any size |
| `optimizeLegibility` | thresholds decide | accepted, means `auto` — ntk has no hinting to turn on |

```js
ctx.textRendering = 'geometricPrecision';
app.fonts.layout(spans, { family: 'Inter', size: 96, textRendering: 'geometricPrecision' });
```

**Per span.** One paragraph can hold a headline that wants exact positions and body text that wants its glyph cache — `drawGlyphRuns` already partitions a draw into the two paths, which is exactly what it does today when a paragraph crosses a size threshold. `textPolicy.textRendering` is the app-wide default for a window that is all display text; a run that names its own wins over it.

## Performance

`auto` is the overwhelmingly common answer and has to stay free. The check is one `??` and one comparison ahead of the existing early return, inlined rather than a call to `routeForRendering` because it is the first thing every run of every draw does.

Microbenchmark against master, one app and a resolved policy passed in, as the real draw path does — 10M calls:

```
case                              master     branch     delta
UI text 14px (early return)         0.82       2.15  +1.32 ns
static face 180px (ring band)      10.82      10.45  -0.38 ns
huge 400px (early return)           3.81       3.51  -0.30 ns
```

That is per **run**, not per glyph. End to end — 200 frames × 8 paragraphs at 14–21px, interleaved runs to share machine conditions:

```
run     master   branch
1       137.8    135.6
2       139.3    138.8
3       144.1    144.2
```

The branch is faster in one and identical in another; +1.3 ns/run works out to roughly 6 µs across the whole 137 ms benchmark, far below that benchmark's own spread. Opting *in* to `geometricPrecision` costs a rasterization per draw, which is the trade being asked for.

(The ring-band case also comes out marginally faster: since #230 the ring's entries stay numbers for a non-variable face, so only a variable instance pays for the composite key.)

## Tests

Six cases in `test/text-rendering.test.js`: the value mapping including the two that mean `auto`, `geometricPrecision` winning where the thresholds say bitmap, `optimizeSpeed` winning where they say vector, `auto` being byte-identical to no value at all, policy default plus run override, and the override beating the churn ring in both directions.

`npm test`: 823/823.
