### PR TITLE
fix(gl): tell a runtime that cannot pass descriptors from a remote display

### DIFF
--- a/docs/context-gles.md
+++ b/docs/context-gles.md
@@ -126,7 +126,8 @@ not the message:
 | `GL_NO_ADDON` | `x11-dri` is not installed | `npm install x11-dri` |
 | `GL_NO_DRIVER` | no `libgbm`/`libEGL`/`libGLESv2`, or not Linux | install Mesa; direct rendering is Linux-only |
 | `GL_NO_DEVICE` | no readable `/dev/dri/renderD*` | map the device into the container, or join the `render` group |
-| `GL_REMOTE_DISPLAY` | the connection cannot pass a descriptor | direct rendering is local-only; use indirect over a network |
+| `GL_REMOTE_DISPLAY` | a TCP or forwarded display | direct rendering is local-only; use indirect over a network |
+| `GL_NO_FD_PASSING` | local display, but this runtime cannot pass a descriptor | run under Node — Bun does not implement the internal x11 uses |
 | `GL_NO_DRI3` | the server has no DRI3/Present | Xvfb, Xephyr and XQuartz have none |
 | `GL_IMPORT_FAILED` | the server refused the buffer | usually different DRM devices — set `devicePath` |
 | `GL_CONTEXT_FAILED` | GBM/EGL setup failed | the message says what did |
@@ -138,6 +139,21 @@ afterwards. Under the default policy it does not run at all, so an app that
 never asked pays nothing for it — but it also means that raising the policy
 *after* connecting needs one `await app.glCapabilities()` before a context can
 be created.
+
+### Runtimes
+
+Direct rendering needs a runtime that can send a file descriptor over a unix
+socket, because that is how DRI3 hands the server a buffer. `x11` does it
+through Node's internal `process.binding('pipe_wrap')`, so:
+
+| runtime | direct | indirect |
+| --- | --- | --- |
+| Node | yes | yes |
+| Bun | **no** — `process.binding('pipe_wrap')` is not implemented | yes |
+
+Under Bun the capability probe reports `GL_NO_FD_PASSING` and `'auto'` falls
+back to indirect GLX, which needs no descriptor passing at all. Nothing else
+about the display has to change.
 
 ## The API is not the GLX one
 

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -32,8 +32,11 @@ import { nodeRequire } from './builtin.js';
  * - `GL_NO_DRIVER` — the addon loaded but the GPU libraries it needs are
  *   missing (`libgbm`, `libEGL`, `libGLESv2`), or this is not Linux.
  * - `GL_NO_DEVICE` — no readable DRM render node (`/dev/dri/renderD*`).
- * - `GL_REMOTE_DISPLAY` — the connection cannot carry descriptors: a TCP or
- *   forwarded display, so there is no way to hand the server a buffer.
+ * - `GL_REMOTE_DISPLAY` — a TCP or forwarded display, so there is no local
+ *   socket to hand the server a buffer down.
+ * - `GL_NO_FD_PASSING` — the display is local, but this JavaScript runtime
+ *   cannot send a descriptor over the socket. Bun is the case in the field;
+ *   x11 does it through a Node internal Bun does not implement.
  * - `GL_NO_DRI3` — the server has no DRI3/Present (Xvfb, Xephyr, XQuartz).
  * - `GL_IMPORT_FAILED` — the server refused the buffer; usually client and
  *   server on different DRM devices.
@@ -45,6 +48,7 @@ export const GLError = {
   NO_DRIVER: 'GL_NO_DRIVER',
   NO_DEVICE: 'GL_NO_DEVICE',
   REMOTE_DISPLAY: 'GL_REMOTE_DISPLAY',
+  NO_FD_PASSING: 'GL_NO_FD_PASSING',
   NO_DRI3: 'GL_NO_DRI3',
   IMPORT_FAILED: 'GL_IMPORT_FAILED',
   CONTEXT_FAILED: 'GL_CONTEXT_FAILED'
@@ -235,6 +239,14 @@ export function canPassDescriptors(display) {
 
 const displayName = () => globalThis.process?.env?.DISPLAY || 'the X server';
 
+/** What is running this, for an error that is about the runtime. */
+const runtimeName = () => {
+  const versions = globalThis.process?.versions;
+  if (versions?.bun) return `Bun (${versions.bun})`;
+  if (versions?.deno) return `Deno (${versions.deno})`;
+  return versions?.node ? `Node (${versions.node})` : 'JavaScript runtime';
+};
+
 const requireExt = (X, name) =>
   new Promise((resolve) => X.require(name, (err, ext) => resolve(err ? null : ext)));
 
@@ -266,12 +278,27 @@ export function glCapabilities(app) {
     if (policy.mode === 'off') {
       return fail(GLError.DISABLED, "glPolicy is 'off', so no GL context will be created");
     }
-    if (!canPassDescriptors(app.display)) {
+    if (!app.display.isLocalSocket) {
       return fail(
         GLError.REMOTE_DISPLAY,
-        'this X connection is not a local socket that can pass descriptors, and DRI3 works by passing one',
+        'this X connection is not a local socket, and DRI3 works by passing a descriptor down one',
         'Direct rendering is local-only by construction. Over a network, indirect GLX is\n' +
           'the backend that can work at all — leave glPolicy at its default.'
+      );
+    }
+    if (!canPassDescriptors(app.display)) {
+      // The socket is local; what is missing is the ability to send a
+      // descriptor along it. x11 does that through Node's internal
+      // `process.binding('pipe_wrap')`, so a runtime that does not implement
+      // it lands here — Bun, today. Saying "not a local socket" would send
+      // the reader off to check their DISPLAY, which is fine.
+      return fail(
+        GLError.NO_FD_PASSING,
+        `this ${runtimeName()} cannot pass file descriptors over the X socket, and DRI3 works by passing one`,
+        'The connection is local; the runtime is what cannot carry the descriptor.\n' +
+          "x11 sends one through Node's process.binding('pipe_wrap'), which Bun does\n" +
+          'not implement. Run under Node for direct rendering, or leave glPolicy at its\n' +
+          'default and use indirect GLX, which needs no descriptor passing at all.'
       );
     }
 
@@ -291,9 +318,10 @@ export function glCapabilities(app) {
     }
     if (!DRI3.fdCapable) {
       return fail(
-        GLError.REMOTE_DISPLAY,
+        GLError.NO_FD_PASSING,
         'the x11 client cannot send descriptors on this connection (DRI3.fdCapable is false)',
-        'x11 builds an fd-capable socket for local displays unless `shm: false` was passed\nto createClient.'
+        'x11 builds an fd-capable socket for local displays unless `shm: false` was passed\n' +
+          'to createClient, and needs a runtime that can pass descriptors — see above.'
       );
     }
 

--- a/test/gl-policy.test.js
+++ b/test/gl-policy.test.js
@@ -219,6 +219,25 @@ describe('glCapabilities', () => {
     assert.equal(asked, false, 'a connection that cannot pass an fd needs no round trip');
   });
 
+  test('a local socket the runtime cannot pass an fd down is a different answer', async () => {
+    // Bun is the case in the field: the display is local and perfectly
+    // usable, and x11 reaches for a Node internal Bun does not implement.
+    // Reporting "not a local socket" would send the reader off to check
+    // DISPLAY, which is fine.
+    setDriAddon(workingAddon);
+    const caps = await glCapabilities(
+      fakeApp({ local: true, fdCapable: false, options: { glPolicy: 'auto' } })
+    );
+    assert.equal(caps.reason.code, GLError.NO_FD_PASSING);
+    assert.match(caps.reason.message, /file descriptors/);
+    assert.match(caps.reason.hint, /Bun/, 'and names the runtime that does this');
+    assert.doesNotMatch(
+      caps.reason.message,
+      /not a local socket/,
+      'without blaming the display, which is local'
+    );
+  });
+
   test('a server without DRI3 says so, and says which servers have it', async () => {
     setDriAddon(workingAddon);
     const caps = await glCapabilities(fakeApp({ exts: { present: {} }, options: { glPolicy: 'auto' } }));


### PR DESCRIPTION
Both cases landed on `GL_REMOTE_DISPLAY`, whose message says **"this X connection is not a local socket"**. Under Bun that is simply untrue — the display is local and perfectly usable, and what is missing is the ability to send a descriptor down the socket. `x11` does that through Node's internal `process.binding('pipe_wrap')`, which Bun answers with:

```
process.binding("pipe_wrap") is not implemented in Bun.
```

So the reader was sent off to check their `DISPLAY`, which was fine all along.

Measured on the same box, same server:

| | node 22 | bun 1.3 |
| --- | --- | --- |
| `display.isLocalSocket` | true | true |
| `stream._fdCapable` | **true** | **false** |
| `stream.sendFds` | function | undefined |

## What changes

`GL_REMOTE_DISPLAY` keeps its meaning — a TCP or forwarded display, checked as `isLocalSocket` alone. `GL_NO_FD_PASSING` is new: the display is local, the *runtime* is what cannot carry the descriptor, and the hint names the runtime it actually found and says to run under Node. The later `DRI3.fdCapable` check is the same condition observed one round trip on, so it reports the same code.

```
GL_NO_FD_PASSING: this Bun (1.3.14) cannot pass file descriptors over the X
socket, and DRI3 works by passing one

  The connection is local; the runtime is what cannot carry the descriptor.
  x11 sends one through Node's process.binding('pipe_wrap'), which Bun does
  not implement. Run under Node for direct rendering, or leave glPolicy at its
  default and use indirect GLX, which needs no descriptor passing at all.
```

Under Bun, `glPolicy: 'auto'` still does the right thing — it falls back to indirect GLX, which needs no descriptor passing at all. Only `'direct'` fails, which is what asking for it strictly means.

`docs/context-gles.md` gains a short **Runtimes** section with the same table, since "which runtimes can do this" is not something a reader can infer from anywhere else.

Found through react-x11, where the symptom was a `<shaderMaterial>` refusing to render under `bun` with an explanation about network transparency. 863 tests pass, including a new one asserting the two cases stay distinct.