### PR TITLE
feat(surface): copyWithin — overlapping self-copy for offscreen surfaces

### DIFF
--- a/docs/surface.md
+++ b/docs/surface.md
@@ -49,6 +49,42 @@ answers that question for SVG documents.
 `globalAlpha` still applies — it folds into the source colour rather than the
 mask, since the mask slot is taken.
 
+## Scrolling and panning: `copyWithin`
+
+A widget that keeps its content in a retained surface — a terminal grid, a
+log view, a minimap, a panning chart — scrolls the way terminals always
+have: copy the band that survives the shift, then repaint only the sliver
+the shift exposed.
+
+```js
+// scroll the whole grid up one 18px row
+if (grid.copyWithin({ x: 0, y: 0, width: grid.width, height: grid.height }, 0, -18)) {
+  drawRow(lastRow); // only the newly exposed row
+} else {
+  drawAllRows();    // nothing survived the shift
+}
+ctx.drawImage(grid, 0, 0);
+```
+
+`surface.copyWithin(src, dx, dy)` shifts the pixels of `src`
+(`{x, y, width, height}`, surface coordinates) by `(dx, dy)` **in place**,
+server-side — one `CopyArea` of the surviving band. The overlap is safe:
+pixmap contents cannot be occluded, and the server fetches the source region
+before storing. The copy is issued in-order with whatever the caller draws
+next on the same connection, and goes out with a shared
+`graphicsExposures: 0` GC — one per app and depth, created on first use —
+so it never emits exposure events.
+
+Returns `false` — having done nothing, so the caller just repaints `src` as
+it would have anyway — when `dx`/`dy` are fractional (a sub-pixel shift
+changes every pixel) or both zero, when nothing of `src` survives the shift
+after clamping to the surface, or on a destroyed surface.
+
+This is [`wnd.scrollRegion`](window.md#wndscrollregionrect-dx-dy--boolean)
+for an offscreen surface, minus the damage bookkeeping — a pixmap has no
+backing store or present path, so compositing the surface afterwards is the
+caller's normal job.
+
 ## API
 
 - `new Surface(app, { width, height, format })` — `format` is `'argb32'`
@@ -63,6 +99,9 @@ mask, since the mask slot is taken.
 - `surface.getContext('2d')` — a context the caller owns, and owes a
   `destroy()`. Use this instead of `render()` for many draws into one surface
 - `surface.clear()` — reset every pixel to transparent
+- `surface.copyWithin(src, dx, dy)` → boolean — shift the pixels of `src`
+  in place by an integer `(dx, dy)`, server-side; see
+  [Scrolling and panning](#scrolling-and-panning-copywithin)
 - `surface.picture(app)` — the server-side Picture, mirroring
   `Image.picture(app)`. Throws for a different connection
 - `surface.destroy()` / `Symbol.dispose` — free the pixmap and the picture.

--- a/docs/window.md
+++ b/docs/window.md
@@ -221,6 +221,9 @@ the reason this operates on the backing store, not the window), and the
 copy is issued in-order with whatever the caller draws next on the same
 connection.
 
+The same operation for a retained offscreen surface is
+[`surface.copyWithin`](surface.md#scrolling-and-panning-copywithin).
+
 ## Frames, coalescing and slow connections
 
 Some X events are noisy by nature: an interactive resize is a stream of

--- a/lib/surface.js
+++ b/lib/surface.js
@@ -1,5 +1,6 @@
 import Picture from './picture.js';
 import Pixmap from './pixmap.js';
+import { safeRelease } from './cleanup.js';
 
 /**
  * An offscreen drawing surface: a pixmap, its Picture, and enough of the
@@ -101,6 +102,67 @@ export class Surface {
    * owes it a `destroy()` */
   getContext(name, ...args) {
     return this.pixmap.getContext(name, ...args);
+  }
+
+  /**
+   * Scroll the pixels of `src` (surface coordinates, `{x, y, width, height}`)
+   * by (dx, dy) in place, server-side: one CopyArea of the band that
+   * survives the shift, in place of the caller re-drawing everything that
+   * merely moved. Returns true when the copy was issued; false means
+   * "nothing survives the shift here", and the caller repaints `src` exactly
+   * as it would have without this method — every refusal is the status quo.
+   *
+   * Refused when the delta is fractional (a sub-pixel shift changes every
+   * pixel, so there is nothing to copy), when it is zero, when nothing of
+   * `src` survives the shift after clamping to the surface, or on a
+   * destroyed surface.
+   *
+   * This is `Window#scrollRegion` for a retained offscreen surface, minus
+   * the damage bookkeeping a pixmap does not have: the caller draws the
+   * exposed strip and composites as usual. The overlapping self-copy is
+   * fully defined — pixmap contents cannot be occluded, and the server
+   * fetches the source region before storing. The copy goes out with a
+   * shared graphicsExposures: 0 GC — one per app and depth, created on
+   * first use and released with the connection, where a default GC would
+   * emit a NoExposure event per copy — and in-order with the caller's
+   * follow-up drawing of the exposed strip on the same connection.
+   */
+  copyWithin(src, dx, dy) {
+    if (this._destroyed) return false;
+    if (!Number.isInteger(dx) || !Number.isInteger(dy) || (dx === 0 && dy === 0)) return false;
+    const x0 = Math.max(0, Math.floor(src.x));
+    const y0 = Math.max(0, Math.floor(src.y));
+    const x1 = Math.min(this.width, Math.ceil(src.x + src.width));
+    const y1 = Math.min(this.height, Math.ceil(src.y + src.height));
+    // the band that survives: dest = clamped src ∩ (clamped src + delta)
+    const dstX0 = Math.max(x0, x0 + dx);
+    const dstY0 = Math.max(y0, y0 + dy);
+    const dstX1 = Math.min(x1, x1 + dx);
+    const dstY1 = Math.min(y1, y1 + dy);
+    if (dstX1 <= dstX0 || dstY1 <= dstY0) return false;
+    const X = this.app.X;
+    // a GC is valid for any drawable of its depth on the screen, so one per
+    // app and depth serves every surface — the upload-GC pattern in image.js
+    const gcs = (this.app._surfaceCopyGC ??= {});
+    safeRelease(X, () => {
+      let gc = gcs[this.depth];
+      if (!gc) {
+        gc = gcs[this.depth] = X.AllocID();
+        X.CreateGC(gc, this.pixmap.id, { graphicsExposures: 0 });
+      }
+      X.CopyArea(
+        this.pixmap.id,
+        this.pixmap.id,
+        gc,
+        dstX0 - dx,
+        dstY0 - dy,
+        dstX0,
+        dstY0,
+        dstX1 - dstX0,
+        dstY1 - dstY0
+      );
+    });
+    return true;
   }
 
   destroy() {

--- a/test/surface.test.js
+++ b/test/surface.test.js
@@ -310,6 +310,120 @@ describe('clipping a surface composite', () => {
   });
 });
 
+describe('copyWithin', () => {
+  /** read pixels straight off a surface's own pixmap */
+  async function surfacePixels(surface) {
+    const ctx = surface.getContext('2d');
+    try {
+      const img = await ctx.getImageData(0, 0, surface.width, surface.height);
+      return (x, y) => [...img.data.slice((y * surface.width + x) * 4, (y * surface.width + x) * 4 + 4)];
+    } finally {
+      ctx.destroy();
+    }
+  }
+
+  test('pixels: the band lands shifted exactly, the exposed strip is untouched', async () => {
+    const surface = new Surface(app, { width: 32, height: 32 });
+    surface.render((ctx) => {
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, 32, 32);
+      ctx.fillStyle = '#ff0000';
+      ctx.fillRect(0, 8, 32, 4);
+      ctx.fillStyle = '#00ff00';
+      ctx.fillRect(0, 12, 32, 4);
+      ctx.fillStyle = '#0000ff';
+      ctx.fillRect(0, 16, 32, 4);
+    });
+
+    assert.equal(surface.copyWithin({ x: 0, y: 4, width: 32, height: 24 }, 0, -4), true);
+
+    const px = await surfacePixels(surface);
+    // the bands moved up by 4
+    assert.deepEqual(px(16, 6), [255, 0, 0, 255]);
+    assert.deepEqual(px(16, 10), [0, 255, 0, 255]);
+    assert.deepEqual(px(16, 14), [0, 0, 255, 255]);
+    // the exposed strip (bottom rows of the region) still holds its old
+    // pixels — the copy does not invent content, the caller draws it
+    assert.deepEqual(px(16, 26), [255, 255, 255, 255]);
+    // outside the region nothing moved
+    assert.deepEqual(px(16, 2), [255, 255, 255, 255]);
+  });
+
+  test('a two-axis shift copies one rectangle, shifted both ways, clamped to the surface', () => {
+    const surface = new Surface(app, { width: 32, height: 32 });
+    const copies = [];
+    const saved = app.X.CopyArea;
+    app.X.CopyArea = (src, dst, gc, sx, sy, dx, dy, width, height) => {
+      copies.push({ src, dst, sx, sy, dx, dy, width, height });
+      return saved.call(app.X, src, dst, gc, sx, sy, dx, dy, width, height);
+    };
+    try {
+      assert.equal(surface.copyWithin({ x: -10, y: -10, width: 100, height: 100 }, 6, -4), true);
+    } finally {
+      app.X.CopyArea = saved;
+    }
+    assert.deepEqual(copies, [
+      {
+        src: surface.pixmap.id,
+        dst: surface.pixmap.id,
+        sx: 0,
+        sy: 4,
+        dx: 6,
+        dy: 0,
+        width: 26,
+        height: 28
+      }
+    ]);
+  });
+
+  test('refusals: fractional, zero, nothing survives, destroyed — all request-free', () => {
+    const surface = new Surface(app, { width: 16, height: 16 });
+    const counts = countX(['CopyArea'], () => {
+      assert.equal(surface.copyWithin({ x: 0, y: 0, width: 16, height: 16 }, 0, -0.5), false);
+      assert.equal(surface.copyWithin({ x: 0, y: 0, width: 16, height: 16 }, 0, 0), false);
+      assert.equal(surface.copyWithin({ x: 0, y: 0, width: 16, height: 16 }, 0, -16), false);
+      assert.equal(surface.copyWithin({ x: 0, y: 0, width: 16, height: 16 }, 20, 0), false);
+      assert.equal(surface.copyWithin({ x: 4, y: 4, width: 0, height: 8 }, 1, 0), false);
+      surface.destroy();
+      assert.equal(surface.copyWithin({ x: 0, y: 0, width: 16, height: 16 }, 0, -1), false);
+    });
+    assert.equal(counts.CopyArea, 0, 'every refusal is request-free');
+  });
+
+  test('the copy GC is shared per app and depth, not created per surface or call', () => {
+    const one = new Surface(app, { width: 8, height: 8 });
+    const two = new Surface(app, { width: 8, height: 8 });
+    one.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 1, 0); // first use may create it
+    const counts = countX(['CreateGC'], () => {
+      one.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, 1);
+      two.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, 1);
+    });
+    assert.equal(counts.CreateGC, 0, 'the depth-32 GC already exists');
+    const a8 = new Surface(app, { width: 8, height: 8, format: 'a8' });
+    const fresh = countX(['CreateGC'], () => {
+      a8.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, 1);
+      a8.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, 1);
+    });
+    assert.equal(fresh.CreateGC, 1, 'a depth not seen before costs one GC, once');
+  });
+
+  test('coverage surfaces scroll too, and keep acting as masks', async () => {
+    const mask = new Surface(app, { width: 8, height: 8, format: 'a8' });
+    mask.render((m) => {
+      m.fillStyle = '#ffffff';
+      m.fillRect(0, 0, 8, 4); // top half covered, bottom half clear
+    });
+    assert.equal(mask.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, 4), true);
+
+    const ctx = target();
+    ctx.fillStyle = '#ff0000';
+    ctx.drawImage(mask, 0, 0);
+    const px = await readPixels(ctx);
+    assert.deepEqual(px(4, 2), [255, 0, 0, 255], 'the top half is untouched');
+    assert.deepEqual(px(4, 6), [255, 0, 0, 255], 'the copied band covers the bottom half');
+  });
+});
+
 describe('context teardown', () => {
   test('destroy() releases and is idempotent', () => {
     const pixmap = app.createPixmap({ width: 8, height: 8, depth: 32 });
@@ -342,27 +456,27 @@ describe('context teardown', () => {
   });
 });
 
-describe('server resources are not leaked', () => {
-  /** count the requests a body issues, by name */
-  function countX(names, body) {
-    const X = app.X;
-    const counts = Object.fromEntries(names.map((n) => [n, 0]));
-    const saved = {};
-    for (const name of names) {
-      saved[name] = X[name];
-      X[name] = (...a) => {
-        counts[name]++;
-        return saved[name].apply(X, a);
-      };
-    }
-    try {
-      body();
-    } finally {
-      for (const name of names) X[name] = saved[name];
-    }
-    return counts;
+/** count the requests a body issues, by name */
+function countX(names, body) {
+  const X = app.X;
+  const counts = Object.fromEntries(names.map((n) => [n, 0]));
+  const saved = {};
+  for (const name of names) {
+    saved[name] = X[name];
+    X[name] = (...a) => {
+      counts[name]++;
+      return saved[name].apply(X, a);
+    };
   }
+  try {
+    body();
+  } finally {
+    for (const name of names) X[name] = saved[name];
+  }
+  return counts;
+}
 
+describe('server resources are not leaked', () => {
   test('drawing a node-canvas source repeatedly allocates once, not per call', () => {
     // this used to create a GC, a pixmap and a picture per call and free
     // none of them, so an animation loop leaked three resources a frame


### PR DESCRIPTION

Closes #252.

`surface.copyWithin(src, dx, dy)` shifts the pixels of `src` in place with one server-side `CopyArea` of the band that survives the shift — `Window#scrollRegion` for a retained offscreen surface, minus the damage bookkeeping a pixmap does not have. Same semantics: integer deltas only, `src` clamped to the surface, `false` when nothing survives the shift so the caller repaints everything exactly as it would have anyway. The overlapping self-copy is fully defined because pixmap contents cannot be occluded.

The copy goes out with a shared `graphicsExposures: 0` GC — one per app and depth, created on first use and released with the connection, following the upload-GC pattern in image.js — so scrolling never emits a NoExposure event per copy, and callers no longer need the raw AllocID/CreateGC/CopyArea escape hatch from the issue.

Tests run against the in-process JS X server: pixel truth for the shifted band and the untouched exposed strip, request arithmetic for clamping and a two-axis shift, request-free refusals, GC sharing per depth, and an a8 coverage surface that keeps acting as a mask after the scroll.

Docs: new "Scrolling and panning" section in docs/surface.md plus an API entry, cross-linked from scrollRegion in docs/window.md.
