### PR TITLE
feat(input): select and route XI2 device events, so a wheel reports a real delta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,9 @@ lib/events_map.js          X event code <-> browser-ish event name tables
                            (incl. FocusIn/FocusOut as 'focus'/'blur')
 lib/keyboard.js            key event -> keysym/codepoint: XKB group from the
                            event state, CapsLock only on cased keys
+lib/xi2.js                 XI2 device events: which types can be selected,
+                           absolute scroll valuators -> wheel deltas (per
+                           device, seeded), XI2 event -> core-shaped ntk event
 lib/clipboard.js           app.clipboard: ICCCM selection/clipboard transfer
                            (CLIPBOARD/PRIMARY, required targets, INCR both
                            ways, multi-format ownership, acquire/release

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ matching file here (see AGENTS.md).
 - [Getting started](getting-started.md) — installation, requirements, first window
 - [App](app.md) — connecting to the X server, the `App` factory object
 - [Window](window.md) — window creation, properties, methods, events,
-  keyboard input, frame pacing / event coalescing, `requestAnimationFrame`
+  keyboard input, smooth scrolling (XI2), frame pacing / event coalescing,
+  `requestAnimationFrame`
 - [Pixmap](pixmap.md) — offscreen drawables
 - [Clipboard](clipboard.md) — `app.clipboard.write()/read()/clear()`:
   transfer over the CLIPBOARD/PRIMARY selections (ICCCM), multi-format

--- a/docs/app.md
+++ b/docs/app.md
@@ -90,6 +90,18 @@ paced slower can never reach the rate its display offers.
   by querying the server; `config.visual`/`config.depth` feed `createWindow`
   and the whole object feeds `getContext('opengl', config)`. See
   [context-opengl.md](context-opengl.md)
+- `app.inputDevices({ refresh }) → Promise<device[]>` — every input device
+  the server knows about, from XInput 2's `XIQueryDevice`:
+  `{deviceId, use, attachment, enabled, name, classes}`, where `classes`
+  describes each device's keys, buttons, valuators and scroll axes. `[]`
+  where the server has no XI2. Cached — this is what a window with
+  [smooth scrolling](window.md#wheel-and-smooth-scrolling) consults to find
+  the axis behind a wheel delta, and it must not cost a round trip per
+  event; pass `{ refresh: true }` to re-read it
+- `app.xinput() → Promise<ext|null>` — the raw node-x11 XInput extension
+  object, or `null` where there is none. `ext.xi2` is `null` on a server
+  that speaks XI1 only. The escape hatch for the XI2 requests ntk does not
+  wrap (grabs, device properties, barriers)
 - `app.close() → Promise` — flush pending requests, then close the connection
 
 ## Resource management

--- a/docs/window.md
+++ b/docs/window.md
@@ -71,6 +71,10 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 - `syncRequest: true` — let the window manager pace interactive resizes to
   this window's repaint rate (see
   [Resize synchronization](#resize-synchronization--syncrequest--enablesyncrequest))
+- `xi2: true`, or a list of XI2 event type names — take this window's input
+  from XInput 2 instead of the core protocol: fractional scroll deltas
+  instead of wheel notches, per-device ids, touch (see
+  [Wheel and smooth scrolling](#wheel-and-smooth-scrolling))
 
 ## Transparent windows
 
@@ -343,6 +347,11 @@ While a frame is pending, noisy events **coalesce** instead of queueing:
   see [`resize` fires for moves](#resize-fires-for-moves).
 - `expose` — damage accumulates: `ev.x/y/width/height` is the bounding box
   of all merged rectangles and `ev.rects` lists each one.
+- `wheel` — scroll distance accumulates: `ev.deltaX`/`ev.deltaY` is the sum
+  of the frame's deltas, reported where the pointer ended up. Keeping the
+  last one instead would throw away everything but the final step of a fast
+  scroll, and a frame's worth of a touchpad's sub-notch deltas is exactly
+  what [smooth scrolling](#wheel-and-smooth-scrolling) exists to deliver.
 
 Discrete events (`mousedown`, `keydown`, …) are never coalesced and are
 delivered immediately — any buffered noisy events are flushed first so
@@ -508,6 +517,10 @@ All return `this` unless noted.
   their events normally, so a submenu keeps working
 - `grabKeyboard(options, cb)` / `ungrabKeyboard(time)` — the same for keys
 - `queryPointer(cb)`, `setMouseHintOnly(isOn)`
+- `selectXI2(types, options)` — take this window's input from XInput 2:
+  smooth scrolling, per-device ids, touch. Returns a promise for whether the
+  server has XI2, not `this` — see
+  [Wheel and smooth scrolling](#wheel-and-smooth-scrolling)
 - `queryTree(cb)` — `cb(err, { parent, root, children })`, all as `Window`s
 - `reparentTo(newParent, x, y)`, `raise()`, `lower()`
 - `setHints(hints)`, `setSizeHints(hints)`, `setWmHints(hints)`,
@@ -1107,6 +1120,8 @@ constructor arg) automatically extends the window's X event mask.
 |---|---|---|
 | `mousedown` / `mouseup` | ButtonPress/Release | `ev.x`, `ev.y`, `ev.keycode` (button) |
 | `mousemove` | MotionNotify | coalesced per frame; full trail in `ev.coalesced` |
+| `wheel` | ButtonPress 4-7, or an XI2 scroll valuator | derived: `ev.deltaX`/`ev.deltaY` in notches, positive down and right. Coalesced per frame, and a frame's deltas **add up**. See [Wheel and smooth scrolling](#wheel-and-smooth-scrolling) |
+| `touchstart` / `touchmove` / `touchend` | XI2 TouchBegin/Update/End | only with `selectXI2(['TouchBegin', …])`; `ev.touchId` identifies the finger |
 | `mouseover` / `mouseout` | Enter/LeaveNotify | |
 | `keydown` / `keyup` | KeyPress/Release | `keydown` carries `ev.codepoint` (unicode) — see [Keyboard input](#keyboard-input) |
 | `focus` / `blur` | FocusIn/FocusOut | keyboard focus arrived at or left this window — usually because the window manager moved it. `ev.detail`/`ev.mode` carry the X notify detail and mode |
@@ -1158,6 +1173,90 @@ the first event after the switch — spurious work, never missed work. The
 alternative is a `TranslateCoordinates` round trip per event, which is the
 cost these flags exist to avoid; ask for one explicitly if you need the true
 screen origin.
+
+## Wheel and smooth scrolling
+
+`wheel` reports scrolling in the units the device measures it in:
+
+```js
+wnd.on('wheel', (ev) => {
+  scrollBy(ev.deltaX * lineHeight, ev.deltaY * lineHeight);
+});
+```
+
+| | |
+|---|---|
+| `ev.deltaX` / `ev.deltaY` | distance, positive **down** and **right** (the direction the DOM calls positive) |
+| `ev.deltaMode` | `'line'` — the unit is one notch of the wheel, whatever pixels that is worth in your content |
+| `ev.smooth` | `true` when the delta came from a device that measures fractions of a notch, `false` when it is one whole notch of a wheel |
+| `ev.source` | `'valuator'` (XI2 scroll axis) or `'button'` (core button 4-7) |
+| `ev.deviceId` / `ev.sourceId` | XI2 only: the master device, and the physical one behind it |
+
+plus the pointer fields (`x`, `y`, `rootx`, `rooty`, `buttons`, `time`) of
+the event it came from.
+
+Deltas are in **notches, not pixels**: a notch is the only unit the device
+itself agrees on — X calls it the axis' `increment` — and how many pixels one
+scrolls is your content's line height, not something a toolkit can know.
+`smooth` is what tells the two granularities apart, which is what a consumer
+deciding whether to animate a scroll actually wants to know.
+
+Without XI2 that is all there is: the core protocol reports a wheel as a
+click of button 4 (up), 5 (down), 6 (left) or 7 (right), so `wheel` fires
+once per notch with `deltaY: ±1` and the matching `mousedown` fires too.
+A touchpad's two-finger scroll arrives the same way — the server counts the
+gesture into whole notches and throws the rest away.
+
+### Smooth scrolling — `selectXI2()` / `xi2: true`
+
+XI2 carries the same gesture as a *scroll valuator*, and ntk turns it into
+fractional deltas:
+
+```js
+const wnd = app.createWindow({ width: 400, height: 300, xi2: true });
+// or later, when you want to know whether the server has XI2:
+const smooth = await wnd.selectXI2();
+```
+
+`selectXI2(types = ['Motion', 'ButtonPress', 'ButtonRelease'], { deviceId })`
+resolves to `true` once XI2 events are selected, and `false` on a server
+without XI2 — where nothing changed and the window keeps its core events,
+`wheel` included, at notch granularity. `selectXI2([])` deselects. The
+selection is per device (`deviceId` defaults to every master device — the
+virtual pointer and keyboard the user is actually driving), and each call
+*replaces* this window's selection for that device rather than adding to it.
+
+Selectable types: `Motion`, `ButtonPress`, `ButtonRelease`, `KeyPress`,
+`KeyRelease`, `TouchBegin`, `TouchUpdate`, `TouchEnd` — the ones node-x11
+decodes into fields. Anything else throws, naming these.
+
+Three consequences worth knowing before opting in:
+
+- **XI2 replaces the core events of the types you select.** The server
+  delivers an event to a client once, and an XI2 selection wins, so a window
+  that selects `Motion` builds its `mousemove` from `XIMotion` from then on.
+  Handlers do not change: a translated event carries the same fields a core
+  one does (`x`, `y`, `keycode`, `buttons` with the modifier and group bits
+  in their core positions), plus `ev.xi2 === true`, `ev.deviceId`,
+  `ev.sourceId`, the raw `ev.valuators`, and `ev.preciseX`/`ev.preciseY` —
+  the sub-pixel coordinates XI2 has and core X does not (`ev.x`/`ev.y` stay
+  integers). Types you did not select stay on the core path, which is why
+  `mouseover`/`mouseout` and `focus`/`blur` keep working.
+- **The emulated wheel clicks disappear.** For a smooth scroll the server
+  sends both halves — the valuator *and* a button 4-7 click flagged
+  `PointerEmulated`, for clients that cannot read valuators — and delivering
+  both would count every notch twice. So a window that has opted in reads
+  `wheel`, not `mousedown` on button 4. A wheel with no smooth-scroll axis
+  behind it is not emulating anything, and still arrives as both.
+- **It is opt-in per window** because selecting it changes what the server
+  sends; a window that has not asked costs exactly what it did before.
+
+Scroll valuators are absolute accumulators — the delta is the change since
+the last event — so the first event from a device seeds and reports no
+distance, and `XIDeviceChanged` (the user moving from the touchpad to the
+mouse, which renumbers the master's axes) drops the accumulators and reseeds.
+Both are handled here rather than by every consumer: getting either wrong is
+a jump of hundreds of notches on the first scroll.
 
 ## Keyboard input
 

--- a/examples/smooth-scroll.js
+++ b/examples/smooth-scroll.js
@@ -1,0 +1,80 @@
+// Smooth scrolling: the same list scrolled by core wheel notches and by XI2
+// scroll valuators, side by side, so the difference is visible rather than
+// described. The left half stays on the core protocol, the right half has
+// XI2 selected — scroll over each with a touchpad and the right one moves in
+// fractions of a notch while the left one jumps a whole line at a time.
+//
+// The readout under each column is the last delta it was handed.
+import { createClient } from '../lib/index.js';
+
+const LINE = 22;
+const ROWS = 60;
+
+const app = await createClient();
+const wnd = app.createWindow({ title: 'smooth-scroll', width: 620, height: 420 });
+const ctx = wnd.getContext('2d');
+
+// two child windows, so each column has its own event selection: XI2 is
+// per window, and the point here is to have both at once
+const left = wnd.createWindow({ x: 0, y: 0, width: 310, height: 420 });
+const right = wnd.createWindow({ x: 310, y: 0, width: 310, height: 420, xi2: true });
+
+const smooth = await right.selectXI2();
+if (!smooth) {
+  console.warn('this server has no XI2 — both columns will scroll in whole notches');
+}
+
+const columns = [
+  { wnd: left, ctx: left.getContext('2d'), title: 'core (button 4/5)', offset: 0, last: null },
+  { wnd: right, ctx: right.getContext('2d'), title: 'XI2 (scroll valuators)', offset: 0, last: null }
+];
+
+function draw(column) {
+  const { ctx: c, wnd: w } = column;
+  c.fillStyle = '#ffffff';
+  c.fillRect(0, 0, w.width, w.height);
+
+  const first = Math.floor(column.offset / LINE);
+  const shift = column.offset - first * LINE;
+  c.font = '13px sans-serif';
+  for (let i = 0; i < Math.ceil(w.height / LINE) + 1; i++) {
+    const row = ((first + i) % ROWS + ROWS) % ROWS;
+    const y = i * LINE - shift;
+    c.fillStyle = row % 2 ? '#f4f4f8' : '#ffffff';
+    c.fillRect(0, y, w.width, LINE);
+    c.fillStyle = '#303040';
+    c.fillText(`row ${String(row).padStart(2, '0')} — the quick brown fox`, 12, y + 15);
+  }
+
+  // header and readout
+  c.fillStyle = '#202030';
+  c.fillRect(0, 0, w.width, 26);
+  c.fillRect(0, w.height - 26, w.width, 26);
+  c.fillStyle = '#ffffff';
+  c.fillText(column.title, 10, 18);
+  const d = column.last;
+  c.fillText(
+    d
+      ? `Δy ${d.deltaY.toFixed(3)}  ${d.smooth ? 'smooth' : 'notch'}  (${d.source})`
+      : 'scroll over me',
+    10,
+    w.height - 8
+  );
+}
+
+for (const column of columns) {
+  column.wnd.on('wheel', (ev) => {
+    column.last = ev;
+    // notches to pixels is the consumer's decision: one notch is one line here
+    column.offset += ev.deltaY * LINE;
+    draw(column);
+  });
+  column.wnd.on('expose', () => draw(column));
+  column.wnd.map();
+}
+
+wnd.on('expose', () => {
+  ctx.fillStyle = '#202030';
+  ctx.fillRect(0, 0, wnd.width, wnd.height);
+});
+wnd.map();

--- a/lib/app.js
+++ b/lib/app.js
@@ -93,6 +93,8 @@ export default class App {
     this._solidPictures = new Map();
     this._rasterizer = undefined;
     this._shm = undefined;
+    this._xinputPromise = null;
+    this._devicesPromise = null;
     // node-x11 emits X errors it cannot route to a request callback as
     // 'error' on the client — from inside its packet parser. With no
     // listener that emit throws and the parser never re-arms, silently
@@ -297,6 +299,53 @@ export default class App {
       this._glCapsResolved = caps;
       return caps;
     });
+  }
+
+  /**
+   * The XInput extension, or `null` where the server has none — asked once
+   * per connection.
+   *
+   * `ext.xi2` is `null` on a server that answers the extension query but
+   * speaks XI1 only, and every XI2 request needs it, so callers check both.
+   *
+   * @returns {Promise<object|null>}
+   */
+  xinput() {
+    if (!this._xinputPromise) {
+      this._xinputPromise = new Promise((resolve) => {
+        this.X.require('xinput', (err, ext) => resolve(err ? null : ext));
+      });
+    }
+    return this._xinputPromise;
+  }
+
+  /**
+   * Every input device the server knows about, from XI2's `XIQueryDevice`:
+   * `{deviceId, use, attachment, enabled, name, classes}`, the classes
+   * describing each device's keys, buttons, valuators and scroll axes (see
+   * node-x11's docs/ext/xinput.md). `[]` where there is no XI2.
+   *
+   * Cached, because it is what `Window.selectXI2` consults to find the
+   * scroll axes behind a wheel delta and it must not cost a round trip per
+   * event. The cache is dropped whenever a window with XI2 selected sees an
+   * `XIDeviceChanged` — a master pointer's axes are those of whichever slave
+   * moved last, so they change under it when the user picks up the mouse
+   * after using the touchpad.
+   *
+   * @param {{refresh?: boolean}} [options]
+   * @returns {Promise<object[]>}
+   */
+  inputDevices({ refresh = false } = {}) {
+    if (refresh) this._devicesPromise = null;
+    if (!this._devicesPromise) {
+      this._devicesPromise = this.xinput().then((XI) => {
+        if (!XI || !XI.xi2) return [];
+        return new Promise((resolve) => {
+          XI.XIQueryDevice(XI.AllDevices, (err, devices) => resolve(err ? [] : devices));
+        });
+      });
+    }
+    return this._devicesPromise;
   }
 
   /** selection/clipboard transfer: write()/read() text (docs/clipboard.md) */

--- a/lib/events_map.js
+++ b/lib/events_map.js
@@ -67,6 +67,10 @@ export const mask = {
   // not an X event of its own: Window derives it from the PropertyNotify for
   // _NET_WM_STATE, so it needs the same mask a 'property' listener does
   statechange: x11.eventMask.PropertyChange,
+  // also derived: a wheel is a click of button 4-7 in the core protocol, and
+  // a scroll valuator under XI2 (see lib/xi2.js). ButtonPress covers the core
+  // half; the XI2 half is opt-in per window and selects itself
+  wheel: x11.eventMask.ButtonPress,
   selection: 0,
   selection_request: 0,
   message: 0
@@ -81,7 +85,12 @@ export const mask = {
 export const coalesce = {
   mousemove: 'last',
   resize: 'last',
-  expose: 'union'
+  expose: 'union',
+  // 'accumulate' — scroll distance adds up. Keeping the last delta instead
+  // would throw away everything but the final step of a fast scroll, and a
+  // frame's worth of a touchpad's sub-notch deltas is exactly the case the
+  // smooth-scroll path exists for.
+  wheel: 'accumulate'
 };
 
 export const toSnake = {
@@ -90,6 +99,7 @@ export const toSnake = {
   onMouseOut: 'mouseout',
   onMouseDown: 'mousedown',
   onMouseUp: 'mouseup',
+  onWheel: 'wheel',
   onMap: 'map',
   onUnmap: 'unmap',
   onResize: 'resize',

--- a/lib/window.js
+++ b/lib/window.js
@@ -7,6 +7,17 @@ import { packIcons, unpackIcons } from './imagedata.js';
 import Pixmap from './pixmap.js';
 import * as xevents from './events_map.js';
 import { decodeKey } from './keyboard.js';
+import {
+  DEFAULT_XI2_EVENTS,
+  POINTER_EMULATED,
+  ScrollTracker,
+  WHEEL_BUTTONS,
+  normalizeXI2Types,
+  scrollAxes,
+  toNtkEvent,
+  wheelEvent,
+  xi2EventName
+} from './xi2.js';
 
 /**
  * How many rectangles a frame's dirty region is allowed to hold.
@@ -435,10 +446,16 @@ export default class Window extends Drawable {
     this._updateRegion = 0;
     this._presentSerial = 0;
     this._presentEid = 0;
+    // Generic Events (type 35) carry an extension opcode where a core event
+    // carries its code, so they are routed by opcode: Present's completions,
+    // XI2's device events, and whatever else selects them later.
+    this._geHandlers = new Map();
     // A direct GL context's swap chain, when one is presenting on this window
-    // (see _setGenericEventSink)
+    // — an override ahead of that table (see _setGenericEventSink)
     this._geSink = null;
     this._geSinkOpcode = 0;
+    // XI2 state, once a window has selected it (see selectXI2)
+    this._xi2 = null;
     // The vblank clock (see _onPresentComplete): the period learnt from
     // completion events, the samples it is drawn from, and the latch the
     // watchdog sets when completions stop arriving.
@@ -591,6 +608,14 @@ export default class Window extends Drawable {
     if (args.alwaysOnTop) {
       this.setAlwaysOnTop(true);
     }
+    if (args.xi2) {
+      // fire and forget: until the extension answers, the window is on core
+      // events, which is where it would have been anyway. `await
+      // wnd.selectXI2()` is the form that says whether the server has XI2.
+      this.selectXI2(args.xi2 === true ? undefined : args.xi2).catch((err) =>
+        this.app.options.onXError?.(err)
+      );
+    }
     if (args.syncRequest && !args.id) {
       // fire and forget: the window manager only reads the counter when it
       // starts managing the window, and map() is the caller's next line at
@@ -612,19 +637,20 @@ export default class Window extends Drawable {
 
     X.event_consumers[this.id] = this;
     this.on('event', (ev) => {
-      // Present speaks in X Generic Events, which carry an extension opcode
-      // and a sub-type where a core event carries its code — the name table
-      // below cannot see them, and they are not events user code asked for
+      // Present and XI2 speak in X Generic Events, which carry an extension
+      // opcode and a sub-type where a core event carries its code — the name
+      // table below cannot see them, so they are routed by opcode instead
       if (ev.type === 35) {
         // A direct GL context presenting on this window selected these events
         // itself and owns the pixmaps they name, so they are its to read — and
         // it is the only user of Present there, a GL window having no backing
-        // store to blit.
+        // store to blit. Hence an override rather than another table entry:
+        // it claims the same extension the window's own blit path uses.
         if (this._geSink && ev.extension === this._geSinkOpcode) {
           this._geSink.handleEvent(ev);
-        } else if (this._presentExt && ev.extension === this._presentExt.majorOpcode) {
-          this._handlePresentEvent(ev);
+          return;
         }
+        this._geHandlers.get(ev.extension)?.(ev);
         return;
       }
       const ntkev = ev; // todo: clone
@@ -658,9 +684,12 @@ export default class Window extends Drawable {
           if (key.codepoint !== undefined) ev.codepoint = key.codepoint;
         }
       }
-      if (this._coalesce && xevents.coalesce[eventName]) {
-        this._enqueueCoalesced(eventName, ntkev);
-        return;
+      // a wheel is a button in the core protocol; say so in the units a
+      // consumer wants. Suppressed once XI2 is delivering the same scroll as
+      // valuators, which is the whole reason to select it (see selectXI2).
+      if (eventName === 'mousedown' && WHEEL_BUTTONS[ev.keycode] && !this._xi2?.smooth) {
+        const [deltaX, deltaY] = WHEEL_BUTTONS[ev.keycode];
+        this._deliverEvent('wheel', wheelEvent({ ...ntkev }, deltaX, deltaY, 'button'));
       }
       // the window manager reporting what it did with the window: a user who
       // hit maximize or a fullscreen hotkey changes the state behind the
@@ -672,19 +701,7 @@ export default class Window extends Drawable {
           () => {}
         );
       }
-      // deliver buffered state events before a discrete one so handlers see
-      // them in the order they happened (a drag sees the move, then the up)
-      this._flushCoalesced();
-      if (eventName === 'resize') this._tagResize(ntkev);
-      this.emit(eventName, ntkev);
-      // a WM_DELETE_WINDOW ClientMessage is the window manager *asking*, and
-      // 'close' is that question in a form an application can answer
-      if (eventName === 'message') {
-        this._emitCloseRequest(ntkev);
-        this._handleSyncRequest(ntkev);
-      }
-      // anything drawn during the handlers becomes visible in one blit
-      if (this._dirty) this._present();
+      this._deliverEvent(eventName, ntkev);
     });
 
     // Events about a *child* of this window: the substructure requests a
@@ -1168,6 +1185,32 @@ export default class Window extends Drawable {
     this._armTimer();
   }
 
+  /**
+   * Deliver one named event: buffer it if its kind coalesces, and otherwise
+   * flush what is buffered before emitting, so handlers see events in the
+   * order they happened (a drag sees the move, then the up).
+   *
+   * Every source ends here — the core event stream, the XI2 one, and the
+   * `wheel` both of them derive.
+   */
+  _deliverEvent(name, ev) {
+    if (this._coalesce && xevents.coalesce[name]) {
+      this._enqueueCoalesced(name, ev);
+      return;
+    }
+    this._flushCoalesced();
+    if (name === 'resize') this._tagResize(ev);
+    this.emit(name, ev);
+    // a WM_DELETE_WINDOW ClientMessage is the window manager *asking*, and
+    // 'close' is that question in a form an application can answer
+    if (name === 'message') {
+      this._emitCloseRequest(ev);
+      this._handleSyncRequest(ev);
+    }
+    // anything drawn during the handlers becomes visible in one blit
+    if (this._dirty) this._present();
+  }
+
   _enqueueCoalesced(name, ev) {
     const pending = this._frame.pending;
     const prev = pending.get(name);
@@ -1177,6 +1220,21 @@ export default class Window extends Drawable {
         ev.rects = [{ x: ev.x, y: ev.y, width: ev.width, height: ev.height }];
       }
       pending.set(name, ev);
+    } else if (xevents.coalesce[name] === 'accumulate') {
+      // scroll distance adds up, and the frame's scroll happened wherever the
+      // pointer ended up. The first event of the frame carries the sum, the
+      // way the union path grows its first event's rectangle.
+      prev.coalesced.push(ev);
+      prev.deltaX += ev.deltaX;
+      prev.deltaY += ev.deltaY;
+      prev.x = ev.x;
+      prev.y = ev.y;
+      prev.rootx = ev.rootx;
+      prev.rooty = ev.rooty;
+      prev.time = ev.time;
+      prev.buttons = ev.buttons;
+      prev.smooth = ev.smooth;
+      prev.source = ev.source;
     } else if (xevents.coalesce[name] === 'union') {
       prev.coalesced.push(ev);
       prev.rects.push({ x: ev.x, y: ev.y, width: ev.width, height: ev.height });
@@ -1282,6 +1340,163 @@ export default class Window extends Drawable {
   _setGenericEventSink(majorOpcode, sink) {
     this._geSink = sink;
     this._geSinkOpcode = sink ? majorOpcode : 0;
+  }
+
+  /**
+   * Ask for XI2 device events on this window, and deliver them as the events
+   * ntk already has names for.
+   *
+   * What this buys is the wheel: the core protocol reports a scroll as a
+   * click of button 4/5/6/7, so a touchpad's two-finger gesture arrives as
+   * whole notches however finely the hardware measured it. XI2 carries the
+   * same gesture as a scroll *valuator*, and `wheel` then reports fractions
+   * of a notch (see docs/window.md "Wheel and smooth scrolling"). Touch and
+   * per-device input come with it — `ev.deviceId`/`ev.sourceId` are on every
+   * translated event, and the core protocol has no way to say either.
+   *
+   * Opt-in per window, via `createWindow({ xi2: true })` or this call,
+   * because selecting XI2 changes what the server sends: a window that has
+   * not asked keeps costing exactly what it did before.
+   *
+   * **Selecting XI2 replaces the core events of the same types.** The server
+   * delivers an event to a client once, and an XI2 selection wins, so
+   * `selectXI2(['Motion'])` means this window's `mousemove` is built from
+   * `XIMotion` from then on. It carries the same fields (plus `ev.xi2`,
+   * the device ids and sub-pixel `preciseX`/`preciseY`), so handlers do not
+   * change — but a window that selects XI2 KeyPress and nothing else still
+   * gets core motion, and mixing the two per-type is what the `types`
+   * argument is for.
+   *
+   * The emulated wheel buttons are dropped once the valuators are flowing:
+   * the server sends both halves of a smooth scroll (the axis and a button
+   * 4-7 click flagged `PointerEmulated`) so that clients which cannot read
+   * valuators still scroll, and delivering both would count every notch
+   * twice. So an app that opts in reads `wheel`, not `mousedown` on button 4.
+   *
+   * @param {string[]|string} [types] XI2 event type names —
+   *   `Motion`, `ButtonPress`, `ButtonRelease`, `KeyPress`, `KeyRelease`,
+   *   `TouchBegin`, `TouchUpdate`, `TouchEnd`. An empty array deselects.
+   * @param {{deviceId?: number}} [options] which device to select for,
+   *   defaulting to every master device (the virtual pointer and keyboard
+   *   the user is actually driving). A selection is per device, so a
+   *   selection on one device id does not replace one made on another.
+   * @returns {Promise<boolean>} false where the server has no XI2 — in which
+   *   case nothing changed and the window keeps its core events, `wheel`
+   *   included, at notch granularity
+   */
+  selectXI2(types = DEFAULT_XI2_EVENTS, { deviceId } = {}) {
+    const names = normalizeXI2Types(types);
+    return Promise.all([this.app.xinput(), this.app.inputDevices()]).then(([XI, devices]) => {
+      if (!XI || !XI.xi2 || this._destroyed) return false;
+      const target = deviceId ?? XI.AllMasterDevices;
+      if (!names.length) {
+        safeRelease(this.X, () => XI.XISelectEvents(this.id, { deviceId: target, mask: 0 }));
+        this._geHandlers.delete(XI.majorOpcode);
+        this._xi2 = null;
+        return true;
+      }
+      // DeviceChanged rides along uninvited: it is the only announcement that
+      // a master pointer's valuators are now some other slave's, which
+      // invalidates both the axis map and the accumulators built on it. Its
+      // body is undecoded, and the device id is all this needs from it.
+      safeRelease(this.X, () =>
+        XI.XISelectEvents(this.id, { deviceId: target, mask: [...names, 'DeviceChanged'] })
+      );
+      this._xi2 = {
+        ext: XI,
+        deviceId: target,
+        types: names,
+        // evtype -> the ntk event it becomes, resolved through the extension's
+        // own table rather than hardcoded numbers
+        byType: new Map(names.map((name) => [XI.EventType[name], xi2EventName[name]])),
+        scroll: this._xi2?.scroll ?? new ScrollTracker(),
+        axes: new Map(devices.map((device) => [device.deviceId, scrollAxes(device)])),
+        // whether the core wheel buttons are now redundant: a scroll-capable
+        // device plus a selection that carries its valuators
+        smooth: names.includes('Motion') && devices.some((device) => scrollAxes(device).size > 0)
+      };
+      this._geHandlers.set(XI.majorOpcode, (ev) => this._handleXI2Event(ev));
+      return true;
+    });
+  }
+
+  /**
+   * One XI2 Generic Event: scroll valuators become `wheel`, everything else
+   * becomes the core-shaped event it stands in for.
+   */
+  _handleXI2Event(ev) {
+    const xi2 = this._xi2;
+    if (!xi2) return;
+    if (ev.evtype === xi2.ext.EventType.DeviceChanged) {
+      this._refreshXI2Devices(ev.deviceId);
+      return;
+    }
+    const name = xi2.byType.get(ev.evtype);
+    if (!name) return;
+
+    const base = toNtkEvent(name, ev);
+    base.window = this;
+    base.target = this;
+
+    if (name === 'mousemove') {
+      // a scroll is a Motion carrying scroll axes; the pointer itself did not
+      // move, so it is a wheel event and not also a mouse move — including
+      // the first one, which has nothing to subtract from yet
+      const scroll = xi2.scroll.delta(ev, this._xi2Axes(ev));
+      if (scroll) {
+        if (scroll.moved) {
+          this._deliverEvent('wheel', wheelEvent(base, scroll.deltaX, scroll.deltaY, 'valuator'));
+        }
+        return;
+      }
+    }
+    if (name === 'mousedown' || name === 'mouseup') {
+      const wheelButton = WHEEL_BUTTONS[ev.detail];
+      // the click the server emulated for clients that cannot read valuators
+      // — we can, and the valuator half of the same scroll is already on its
+      // way, so this one is noise
+      if (wheelButton && ev.flags & POINTER_EMULATED) return;
+      if (wheelButton && name === 'mousedown') {
+        const wheel = wheelEvent({ ...base }, wheelButton[0], wheelButton[1], 'button');
+        this._deliverEvent('wheel', wheel);
+      }
+    }
+    if (name === 'keydown' || name === 'keyup') {
+      const key = decodeKey(this.X.keycode2keysyms[ev.detail], base.buttons);
+      if (key) {
+        base.keysym = key.keysym;
+        base.baseKeysym = key.baseKeysym;
+        base.group = key.group;
+        if (key.codepoint !== undefined) base.codepoint = key.codepoint;
+      }
+    }
+    this._deliverEvent(name, base);
+  }
+
+  /** This window's scroll-axis map for the device an event came from. */
+  _xi2Axes(ev) {
+    return this._xi2?.axes.get(ev.deviceId);
+  }
+
+  /**
+   * A master device's slave changed: re-read what its axes are now, and drop
+   * the accumulators, because the values arriving next belong to a different
+   * device and subtracting across the switch is the jump seeding exists to
+   * avoid.
+   */
+  _refreshXI2Devices(deviceId) {
+    const xi2 = this._xi2;
+    if (!xi2) return;
+    xi2.scroll.reset(deviceId);
+    this.app.inputDevices({ refresh: true }).then(
+      (devices) => {
+        if (this._xi2 !== xi2) return; // deselected or reselected meanwhile
+        xi2.axes = new Map(devices.map((device) => [device.deviceId, scrollAxes(device)]));
+        xi2.smooth =
+          xi2.types.includes('Motion') && devices.some((device) => scrollAxes(device).size > 0);
+      },
+      () => {}
+    );
   }
 
   /**
@@ -1702,6 +1917,7 @@ export default class Window extends Drawable {
       safeRelease(X, () => fixes.CreateRegion(this._updateRegion, []));
       this._presentExt = present;
       this._fixesExt = fixes;
+      this._geHandlers.set(present.majorOpcode, (ev) => this._handlePresentEvent(ev));
       this._selectPresentInput();
       return this;
     });

--- a/lib/xi2.js
+++ b/lib/xi2.js
@@ -1,0 +1,290 @@
+/**
+ * XI2 (X Input Extension 2) device events: what to select, how to turn one
+ * into an ntk event, and the per-device bookkeeping a scroll delta needs.
+ *
+ * The core protocol flattens every input device onto one virtual pointer and
+ * one virtual keyboard, and reports a wheel as a click of button 4/5/6/7. A
+ * touchpad's two-finger scroll therefore reaches a core client as a series of
+ * whole notches, which is why nothing built on core X can scroll smoothly.
+ * XI2 carries the same gesture as a *valuator*: an absolute accumulator per
+ * scroll axis, whose difference between two events is the distance scrolled,
+ * in units of the axis' `increment` (one notch).
+ *
+ * Three facts shape everything here:
+ *
+ * 1. **Valuators are absolute.** A delta is `(now - before) / increment`, so
+ *    the first event from a device has nothing to subtract from and must seed
+ *    rather than report — otherwise the first scroll of a session jumps by
+ *    however far the axis had travelled before the window existed.
+ * 2. **A device's axes are described once, not per event.** Which valuator is
+ *    the vertical scroll axis, and what one notch of it is worth, comes from
+ *    `XIQueryDevice`'s `Scroll` classes. They change under a master device
+ *    when the user switches from a mouse to a touchpad, which is what
+ *    `XIDeviceChanged` announces — and that also resets the accumulators.
+ * 3. **Selecting XI2 turns off core delivery.** The server delivers an event
+ *    to a client once: an XI2 selection on a window suppresses the core
+ *    events of the same types *for that client on that window*. So a window
+ *    that selects XI2 Motion stops receiving core MotionNotify, and this
+ *    module has to reproduce the core-shaped event ntk consumers already
+ *    listen for.
+ */
+
+/**
+ * XI2 event types ntk can deliver, and the ntk event each becomes.
+ *
+ * Only the types node-x11 decodes into fields are here. The rest —
+ * Enter/Leave, FocusIn/FocusOut, HierarchyChanged, the barriers — arrive with
+ * their bodies undecoded (`ev.data`), and selecting one would suppress the
+ * core event that *is* decoded in exchange for nothing.
+ */
+export const xi2EventName = {
+  Motion: 'mousemove',
+  ButtonPress: 'mousedown',
+  ButtonRelease: 'mouseup',
+  KeyPress: 'keydown',
+  KeyRelease: 'keyup',
+  TouchBegin: 'touchstart',
+  TouchUpdate: 'touchmove',
+  TouchEnd: 'touchend'
+};
+
+/**
+ * What `xi2: true` selects: the pointer, which is what smooth scrolling
+ * needs. Keyboard and touch are opt-in by name — a window that selects XI2
+ * KeyPress takes on decoding it (and loses the core KeyPress it was getting).
+ */
+export const DEFAULT_XI2_EVENTS = ['Motion', 'ButtonPress', 'ButtonRelease'];
+
+// XIScrollClass.scrollType
+const SCROLL_VERTICAL = 1;
+
+// XIPointerEventFlags.PointerEmulated: this button event is the server's
+// rendering of a scroll axis into a wheel click, for clients that cannot read
+// valuators. Both halves of the scroll are sent, so a client that reads the
+// axis has to drop this one or count every notch twice.
+export const POINTER_EMULATED = 1 << 16;
+
+/** Wheel buttons in the core protocol: up, down, left, right. */
+export const WHEEL_BUTTONS = { 4: [0, -1], 5: [0, 1], 6: [-1, 0], 7: [1, 0] };
+
+/**
+ * Check a list of XI2 event-type names, and say what a caller can ask for.
+ *
+ * The failure this catches is a silent one: an unknown name reaches
+ * `XISelectEvents` as `undefined` and throws from node-x11 naming a bit
+ * position, and a *known* name ntk cannot decode (`Enter`) would select
+ * happily and then deliver nothing anyone can read.
+ *
+ * @param {string[]|string} types
+ * @returns {string[]}
+ */
+export function normalizeXI2Types(types) {
+  const list = typeof types === 'string' ? [types] : Array.from(types ?? []);
+  for (const name of list) {
+    if (xi2EventName[name]) continue;
+    const known = Object.keys(xi2EventName).join(', ');
+    throw new Error(
+      `ntk: selectXI2 cannot deliver '${name}'. Supported XI2 event types: ${known}. ` +
+        (name?.startsWith?.('Raw')
+          ? 'Raw events carry no window and are only sent for selections on the root, ' +
+            'so they are not routed to a window — read them off app.X directly.'
+          : 'Other XI2 events arrive with their bodies undecoded, and selecting one ' +
+            'would suppress the core event carrying the same information.')
+    );
+  }
+  return list;
+}
+
+/**
+ * The scroll axes of one device, from its `XIQueryDevice` classes:
+ * valuator number -> `{ vertical, increment }`.
+ *
+ * A device with no scroll class (a plain wheel mouse on an old driver, a
+ * tablet) yields an empty map, and everything below then leaves scrolling to
+ * the emulated buttons.
+ */
+export function scrollAxes(device) {
+  const axes = new Map();
+  for (const cls of device?.classes ?? []) {
+    // ClassType.Scroll
+    if (cls.type !== 3) continue;
+    if (!cls.increment) continue; // an axis one of whose notches is 0 long
+    axes.set(cls.number, {
+      vertical: cls.scrollType === SCROLL_VERTICAL,
+      increment: cls.increment
+    });
+  }
+  return axes;
+}
+
+/**
+ * Per-device scroll accumulators.
+ *
+ * Keyed by the *source* device as well as the master, because a master
+ * pointer's valuators are whatever its last-used slave put there: switching
+ * from the touchpad to the mouse continues the numbering with an unrelated
+ * value, and subtracting across that switch is the same jump as subtracting
+ * from zero.
+ */
+export class ScrollTracker {
+  constructor() {
+    this._last = new Map();
+  }
+
+  /** Forget a device's axes: the next event from it seeds again. */
+  reset(deviceId) {
+    for (const key of this._last.keys()) {
+      if (key.startsWith(`${deviceId}:`)) this._last.delete(key);
+    }
+  }
+
+  /**
+   * The scroll an event's valuators describe, or null when it carries no
+   * scroll axis and is therefore about something else (a pointer move).
+   *
+   * `moved` distinguishes a scroll from the first event of one: the seeding
+   * event carries a scroll axis — so it is not a pointer move and must not be
+   * reported as one — but has nothing to subtract from and so no distance to
+   * report. Distances are in notches, fractional, positive down and right
+   * (the direction a DOM `wheel` event calls positive).
+   *
+   * @param {object} ev a decoded XI2 device event
+   * @param {Map<number, {vertical: boolean, increment: number}>} axes
+   * @returns {{deltaX: number, deltaY: number, moved: boolean}|null}
+   */
+  delta(ev, axes) {
+    if (!axes?.size) return null;
+    let deltaX = 0;
+    let deltaY = 0;
+    let scrolled = false;
+    let moved = false;
+    for (const [number, axis] of axes) {
+      const value = ev.valuators?.[number];
+      if (value === undefined) continue;
+      scrolled = true;
+      const key = `${ev.deviceId}:${ev.sourceId}:${number}`;
+      const previous = this._last.get(key);
+      this._last.set(key, value);
+      // seeding: an absolute accumulator says nothing on its own
+      if (previous === undefined || value === previous) continue;
+      moved = true;
+      // a negative increment is how a device declares its axis inverted, and
+      // dividing by it puts the delta back in the natural direction
+      const notches = (value - previous) / axis.increment;
+      if (axis.vertical) deltaY += notches;
+      else deltaX += notches;
+    }
+    return scrolled ? { deltaX, deltaY, moved } : null;
+  }
+}
+
+/**
+ * The core `state` field, rebuilt from an XI2 event.
+ *
+ * ntk hands this to consumers as `ev.buttons` and to the keyboard decoder as
+ * the layout group, both of which predate XI2 and read the core bit layout:
+ * modifiers in bits 0-7, buttons 1-5 in bits 8-12, the XKB group in 13-14.
+ * XI2 splits the same information three ways, and reports buttons as a list.
+ */
+export function coreState(ev) {
+  let state = (ev.mods?.effective ?? 0) & 0xff;
+  for (const button of ev.buttons ?? []) {
+    if (button >= 1 && button <= 5) state |= 1 << (7 + button);
+  }
+  state |= ((ev.group?.effective ?? 0) & 3) << 13;
+  return state;
+}
+
+// Core event codes, so a translated event answers `ev.type` the way the event
+// it stands in for would.
+const coreType = {
+  mousemove: 6,
+  mousedown: 4,
+  mouseup: 5,
+  keydown: 2,
+  keyup: 3
+};
+
+/**
+ * An XI2 device event in the shape ntk delivers.
+ *
+ * Core-compatible where the two overlap — a handler written against
+ * `mousedown` cannot tell the difference — with the XI2 extras alongside:
+ * `deviceId`/`sourceId`, the sub-pixel `preciseX`/`preciseY` that FP1616
+ * coordinates carry and the integer `x`/`y` cannot, and the raw `valuators`.
+ */
+export function toNtkEvent(name, ev) {
+  const out = {
+    type: coreType[name] ?? ev.type,
+    name: ev.name,
+    xi2: true,
+    time: ev.time,
+    root: ev.root,
+    wid: ev.wid,
+    child: ev.child,
+    // core X reports integer coordinates; keep that the delivered contract and
+    // put the precision XI2 adds next to it rather than in place of it
+    x: Math.round(ev.x),
+    y: Math.round(ev.y),
+    rootx: Math.round(ev.rootx),
+    rooty: Math.round(ev.rooty),
+    preciseX: ev.x,
+    preciseY: ev.y,
+    preciseRootX: ev.rootx,
+    preciseRootY: ev.rooty,
+    buttons: coreState(ev),
+    buttonsDown: ev.buttons,
+    deviceId: ev.deviceId,
+    sourceId: ev.sourceId,
+    flags: ev.flags,
+    valuators: ev.valuators,
+    sameScreen: 1
+  };
+  // `detail` is the keycode, the button number or the touch id, depending;
+  // core X calls the first two `keycode`, and ntk documents them under that
+  if (name === 'touchstart' || name === 'touchmove' || name === 'touchend') {
+    out.touchId = ev.detail;
+  } else {
+    out.keycode = ev.detail;
+  }
+  return out;
+}
+
+/**
+ * A `wheel` event: `deltaX`/`deltaY` in notches, positive down and right.
+ *
+ * Notches rather than pixels, because a notch is the only unit the device
+ * agrees on — `increment` is defined as the value that makes one — and how
+ * many pixels one is worth is the consumer's line height, not ours. A
+ * touchpad reports fractions of one, which is the whole point: `smooth` says
+ * whether this delta came from a device that can, so a consumer can decide
+ * whether to animate the scroll or snap it.
+ *
+ * @param {string} source 'valuator' (XI2 scroll axes) or 'button' (4-7)
+ */
+export function wheelEvent(base, deltaX, deltaY, source) {
+  return {
+    // `type` stays that of the X event this was derived from — a button press
+    // or a motion — because a wheel has no core event code of its own
+    ...base,
+    name: 'wheel',
+    deltaX,
+    deltaY,
+    deltaMode: 'line',
+    smooth: source === 'valuator',
+    source
+  };
+}
+
+export default {
+  xi2EventName,
+  DEFAULT_XI2_EVENTS,
+  POINTER_EMULATED,
+  WHEEL_BUTTONS,
+  normalizeXI2Types,
+  scrollAxes,
+  ScrollTracker,
+  coreState,
+  toNtkEvent,
+  wheelEvent
+};

--- a/test/events-map.test.js
+++ b/test/events-map.test.js
@@ -11,9 +11,11 @@ test('every camelCase handler name maps to a snake event with a mask entry', () 
 });
 
 // names in the mask table that are not X event types. `statechange` is
-// derived from the PropertyNotify for _NET_WM_STATE and is in the table
-// because a listener for it still has to select PropertyChange.
-const DERIVED = new Set(['statechange']);
+// derived from the PropertyNotify for _NET_WM_STATE and `wheel` from a
+// ButtonPress of button 4-7 (or an XI2 scroll valuator); both are in the
+// table because a listener for one still has to select the mask it is
+// derived from.
+const DERIVED = new Set(['statechange', 'wheel']);
 
 test('every maskable event name is emitted by some X event type, or derived from one', () => {
   const emitted = new Set(eventName.filter(Boolean));
@@ -30,12 +32,13 @@ test('every maskable event name is emitted by some X event type, or derived from
 test('coalescible events are known event names with known strategies', () => {
   const emitted = new Set(eventName.filter(Boolean));
   for (const [name, strategy] of Object.entries(coalesce)) {
-    assert.ok(emitted.has(name), `${name} never emitted`);
-    assert.ok(['last', 'union'].includes(strategy), `unknown strategy ${strategy}`);
+    assert.ok(emitted.has(name) || DERIVED.has(name), `${name} never emitted`);
+    assert.ok(['last', 'union', 'accumulate'].includes(strategy), `unknown strategy ${strategy}`);
   }
   assert.equal(coalesce.mousemove, 'last');
   assert.equal(coalesce.resize, 'last');
   assert.equal(coalesce.expose, 'union');
+  assert.equal(coalesce.wheel, 'accumulate');
 });
 
 test('core event codes map to browser-like names', () => {

--- a/test/xi2-live.test.js
+++ b/test/xi2-live.test.js
@@ -1,0 +1,128 @@
+// XI2 against a real X server: does selecting it actually change what
+// arrives, and does what arrives still look like the event ntk documents?
+//
+// The half that needs a server is exactly the half a stub cannot check —
+// that an XI2 selection *replaces* this client's core events for the same
+// types, which is a server delivery rule rather than anything ntk decides.
+// The scroll arithmetic is hermetic, in xi2.test.js; a wheel cannot be faked
+// here at all, because no request generates one (XTEST fakes buttons, not
+// valuators).
+//
+// Skipped where there is no DISPLAY, and where the server has no XI2.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import { createClient } from '../lib/index.js';
+import { withTimeout } from './helpers/async.js';
+
+let app = null;
+let skip = false;
+let keepalive = null;
+
+before(async () => {
+  if (!process.env.DISPLAY) {
+    skip = 'no DISPLAY set';
+    return;
+  }
+  keepalive = setInterval(() => {}, 1000);
+  try {
+    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+  } catch (err) {
+    skip = `cannot connect to X server: ${err.message}`;
+    return;
+  }
+  const XI = await app.xinput();
+  if (!XI || !XI.xi2) skip = 'the server has no XI2';
+});
+
+after(async () => {
+  clearInterval(keepalive);
+  await app?.close();
+});
+
+/** Map and wait until the server will deliver pointer events to the window. */
+const mapAndWait = (wnd) =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, 1000);
+    wnd.once('expose', () => {
+      clearTimeout(timer);
+      setTimeout(resolve, 50);
+    });
+    wnd.map();
+  });
+
+/**
+ * Move the pointer inside the window — a motion event no input device has to
+ * make — and hand back the event it produced.
+ *
+ * Matched on the coordinates rather than taken as the last event to arrive,
+ * because a real server has a real pointer on it: someone brushing the
+ * touchpad while the suite runs is otherwise a failure. Motion is coalesced
+ * per frame, so this waits for frames rather than for a fixed sleep.
+ */
+const warp = async (wnd, x, y, seen) => {
+  const before = seen.length;
+  app.X.WarpPointer(0, wnd.id, 0, 0, 0, 0, x, y);
+  for (let tries = 0; tries < 20; tries++) {
+    await new Promise((resolve) => app.X.GetInputFocus(() => setTimeout(resolve, 25)));
+    const match = seen.slice(before).find((ev) => ev.x === x && ev.y === y);
+    if (match) return match;
+  }
+  throw new Error(`no motion event at ${x},${y} after warping there`);
+};
+
+test('inputDevices reports the master pointer and its classes', async (t) => {
+  if (skip) return t.skip(skip);
+  const devices = await app.inputDevices();
+  assert.ok(devices.length >= 2, 'a server has at least a virtual pointer and keyboard');
+  const master = devices.find((device) => device.use === 1); // DeviceType.MasterPointer
+  assert.ok(master, 'there is a master pointer');
+  assert.ok(master.classes.length, 'whose axes and buttons are described');
+  assert.equal(await app.inputDevices(), devices, 'cached — this is read per scroll event');
+});
+
+test('an XI2 selection takes over the events it names, and only those', async (t) => {
+  if (skip) return t.skip(skip);
+  const wnd = app.createWindow({ width: 200, height: 200, backingStore: false });
+  const moves = [];
+  wnd.on('mousemove', (ev) => moves.push(ev));
+  await mapAndWait(wnd);
+
+  const core = await warp(wnd, 20, 20, moves);
+  assert.equal(core.xi2, undefined, 'core MotionNotify, before anything is selected');
+
+  assert.equal(await wnd.selectXI2(['Motion']), true);
+  const xi2 = await warp(wnd, 120, 130, moves);
+  assert.equal(xi2.xi2, true, 'the same gesture now arrives as XIMotion');
+  assert.equal(xi2.y, 130, 'in the window coordinates a core event would have reported');
+  assert.ok(xi2.deviceId > 0, 'and says which device it came from, which core X cannot');
+  assert.equal(typeof xi2.preciseX, 'number');
+
+  // deselecting hands the core events back
+  assert.equal(await wnd.selectXI2([]), true);
+  assert.equal((await warp(wnd, 40, 45, moves)).xi2, undefined);
+
+  wnd.destroy();
+});
+
+test('selecting XI2 leaves the events it did not name on the core path', async (t) => {
+  if (skip) return t.skip(skip);
+  const wnd = app.createWindow({ width: 200, height: 200, backingStore: false });
+  const seen = [];
+  wnd.on('mousemove', (ev) => seen.push(ev));
+  // Enter/Leave are still core events: XI2's are undecoded, so selectXI2
+  // refuses to take them over and the window keeps the ones it can read
+  wnd.on('mouseover', (ev) => seen.push(ev));
+  await mapAndWait(wnd);
+  assert.equal(await wnd.selectXI2(['Motion']), true);
+
+  await warp(wnd, 10, 10, seen);
+  const motion = await warp(wnd, 150, 150, seen);
+  assert.equal(motion.xi2, true, 'motion is XI2 now');
+  assert.ok(
+    seen.every((ev) => ev.type !== 7 || !ev.xi2),
+    'and an EnterNotify is still an EnterNotify'
+  );
+
+  wnd.destroy();
+});

--- a/test/xi2.test.js
+++ b/test/xi2.test.js
@@ -1,0 +1,460 @@
+// XI2 device events: the scroll bookkeeping a wheel delta needs, and the
+// routing that turns a Generic Event into an ntk one.
+//
+// Hermetic. The wire half — XISelectEvents and the server's own decoding —
+// belongs to node-x11 and is tested there; what is ntk's is the arithmetic on
+// absolute valuators, which device an accumulator belongs to, and what comes
+// out of `wnd.on(...)`. The extension object is stubbed for exactly that
+// reason: a server that has XI2 is not something a test can arrange, and
+// XQuartz reports scroll increments no synthetic event could reproduce.
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+import {
+  ScrollTracker,
+  coreState,
+  normalizeXI2Types,
+  scrollAxes,
+  toNtkEvent
+} from '../lib/xi2.js';
+
+const { createServer, createStreamPair } = xserver;
+
+// XI2 protocol constants, as node-x11 attaches them to the extension object
+const XI_OPCODE = 131;
+const EventType = {
+  DeviceChanged: 1,
+  KeyPress: 2,
+  KeyRelease: 3,
+  ButtonPress: 4,
+  ButtonRelease: 5,
+  Motion: 6,
+  TouchBegin: 18,
+  TouchUpdate: 19,
+  TouchEnd: 20
+};
+const POINTER_EMULATED = 1 << 16;
+
+// a master pointer whose current slave is a touchpad: two scroll axes,
+// fifteen units to the notch (what libinput reports for a wheel)
+const DEVICES = [
+  {
+    deviceId: 2,
+    name: 'Virtual core pointer',
+    classes: [
+      { type: 2, sourceId: 6, number: 0, label: 0, min: -1, max: -1, value: 0 },
+      { type: 3, sourceId: 6, number: 4, scrollType: 1, flags: 0, increment: 15 },
+      { type: 3, sourceId: 6, number: 5, scrollType: 2, flags: 0, increment: 15 }
+    ]
+  },
+  { deviceId: 3, name: 'Virtual core keyboard', classes: [] }
+];
+
+test('normalizeXI2Types names what it can deliver, and why a Raw event is not it', () => {
+  assert.deepEqual(normalizeXI2Types(['Motion', 'ButtonPress']), ['Motion', 'ButtonPress']);
+  assert.deepEqual(normalizeXI2Types('Motion'), ['Motion']);
+  assert.deepEqual(normalizeXI2Types([]), []);
+
+  assert.throws(() => normalizeXI2Types(['RawMotion']), (err) => {
+    assert.match(err.message, /RawMotion/);
+    assert.match(err.message, /root/, 'says why a raw event cannot be routed to a window');
+    assert.match(err.message, /Motion, ButtonPress/, 'lists what can be selected');
+    return true;
+  });
+  // decodable by the server, but not by node-x11: selecting it would cost the
+  // core Enter/Leave and deliver an undecoded body in exchange
+  assert.throws(() => normalizeXI2Types(['Enter']), /undecoded/);
+});
+
+test('scrollAxes reads the Scroll classes, and skips an axis with no increment', () => {
+  const axes = scrollAxes(DEVICES[0]);
+  assert.deepEqual([...axes.keys()], [4, 5]);
+  assert.equal(axes.get(4).vertical, true);
+  assert.equal(axes.get(5).vertical, false);
+  assert.equal(axes.get(4).increment, 15);
+
+  assert.equal(scrollAxes(DEVICES[1]).size, 0);
+  assert.equal(
+    scrollAxes({ classes: [{ type: 3, number: 4, scrollType: 1, increment: 0 }] }).size,
+    0,
+    'a notch zero units long would divide by zero'
+  );
+});
+
+const motionEvent = (valuators, extra = {}) => ({
+  type: 35,
+  extension: XI_OPCODE,
+  evtype: EventType.Motion,
+  name: 'XIMotion',
+  deviceId: 2,
+  sourceId: 6,
+  time: 1000,
+  detail: 0,
+  root: 1,
+  child: 0,
+  rootx: 100,
+  rooty: 200,
+  x: 10,
+  y: 20,
+  buttons: [],
+  flags: 0,
+  mods: { base: 0, latched: 0, locked: 0, effective: 0 },
+  group: { base: 0, latched: 0, locked: 0, effective: 0 },
+  valuators,
+  ...extra
+});
+
+test('a scroll delta is the change in an absolute valuator, and the first one seeds', () => {
+  const tracker = new ScrollTracker();
+  const axes = scrollAxes(DEVICES[0]);
+
+  // the axis has been accumulating since the device was plugged in — reading
+  // it as a delta would scroll a thousand notches on the first event
+  assert.deepEqual(
+    tracker.delta(motionEvent({ 4: 1500 }), axes),
+    { deltaX: 0, deltaY: 0, moved: false },
+    'seeds, reports no distance'
+  );
+
+  assert.deepEqual(tracker.delta(motionEvent({ 4: 1515 }), axes), {
+    deltaX: 0,
+    deltaY: 1,
+    moved: true
+  });
+  assert.deepEqual(
+    tracker.delta(motionEvent({ 4: 1510 }), axes),
+    { deltaX: 0, deltaY: -1 / 3, moved: true },
+    'a touchpad moves a fraction of a notch at a time'
+  );
+  assert.equal(
+    tracker.delta(motionEvent({ 5: 30 }), axes).moved,
+    false,
+    'the other axis seeds on its own'
+  );
+  assert.deepEqual(tracker.delta(motionEvent({ 5: 45 }), axes), {
+    deltaX: 1,
+    deltaY: 0,
+    moved: true
+  });
+
+  assert.equal(
+    tracker.delta(motionEvent({ 0: 12 }), axes),
+    null,
+    'a plain pointer axis is not scroll'
+  );
+  assert.equal(
+    tracker.delta(motionEvent({ 4: 1600 }), new Map()),
+    null,
+    'a device with no scroll class'
+  );
+  assert.deepEqual(
+    tracker.delta(motionEvent({ 4: 1510 }), axes),
+    { deltaX: 0, deltaY: 0, moved: false },
+    'an axis that did not move is still a scroll event, not a pointer move'
+  );
+});
+
+test('a negative increment is a device declaring its axis inverted', () => {
+  const tracker = new ScrollTracker();
+  const axes = scrollAxes({ classes: [{ type: 3, number: 4, scrollType: 1, increment: -1 }] });
+  tracker.delta(motionEvent({ 4: 10 }), axes);
+  assert.deepEqual(tracker.delta(motionEvent({ 4: 11 }), axes), {
+    deltaX: 0,
+    deltaY: -1,
+    moved: true
+  });
+});
+
+test('accumulators are per source device, and a device change reseeds them', () => {
+  const tracker = new ScrollTracker();
+  const axes = scrollAxes(DEVICES[0]);
+  tracker.delta(motionEvent({ 4: 1500 }), axes);
+  assert.deepEqual(tracker.delta(motionEvent({ 4: 1530 }), axes), {
+    deltaX: 0,
+    deltaY: 2,
+    moved: true
+  });
+
+  // the user let go of the touchpad and turned the wheel: same master, other
+  // slave, and its axis is nowhere near 1530
+  assert.equal(tracker.delta(motionEvent({ 4: 12 }, { sourceId: 9 }), axes).moved, false);
+  assert.deepEqual(tracker.delta(motionEvent({ 4: 27 }, { sourceId: 9 }), axes), {
+    deltaX: 0,
+    deltaY: 1,
+    moved: true
+  });
+
+  tracker.reset(2);
+  assert.equal(
+    tracker.delta(motionEvent({ 4: 27 }, { sourceId: 9 }), axes).moved,
+    false,
+    'seeds again'
+  );
+});
+
+test('coreState packs XI2 modifiers, buttons and group the way core X reports them', () => {
+  assert.equal(coreState(motionEvent({})), 0);
+  assert.equal(
+    coreState(motionEvent({}, { mods: { effective: 4 }, buttons: [1, 3] })),
+    4 | (1 << 8) | (1 << 10),
+    'Control, plus buttons 1 and 3 held'
+  );
+  assert.equal(
+    coreState(motionEvent({}, { group: { effective: 1 } })),
+    1 << 13,
+    'the XKB group lives in bits 13-14, which is where the keyboard decoder reads it'
+  );
+  assert.equal(
+    coreState(motionEvent({}, { buttons: [8] })),
+    0,
+    'core state has no bit for buttons past 5'
+  );
+});
+
+test('a translated event keeps the core fields and adds the sub-pixel ones', () => {
+  const ev = toNtkEvent('mousedown', motionEvent({}, { detail: 3, x: 10.75, y: 20.5 }));
+  assert.equal(ev.type, 4, 'ButtonPress, as a handler switching on ev.type expects');
+  assert.equal(ev.keycode, 3, 'core X calls the button number keycode');
+  assert.equal(ev.x, 11, 'integers, as core X reports them');
+  assert.equal(ev.y, 21);
+  assert.equal(ev.preciseX, 10.75, 'and the precision XI2 adds, alongside');
+  assert.equal(ev.deviceId, 2);
+  assert.equal(ev.sourceId, 6);
+  assert.equal(ev.xi2, true);
+
+  const touch = toNtkEvent('touchstart', motionEvent({}, { detail: 7 }));
+  assert.equal(touch.touchId, 7, 'the same field is a touch id here');
+  assert.equal(touch.keycode, undefined);
+});
+
+// --- routing, against a real Window on the hermetic server -----------------
+
+let server = null;
+let client = null;
+
+const connect = async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+};
+
+beforeEach(async () => {
+  server = createServer({ width: 400, height: 300 });
+  client = await connect();
+});
+
+afterEach(() => {
+  client?.X.terminate();
+  server = client = null;
+});
+
+/**
+ * A window with XI2 selected, without an X server that has XI2: the
+ * extension and the device list are stubbed, and everything downstream of
+ * them is the real thing.
+ */
+const xi2Window = async (app, { types, devices = DEVICES } = {}) => {
+  const selections = [];
+  app.xinput = () =>
+    Promise.resolve({
+      majorOpcode: XI_OPCODE,
+      xi2: { majorVersion: 2, minorVersion: 2 },
+      AllDevices: 0,
+      AllMasterDevices: 1,
+      EventType,
+      XISelectEvents: (wid, masks) => selections.push({ wid, masks })
+    });
+  app.inputDevices = () => Promise.resolve(devices);
+  const wnd = app.createWindow({ width: 100, height: 100, backingStore: false });
+  assert.equal(await wnd.selectXI2(types), true);
+  return { wnd, selections };
+};
+
+const next = (wnd, name) => new Promise((resolve) => wnd.once(name, resolve));
+
+test('selectXI2 asks for the caller\'s events plus the one that invalidates the cache', async () => {
+  const { wnd, selections } = await xi2Window(client);
+  assert.equal(selections.length, 1);
+  assert.equal(selections[0].wid, wnd.id);
+  assert.equal(selections[0].masks.deviceId, 1, 'every master device');
+  assert.deepEqual(selections[0].masks.mask, [
+    'Motion',
+    'ButtonPress',
+    'ButtonRelease',
+    'DeviceChanged'
+  ]);
+
+  const perDevice = await xi2Window(client, { types: ['Motion'] });
+  assert.deepEqual(perDevice.selections[0].masks.mask, ['Motion', 'DeviceChanged']);
+});
+
+test('selectXI2([]) deselects and puts the window back on core events', async () => {
+  const { wnd, selections } = await xi2Window(client);
+  assert.equal(await wnd.selectXI2([]), true);
+  assert.equal(selections[1].masks.mask, 0, 'an empty mask is how XI2 says stop');
+
+  // a core ButtonPress of button 4 is a wheel again
+  const wheel = next(wnd, 'wheel');
+  wnd.emit('event', { type: 4, keycode: 4, x: 1, y: 2, buttons: 0 });
+  assert.equal((await wheel).deltaY, -1);
+});
+
+test('a window with no XI2 server keeps its core wheel', async () => {
+  const wnd = client.createWindow({ width: 100, height: 100, backingStore: false });
+  client.xinput = () => Promise.resolve(null);
+  assert.equal(await wnd.selectXI2(), false, 'says so rather than pretending');
+
+  const seen = [];
+  wnd.on('wheel', (ev) => seen.push(ev));
+  wnd.emit('event', { type: 4, keycode: 5, x: 1, y: 2, buttons: 0 });
+  wnd.emit('event', { type: 4, keycode: 6, x: 1, y: 2, buttons: 0 });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.deepEqual(
+    seen.map((ev) => [ev.deltaX, ev.deltaY, ev.smooth, ev.deltaMode]),
+    [
+      [0, 1, false, 'line'],
+      [-1, 0, false, 'line']
+    ],
+    'buttons 5 and 6: one notch down, one notch left'
+  );
+});
+
+test('a scroll valuator becomes a wheel event, and not also a mouse move', async () => {
+  const { wnd } = await xi2Window(client);
+  const moves = [];
+  wnd.on('mousemove', (ev) => moves.push(ev));
+
+  wnd.emit('event', motionEvent({ 4: 1500 }, { wid: wnd.id })); // seeds
+  const wheel = next(wnd, 'wheel');
+  wnd.emit('event', motionEvent({ 4: 1505 }, { wid: wnd.id }));
+
+  const ev = await wheel;
+  assert.equal(ev.deltaY, 1 / 3, 'a third of a notch, which no core event could say');
+  assert.equal(ev.deltaX, 0);
+  assert.equal(ev.smooth, true);
+  assert.equal(ev.deltaMode, 'line');
+  assert.equal(ev.deviceId, 2);
+  assert.equal(ev.sourceId, 6);
+  assert.equal(ev.window, wnd);
+  assert.equal(ev.target, wnd);
+  assert.deepEqual(moves, [], 'the pointer did not move; only the wheel did');
+});
+
+test('an XI2 motion that is not a scroll is still a mousemove', async () => {
+  const { wnd } = await xi2Window(client);
+  const move = next(wnd, 'mousemove');
+  wnd.emit('event', motionEvent({ 0: 30, 1: 40 }, { wid: wnd.id, x: 30.5, y: 40.25 }));
+  const ev = await move;
+  assert.equal(ev.x, 31);
+  assert.equal(ev.preciseX, 30.5);
+  assert.equal(ev.xi2, true);
+});
+
+test('the emulated wheel click is dropped, so a notch is not counted twice', async () => {
+  const { wnd } = await xi2Window(client);
+  const seen = [];
+  wnd.on('wheel', (ev) => seen.push(ev.source));
+  wnd.on('mousedown', () => seen.push('mousedown'));
+
+  // what the server sends for one smooth notch: the valuator, and a button
+  // press for clients that cannot read it
+  wnd.emit('event', motionEvent({ 4: 1500 }, { wid: wnd.id }));
+  wnd.emit('event', motionEvent({ 4: 1515 }, { wid: wnd.id }));
+  wnd.emit(
+    'event',
+    motionEvent({}, {
+      wid: wnd.id,
+      evtype: EventType.ButtonPress,
+      detail: 5,
+      flags: POINTER_EMULATED
+    })
+  );
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.deepEqual(seen, ['valuator'], 'one notch, once');
+});
+
+test('a wheel with no scroll class behind it still arrives, one notch at a time', async () => {
+  // an old driver, or a mouse the server has no smooth scrolling for: the
+  // button press is not emulating anything, so it is the event
+  const { wnd } = await xi2Window(client, { devices: [DEVICES[1]] });
+  const seen = [];
+  wnd.on('wheel', (ev) => seen.push(ev));
+  wnd.on('mousedown', (ev) => seen.push(ev));
+
+  wnd.emit(
+    'event',
+    motionEvent({}, { wid: wnd.id, evtype: EventType.ButtonPress, detail: 4, flags: 0 })
+  );
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(seen.length, 2);
+  assert.equal(seen[0].deltaY, -1);
+  assert.equal(seen[0].smooth, false);
+  assert.equal(seen[1].keycode, 4, 'and the button press itself, as core X would have sent it');
+});
+
+test('a frame of scrolling adds up, rather than reporting only its last step', async () => {
+  const { wnd } = await xi2Window(client);
+  wnd.emit('event', motionEvent({ 4: 1500 }, { wid: wnd.id }));
+  const wheel = next(wnd, 'wheel');
+  for (const value of [1503, 1506, 1509, 1512]) {
+    wnd.emit('event', motionEvent({ 4: value }, { wid: wnd.id, time: 1000 + value }));
+  }
+  const ev = await wheel;
+  assert.equal(ev.deltaY, 12 / 15, 'four fifths of a notch, not the last fifth');
+  assert.equal(ev.coalesced.length, 4);
+  assert.equal(ev.time, 2512, 'and it happened where the last one did');
+});
+
+test('XI2 key events carry the keysym decoding core ones do', async () => {
+  const { wnd } = await xi2Window(client, { types: ['KeyPress'] });
+  // the hermetic server has no keyboard layout to speak of; what matters here
+  // is that the XI2 path reads the same map the core one does
+  const keycode = 38;
+  client.X.keycode2keysyms[keycode] = [0x61, 0x41]; // 'a', 'A'
+
+  const key = next(wnd, 'keydown');
+  wnd.emit(
+    'event',
+    motionEvent({}, { wid: wnd.id, evtype: EventType.KeyPress, name: 'XIKeyPress', detail: keycode })
+  );
+  const ev = await key;
+  assert.equal(ev.keycode, keycode);
+  assert.equal(ev.codepoint, 0x61);
+  assert.equal(ev.keysym, 0x61);
+});
+
+test('a device change drops the accumulators built on the old device', async () => {
+  const { wnd } = await xi2Window(client);
+  const first = next(wnd, 'wheel');
+  wnd.emit('event', motionEvent({ 4: 1500 }, { wid: wnd.id }));
+  wnd.emit('event', motionEvent({ 4: 1515 }, { wid: wnd.id })); // one notch
+  assert.equal((await first).deltaY, 1);
+
+  wnd.emit(
+    'event',
+    motionEvent({}, { wid: wnd.id, evtype: EventType.DeviceChanged, name: 'XIDeviceChanged' })
+  );
+
+  const seen = [];
+  wnd.on('wheel', (ev) => seen.push(ev.deltaY));
+  // the new slave's axis starts somewhere else entirely
+  wnd.emit('event', motionEvent({ 4: 40 }, { wid: wnd.id }));
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.deepEqual(seen, [], 'no 97-notch jump from subtracting across the switch');
+
+  const wheel = next(wnd, 'wheel');
+  wnd.emit('event', motionEvent({ 4: 55 }, { wid: wnd.id }));
+  assert.equal((await wheel).deltaY, 1);
+});
+
+test('Present keeps its Generic Events while XI2 has its own', async () => {
+  const { wnd } = await xi2Window(client);
+  const routed = [];
+  wnd._geHandlers.set(200, (ev) => routed.push(ev.evtype));
+  wnd.emit('event', { type: 35, extension: 200, evtype: 1 });
+  wnd.emit('event', { type: 35, extension: 201, evtype: 1 }); // nobody's
+  assert.deepEqual(routed, [1], 'routed by extension opcode, not first-come');
+});


### PR DESCRIPTION
Closes #247.

ntk had no XI2 at all: nothing selected it, and a Generic Event that was not
Present's was dropped two lines into the event handler. So every scroll in
every ntk app was a fixed step from the emulated buttons 4/5, whatever the
hardware measured.

## What a consumer sees

A new derived event, on every window, with no opt-in:

```js
wnd.on('wheel', onWheel);

function onWheel(ev) {
  offsetX += ev.deltaX * lineHeight;
  offsetY += ev.deltaY * lineHeight;
}
```

`ev.deltaX`/`ev.deltaY` are positive down and right, and `ev.deltaMode` is
`'line'`. On the core protocol that is one whole notch per event, from a
ButtonPress of button 4-7, exactly as before — the event is new, the
information is not.

Opting a window in to XI2 is what makes the same handler smooth:

```js
const wnd = app.createWindow({ width: 400, height: 300, xi2: true });
// or, when you want to know whether the server has XI2:
const smooth = await wnd.selectXI2();
```

Now a touchpad's two-finger scroll arrives as fractions of a notch,
`ev.smooth` is true, and `ev.deviceId`/`ev.sourceId` say which device did it.

`app.inputDevices()` exposes the XIQueryDevice list, and `app.xinput()` the
raw extension for the XI2 requests ntk does not wrap.

## Three things built in rather than left to callers

- **Scroll bookkeeping.** Valuators are absolute accumulators, so a delta is
  the change divided by the axis' increment, and the first event from a
  device must seed rather than subtract from zero. Accumulators are keyed by
  source device, and `XIDeviceChanged` — the user moving from touchpad to
  mouse — drops them and re-reads the axis map. Getting either wrong is a
  jump of hundreds of notches on the first scroll of a session.
- **Coalescing that adds up.** `wheel` joins the per-frame coalescing table
  with a new `accumulate` strategy: a frame's deltas sum instead of
  last-wins, which is the difference between fast scrolling losing distance
  and not.
- **Not counting a notch twice.** For a smooth scroll the server sends both
  halves — the valuator and a button 4-7 click flagged `PointerEmulated` —
  so the emulated click is dropped once the valuators are flowing.

## Two things worth knowing about the design

**Selecting XI2 replaces core delivery for the types you select.** The server
delivers an event to a client once and an XI2 selection wins, so a window
that selects `Motion` stops receiving core MotionNotify. Verified against a
real server rather than assumed, and `test/xi2-live.test.js` pins it. So ntk
translates XI2 device events into the core-shaped events it already
documents: same `x`/`y`/`keycode`/`buttons`, with the modifier and XKB-group
bits rebuilt in their core positions, plus `ev.xi2`, the device ids, the raw
valuators and sub-pixel `preciseX`/`preciseY`. Existing handlers do not
change. Types you did not select stay on the core path, which is why
`mouseover` and `focus` keep working; the types ntk cannot decode are
refused by name, with the list of the ones it can.

**Deltas are in notches, not pixels.** The issue proposed `deltaMode:
'pixel'` for the XI2 side, but the value it also specified — the valuator
delta divided by the device increment — is a count of notches, since the
increment is defined as what makes one. How many pixels a notch is worth is
the consumer's line height. So the unit is `'line'` from both sources and
`ev.smooth` carries what `'pixel'` was reaching for: whether this delta has
sub-notch precision.

The Generic Event block is now a map of extension opcode to handler, as the
issue suggested. The direct GL context's sink stays an override ahead of it,
since it claims the same extension the window's own blit path uses.

## Tests

`test/xi2.test.js` — hermetic: the valuator arithmetic, seeding, per-source
keying, the reseed on device change, state-mask packing, and routing end to
end through a real `Window` with the extension stubbed.

`test/xi2-live.test.js` — against a real X server, skipped without one: that
an XI2 selection really does take over the events it names, that the ones it
does not name stay core, and that deselecting hands them back. It moves the
pointer with WarpPointer, so it needs no input device.

`examples/smooth-scroll.js` — the same list in two columns, one on core
wheel notches and one on XI2, so the difference is visible rather than
described.

