### PR TITLE
fix(gl): do not cap the optional GPU addon at one minor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "node": ">=18.19.0"
       },
       "optionalDependencies": {
-        "x11-dri": "^0.2.0"
+        "x11-dri": ">=0.2.0 <1"
       }
     },
     "node_modules/@conventional-commits/parser": {
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/x11-dri": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.2.0.tgz",
-      "integrity": "sha512-GWN5YuFhKoSA8UBvnfN5de5a15pMyq4x8zpZl2HPxc5h5mrNBz18wz9522aMXp3im1p18/CYfTcx5mFsNr3B0w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.4.0.tgz",
+      "integrity": "sha512-DmNis7rUWuGm4l00DUAlCt+ld4pV2vqw2id+Q1EEIJz9gTFo1Dd1LzCUHrfq3LZxhY0crho0NFESMyylQG5g/w==",
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "x11-dri": "^0.2.0"
+    "x11-dri": ">=0.2.0 <1"
   },
   "scripts": {
     "test": "NTK_STRICT_COLORS=1 node --test",


### PR DESCRIPTION
`x11-dri: ^0.2.0` means `>=0.2.0 <0.3.0` for a 0.x package, so ntk pinned itself to the addon's first release. npm then **nests that copy under `node_modules/ntk/`** even when the consuming app asks for a newer one, so `require('x11-dri')` inside ntk keeps finding 0.2.0 — declaring a newer version downstream does not help.

That matters more than a normal version cap, because the GL surface a direct context exposes is the addon's table [passed straight through](https://github.com/sidorares/ntk/blob/master/lib/renderingcontext_gles.js). The cap silently strands every consumer on whatever entry points 0.2.0 happened to have: no textures, no blending, no framebuffer objects, no `uniformMatrix3fv`. Found while wiring react-x11's shader renderer, where it presents as "the material code cannot compile" with nothing pointing at a version range.

ntk itself only uses the stable core of that API — `probe`, `listRenderNodes`, `Gpu`, `Surface`, `FORMAT`, `GBM_USE` — and forwards the rest. So the range that matches how the two are actually coupled is "any 0.x from 0.2 on", which is what this declares.

Tests unchanged: 862 pass, and the live direct-rendering tests still pass against 0.4.0, whose 141 entry points now reach the context instead of 0.2.0's 44.