### PR TITLE
feat(context2d): createPattern tiles a surface as one repeating fill

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -23,7 +23,8 @@ ctx.fillRect(0, 0, 100, 100);
 - `ctx.canvas` — the owning drawable (window or pixmap), like in the browser
 - `ctx.width`, `ctx.height` — drawable size
 - `ctx.fillStyle`, `ctx.strokeStyle` — a CSS color string, a premultiplied
-  `[r, g, b, a]` array (0..1 floats), a `CanvasGradient`, or a `Picture`.
+  `[r, g, b, a]` array (0..1 floats), a `CanvasGradient`, a `CanvasPattern`,
+  or a `Picture`.
   Named colors, `rgb[a]()`, `hsl[a]()` and hex in all four lengths
   (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) are accepted; anything
   unparseable throws rather than drawing something arbitrary. See
@@ -126,8 +127,8 @@ to the anchor point, but glyphs are not rotated/scaled — size text via
   transform and a rectangular (or absent) clip sends the whole list as a
   **single `Render.FillRectangles` request**, which is what makes
   many-small-rectangles frames (terminal cell backgrounds, sparkline bars,
-  heat maps, row striping) cheap. Gradient/`Picture` styles, transforms and
-  non-rectangular clips fall back to the per-rectangle loop
+  heat maps, row striping) cheap. Gradient/pattern/`Picture` styles,
+  transforms and non-rectangular clips fall back to the per-rectangle loop
 - `strokeRect(x, y, w, h)` — outlines a rect without touching the current path
 - `clearRect(x, y, w, h)` — resets to nothing (honors clip + transform).
   What "nothing" is depends on the target: **transparent black** on a
@@ -485,6 +486,70 @@ ctx.fillStyle = g;
 
 Gradients are uploaded lazily on first use and freed with the context's
 pictures on GC.
+
+## Patterns
+
+`createPattern(source, repetition)` returns a `CanvasPattern`: a tile the
+server repeats across whatever the pattern fills, in the one composite the
+fill already costs.
+
+```js
+const tile = new Surface(app, { width: 24, height: 24 });
+tile.render((c) => {
+  c.fillStyle = '#d0d4dc';
+  c.fillRect(0, 0, 1, 1); // one dot per 24x24 cell
+});
+
+ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+ctx.fillRect(0, 0, ctx.width, ctx.height); // one request, no mask
+```
+
+That is the difference a background grid notices. Drawn as paths — one
+subpath per dot, batched or not — the grid rasterizes into an a8 coverage
+mask the size of its own bounding box, which for a background *is* the pane,
+then uploads and composites it, every frame. Measured at 1100x700 that grid
+cost ~700 KB and ~25 ms of a ~100 ms frame (issue #263); as a pattern it is
+a tile-sized picture and one `Composite`, and the cost stops scaling with
+the pane. The same applies to checkerboards under transparency, hatched
+chart fills and any texture-shaped background.
+
+- **`source`** is a [`Surface`](surface.md) (pixels the server drew), an
+  [`Image`](images.md) (pixels uploaded from the client), a `Pixmap` or a
+  `Window`. A repeating Picture is created *over* those pixels, so tiling a
+  surface does not change how `drawImage` samples that same surface. A
+  coverage (`a8`) surface is refused: it has no colour to paint with —
+  `drawImage` is what paints coverage in the current `fillStyle`
+- **`repetition`** is `'repeat'` (the default, and what `null` means),
+  `'no-repeat'`, or the two XRender modes the canvas spec has no name for:
+  `'pad'` (clamp to the edge pixels) and `'reflect'` (mirror every other
+  tile). The spec's `'repeat-x'`/`'repeat-y'` are **not** supported —
+  XRender repeats a source picture on both axes or on neither — and throw
+  with the equivalent: tile with `'repeat'` and bound the fill to the one
+  row or column of tiles, `ctx.fillRect(x, y, w, tile.height)`
+- **`pattern.setTransform(matrix)`** positions the tile: `[a, b, c, d, e, f]`
+  or a DOMMatrix-shaped `{a, b, c, d, e, f}` mapping pattern space to user
+  space. Translating by the scroll offset is what keeps a grid glued to the
+  content under it; a zoom step re-renders the tile and keeps the composite
+- The pattern is painted in **user space**: the transform in force at fill
+  time applies to the tile as well as to the shape, so a scaled context
+  scales its grid (this is where patterns differ from the gradients above,
+  whose coordinates are device-space). A transform that collapses (a zero
+  scale) paints nothing, as the canvas spec says
+- Whole-pixel tiling samples with the `nearest` filter — the tile's own
+  pixels, exactly — and anything else (a fractional offset, a scale, a
+  rotation) resamples bilinearly
+- The repeating picture is created on first use. `pattern.destroy()` (or
+  `Symbol.dispose`, or the GC) frees it; the tile it reads is the caller's,
+  and destroying that `Surface`/`Image` while the pattern lives is safe — X
+  keeps pixmap storage alive as long as a picture references it, though the
+  pixels then stop tracking anything drawn afterwards
+- A pattern belongs to the connection, not to the context that created it:
+  one grid tile serves every window on the app, and it outlives
+  `ctx.destroy()`
+
+Patterns work anywhere a colour does — `fillRect`, path fills, strokes,
+`fillText` — and go through the clip, `globalAlpha` and the composite op
+like any other style.
 
 ## Text
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -42,6 +42,11 @@ wnd.map();
   server-side picture for that app's display (uploaded on first call).
   `ctx.drawImage` uses this internally; it is public for manual Render
   compositing
+- `image.pixmap(app)` → [`Pixmap`](pixmap.md) — the drawable those pixels
+  were uploaded to (uploading on first call, like `picture`). It is what
+  building a *second* picture over the same upload needs:
+  [`ctx.createPattern`](context-2d.md#patterns) makes a repeating one there
+  rather than changing how `picture(app)` samples everywhere else
 - `image.destroy()` / `Symbol.dispose` — free the server-side copies
   (safe: the image re-uploads if drawn again). Client-side pixel data stays
   usable; the server resources are also reclaimed by GC as a fallback (see

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -104,6 +104,10 @@ caller's normal job.
   [Scrolling and panning](#scrolling-and-panning-copywithin)
 - `surface.picture(app)` — the server-side Picture, mirroring
   `Image.picture(app)`. Throws for a different connection
+- a surface is also what [`ctx.createPattern`](context-2d.md#patterns) tiles:
+  drawn once, then repeated across a fill by the server. A background grid,
+  a checkerboard or a hatch is a tile-sized surface and one composite,
+  instead of a pane-sized coverage mask per frame
 - `surface.destroy()` / `Symbol.dispose` — free the pixmap and the picture.
   Both carry finalizers, so a dropped surface still releases
 

--- a/examples/pattern-grid.js
+++ b/examples/pattern-grid.js
@@ -1,0 +1,97 @@
+// A pannable graph pane on a tiled background grid (ntk#263): drag to pan.
+//
+// The grid is a 24x24 tile drawn once into a Surface and repeated by the
+// server — one Composite per frame, whatever the pane size. Panning moves
+// the pattern rather than redrawing it: the tile's transform takes the scroll
+// offset, so the grid stays glued to the nodes on top of it.
+//
+// usage: node pattern-grid.js [dot|line|cross]
+import { createClient, Surface } from '../lib/index.js';
+
+const KIND = process.argv[2] || 'dot';
+const PITCH = 24;
+const BG = '#12151c';
+const GRID = '#2c3444';
+
+const app = await createClient();
+const wnd = app.createWindow({ title: 'ntk pattern grid — drag to pan', width: 720, height: 480 });
+wnd.map();
+const ctx = wnd.getContext('2d');
+
+/** the grid cell, drawn once: everything but the ink stays transparent */
+const tile = new Surface(app, { width: PITCH, height: PITCH });
+tile.render((c) => {
+  c.fillStyle = GRID;
+  if (KIND === 'line') {
+    c.fillRect(0, 0, PITCH, 1);
+    c.fillRect(0, 0, 1, PITCH);
+  } else if (KIND === 'cross') {
+    c.fillRect(PITCH / 2 - 3, PITCH / 2, 7, 1);
+    c.fillRect(PITCH / 2, PITCH / 2 - 3, 1, 7);
+  } else {
+    c.fillRect(0, 0, 2, 2);
+  }
+});
+const grid = ctx.createPattern(tile, 'repeat');
+
+const nodes = [
+  { x: 60, y: 60, w: 140, h: 64, label: 'source' },
+  { x: 300, y: 140, w: 140, h: 64, label: 'transform' },
+  { x: 120, y: 280, w: 140, h: 64, label: 'sink' },
+];
+
+let panX = 0;
+let panY = 0;
+
+function draw() {
+  const { width, height } = wnd;
+
+  // background: one fill, one request — the pattern carries the pan, so the
+  // grid scrolls with the nodes without any of it being redrawn
+  ctx.fillStyle = BG;
+  ctx.fillRect(0, 0, width, height);
+  grid.setTransform([1, 0, 0, 1, panX, panY]);
+  ctx.fillStyle = grid;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.save();
+  ctx.translate(panX, panY);
+  ctx.strokeStyle = '#4c9aff';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(nodes[0].x + nodes[0].w, nodes[0].y + nodes[0].h / 2);
+  ctx.lineTo(nodes[1].x, nodes[1].y + nodes[1].h / 2);
+  ctx.moveTo(nodes[1].x, nodes[1].y + nodes[1].h / 2);
+  ctx.lineTo(nodes[2].x + nodes[2].w, nodes[2].y + nodes[2].h / 2);
+  ctx.stroke();
+
+  ctx.font = '14px sans-serif';
+  for (const node of nodes) {
+    ctx.fillStyle = '#1e2534';
+    ctx.beginPath();
+    ctx.roundRect(node.x, node.y, node.w, node.h, 8);
+    ctx.fill();
+    ctx.strokeStyle = '#4c9aff';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.fillStyle = '#dde3ee';
+    ctx.fillText(node.label, node.x + 16, node.y + node.h / 2 + 5);
+  }
+  ctx.restore();
+}
+
+let dragging = null;
+wnd.on('mousedown', (ev) => {
+  dragging = { x: ev.x - panX, y: ev.y - panY };
+});
+wnd.on('mouseup', () => {
+  dragging = null;
+});
+wnd.on('mousemove', (ev) => {
+  if (!dragging) return;
+  panX = ev.x - dragging.x;
+  panY = ev.y - dragging.y;
+  draw();
+});
+wnd.on('expose', draw);
+wnd.on('resize', draw);

--- a/lib/image.js
+++ b/lib/image.js
@@ -79,6 +79,18 @@ export class Image {
     return picture;
   }
 
+  /**
+   * The Pixmap those pixels live in on `app` (uploading on first use, like
+   * `picture`). What it is for is building a *second* Picture over the same
+   * upload — `ctx.createPattern` needs a repeating one, and changing the
+   * cached picture's attributes instead would change how `drawImage` samples
+   * this image everywhere else.
+   */
+  pixmap(app) {
+    this.picture(app);
+    return this._uploads.get(app).pixmap;
+  }
+
   /** free server-side copies of this image (safe to draw again afterwards) */
   destroy() {
     for (const { pixmap, picture } of this._uploads.values()) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ import { cssColor, cssLength } from './widgets/css.js';
 // comes last on purpose: it wraps the 'opengl' factory the indirect one just
 // registered, so that the backend-neutral name can dispatch on glPolicy.
 import './renderingcontext_x11.js';
-import './renderingcontext_2d.js';
+import { CanvasGradient, CanvasPattern } from './renderingcontext_2d.js';
 import './renderingcontext_opengl.js';
 import './renderingcontext_gles.js';
 
@@ -237,6 +237,10 @@ export {
   Pixmap,
   Picture,
   Surface,
+  // fill/stroke styles the 2d context hands back (docs/context-2d.md) —
+  // exported for `instanceof`, not to be constructed directly
+  CanvasGradient,
+  CanvasPattern,
   Image,
   ImageData,
   pixelLayout,

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -26,6 +26,7 @@ import {
 import Picture from "./picture.js";
 import Pixmap from "./pixmap.js";
 import { routeRaster } from "./rasterize.js";
+import { Surface } from "./surface.js";
 import {
   BL,
   BR,
@@ -103,10 +104,90 @@ const gcRegistry = new FinalizationRegistry(({ X, gcs }) => {
  * the type. A `RenderingContext2d` deliberately does not match: its `picture`
  * is a property rather than a method, and it keeps its own branch below.
  */
-/** a fillStyle with a single colour behind it, as opposed to a gradient or a
- * caller-supplied Picture */
+/** a fillStyle with a single colour behind it, as opposed to a gradient, a
+ * pattern or a caller-supplied Picture */
 function isPlainColor(style) {
   return typeof style === "string" || Array.isArray(style);
+}
+
+// `createPattern` repetitions -> XRender Repeat modes. The canvas spec's
+// per-axis 'repeat-x'/'repeat-y' have no mode here (see createPattern);
+// 'pad' and 'reflect' are the two XRender modes the spec has no name for.
+const REPEAT_MODES = {
+  repeat: 1, // Repeat.Normal
+  "no-repeat": 0, // Repeat.None
+  pad: 2, // clamp to the edge pixels
+  reflect: 3, // mirror every other tile
+};
+
+const PATTERN_DOCS =
+  "https://github.com/sidorares/ntk/blob/master/docs/context-2d.md#patterns";
+
+/**
+ * What a pattern tiles: a drawable holding the tile plus the picture format
+ * to read it through. A repeating source Picture is created over it rather
+ * than the source's own picture being changed, so tiling a `Surface` leaves
+ * `drawImage` of that same surface exactly as it was.
+ */
+function patternSourceOf(app, source) {
+  const Render = app.display.Render;
+  const formatFor = (depth) =>
+    depth === 32 ? Render.rgba32 : depth === 8 ? "a8" : Render.rgb24;
+
+  let drawable = null;
+  let width;
+  let height;
+  let format;
+  if (source instanceof Surface) {
+    if (source.app !== app) {
+      throw new Error(
+        "createPattern: the Surface belongs to a different X connection",
+      );
+    }
+    drawable = source.pixmap;
+    format = source.format === "a8" ? "a8" : Render.rgba32;
+    ({ width, height } = source);
+  } else if (source instanceof Image) {
+    drawable = source.pixmap(app);
+    format = Render.rgba32;
+    ({ width, height } = source);
+  } else if (source && typeof source.id === "number") {
+    // a Drawable: a Pixmap, or a Window (through its backing pixmap, which
+    // is where a double-buffered window's current pixels actually are)
+    drawable = source._backing || source;
+    const depth = drawable.depth ?? source.depth;
+    if (!depth) {
+      throw new Error(
+        "createPattern: the drawable's depth is not known yet — await the window's geometry, or pass a Surface",
+      );
+    }
+    format = formatFor(depth);
+    width = drawable.width ?? source.width;
+    height = drawable.height ?? source.height;
+  } else {
+    throw new Error(
+      "createPattern: expected a Surface, an Image, a Pixmap or a Window as the tile, got " +
+        (source === null ? "null" : typeof source),
+    );
+  }
+  if (format === "a8") {
+    throw new Error(
+      "createPattern: a coverage (a8) tile has no colour to paint with — XRender would " +
+        "sample it as black. Draw the tile into an argb32 Surface and tile that, or keep " +
+        `the a8 one and use ctx.drawImage, which paints it in the current fillStyle. ${PATTERN_DOCS}`,
+    );
+  }
+  return { drawable, format, width, height };
+}
+
+/**
+ * Point a pattern's picture transform at the transform in force for this
+ * fill — patterns are painted in user space, so the CTM is part of the
+ * mapping. Returns false when nothing would be painted (a singular matrix),
+ * true for anything else, including every non-pattern style.
+ */
+function preparePattern(src, m) {
+  return src instanceof CanvasPattern ? src._sync(m) : true;
 }
 
 function isPictureSource(image) {
@@ -458,7 +539,11 @@ class RenderingContext2d {
       const c = parseColor(value);
       return this.createSolidPicture(c[0], c[1], c[2], c[3]);
     }
-    if (value instanceof Picture || value instanceof CanvasGradient) {
+    if (
+      value instanceof Picture ||
+      value instanceof CanvasGradient ||
+      value instanceof CanvasPattern
+    ) {
       return value;
     }
     throw new Error("Unknown fill style");
@@ -898,6 +983,7 @@ class RenderingContext2d {
     op = op ?? this._op();
     alpha = alpha ?? this.globalAlpha;
     if (alpha <= 0) return;
+    if (!preparePattern(src, this._m)) return;
 
     // Everything below is bounded to the shape's bounding box rather than
     // the whole surface. On the wire it makes no difference — a Composite
@@ -1325,14 +1411,22 @@ class RenderingContext2d {
     const chunk = 4000 * 6;
     if (direct) {
       for (let i = 0; i < tris.length; i += chunk) {
+        const batch = tris.slice(i, i + chunk);
+        // RENDER aligns the source with the *first triangle's first vertex*,
+        // not with the destination: the source is sampled at
+        // (srcX + x - floor(tris[0].x)). Passing that vertex back is what
+        // makes source coordinates equal destination coordinates, the same
+        // convention drawGlyphRuns and compositeTraps use — without it every
+        // non-constant stroke style (a gradient, a pattern) is offset by
+        // wherever the stroke happens to start, and shifts as it moves.
         this.Render.Triangles(
           op,
           src.id,
-          0,
-          0,
+          Math.floor(batch[0]),
+          Math.floor(batch[1]),
           this.picture.id,
           this.Render.a8,
-          tris.slice(i, i + chunk),
+          batch,
         );
       }
       this._markDirty();
@@ -1463,6 +1557,7 @@ class RenderingContext2d {
   drawGlyphs(op, src, positioned) {
     const app = this.window.app;
     const R = this.Render;
+    if (!preparePattern(src, this._m)) return;
     if (!this._clips.length) {
       drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
       this._markDirty();
@@ -1684,6 +1779,7 @@ class RenderingContext2d {
 
   fillRect(x, y, w, h) {
     if (matIsIdentity(this._m)) {
+      if (!preparePattern(this._backgroundPicture, this._m)) return;
       const mask = this._compositeMask();
       this.Render.Composite(
         this._op(),
@@ -2748,6 +2844,35 @@ class RenderingContext2d {
     return new CanvasGradient("conical", this, x0, y0, angle);
   }
 
+  /**
+   * A tiled paint: `source` repeated across whatever it fills, by the server,
+   * in the one composite the fill already costs (issue #263).
+   *
+   *     const tile = new Surface(app, { width: 24, height: 24 });
+   *     tile.render((c) => { c.fillStyle = '#333'; c.fillRect(0, 0, 1, 1); });
+   *     ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+   *     ctx.fillRect(0, 0, ctx.width, ctx.height);   // one request, no mask
+   *
+   * That is the difference between a background grid costing one repeating
+   * picture and costing a pane-sized coverage mask: drawn as thousands of
+   * tiny subpaths, a dot grid rasterizes client-side into an a8 mask the
+   * size of its own bounding box — which for a background *is* the pane —
+   * then uploads and composites it, every frame.
+   *
+   * `source` is a `Surface` (pixels the server drew), an `Image` (pixels
+   * uploaded from the client), a `Pixmap` or a `Window`.
+   *
+   * `repetition` is `'repeat'` (the default), `'no-repeat'`, or the two
+   * XRender modes the canvas spec has no name for: `'pad'` (clamp to the
+   * edge pixels) and `'reflect'` (mirror every other tile). The spec's
+   * per-axis `'repeat-x'`/`'repeat-y'` are not among them — XRender repeats
+   * a source picture on both axes or on neither — and asking for one throws
+   * with the clip-to-a-strip equivalent.
+   */
+  createPattern(source, repetition = "repeat") {
+    return new CanvasPattern(this.window.app, source, repetition);
+  }
+
   /** the pixel layout of whatever this context currently draws into */
   get _layout() {
     const depth =
@@ -2986,8 +3111,13 @@ class RenderingContext2d {
    * colour to fold into; `_drawCoverage` routes those through the scratch. */
   _coverageSource() {
     const style = this._fillStyle;
-    if (this.globalAlpha >= 1 || !isPlainColor(style))
-      return this._backgroundPicture;
+    if (this.globalAlpha >= 1 || !isPlainColor(style)) {
+      // a pattern whose transform collapsed paints nothing, and "nothing" as
+      // a source is transparent black — no call site here has to know
+      return preparePattern(this._backgroundPicture, this._m)
+        ? this._backgroundPicture
+        : this.createSolidPicture(0, 0, 0, 0);
+    }
     const c = parseColor(style);
     return this.createSolidPicture(c[0], c[1], c[2], c[3] * this.globalAlpha);
   }
@@ -3478,9 +3608,167 @@ class CanvasGradient {
   }
 }
 
+/**
+ * The fill/stroke style `ctx.createPattern` returns: a tile and how it
+ * repeats, backed by one repeating XRender source picture.
+ *
+ * The picture is created on first use and freed by `destroy()` (or by the
+ * GC, through `Picture`'s finalizer). The tile it reads is *not* the
+ * pattern's to free: destroying the `Surface`/`Image` it came from is safe
+ * while the pattern lives — X keeps pixmap storage alive as long as a
+ * picture references it — but the pixels stop tracking anything drawn after.
+ *
+ * A pattern is bound to the connection, not to the context that made it, so
+ * one grid tile serves every window on the app.
+ */
+class CanvasPattern {
+  constructor(app, source, repetition = "repeat") {
+    const name = repetition ?? "repeat";
+    const repeat = REPEAT_MODES[name];
+    if (repeat === undefined) {
+      const known = Object.keys(REPEAT_MODES)
+        .map((k) => `'${k}'`)
+        .join(", ");
+      const axis = name === "repeat-x" || name === "repeat-y";
+      throw new Error(
+        `createPattern: unsupported repetition ${JSON.stringify(name)}` +
+          (axis
+            ? " — XRender repeats a source picture on both axes or on neither, with no" +
+              " per-axis mode to map this one to. Tile with 'repeat' and bound the fill" +
+              " to the one row/column of tiles instead: ctx.fillRect(x, y, w, tile.height)" +
+              " repeats horizontally and nowhere else."
+            : "") +
+          `. Supported: ${known}. ${PATTERN_DOCS}`,
+      );
+    }
+    const { drawable, format, width, height } = patternSourceOf(app, source);
+
+    this.app = app;
+    this.Render = app.display.Render;
+    this.source = source;
+    this.repetition = name;
+    this.width = width;
+    this.height = height;
+    this._repeat = repeat;
+    this._drawable = drawable;
+    this._format = format;
+    // pattern space -> user space, the canvas `CanvasPattern.setTransform`
+    // matrix. The picture transform is its inverse, composed with the CTM.
+    this._m = [1, 0, 0, 1, 0, 0];
+    this._picture = null;
+    // what the server currently holds: a fresh picture is untransformed and
+    // filtered nearest, so an untransformed fill costs no extra request
+    this._applied = [1, 0, 0, 1, 0, 0];
+    this._filter = "nearest";
+  }
+
+  /**
+   * Position/scale/rotate the tile, canvas-style: `matrix` maps pattern
+   * space to user space, as `[a, b, c, d, e, f]` or a DOMMatrix-shaped
+   * `{a, b, c, d, e, f}`. Translating by the scroll offset is what keeps a
+   * grid glued to the content under it.
+   */
+  setTransform(matrix) {
+    const m = Array.isArray(matrix)
+      ? matrix
+      : [matrix.a, matrix.b, matrix.c, matrix.d, matrix.e, matrix.f];
+    if (m.length < 6 || m.some((v) => !Number.isFinite(Number(v)))) {
+      throw new Error(
+        "CanvasPattern.setTransform: expected [a, b, c, d, e, f] or {a, b, c, d, e, f} of finite numbers",
+      );
+    }
+    this._m = m.slice(0, 6).map(Number);
+    return this;
+  }
+
+  /** the repeating source Picture, created on first use */
+  get picture() {
+    if (!this._picture) {
+      this._picture = new Picture(this.app, {
+        drawable: this._drawable,
+        format: this._format,
+        repeat: this._repeat,
+      });
+    }
+    return this._picture;
+  }
+
+  /** the Picture id, which is all a fill needs of a style */
+  get id() {
+    return this.picture.id;
+  }
+
+  /**
+   * Make the server-side mapping match `ctm ∘ patternMatrix`. XRender's
+   * picture transform runs the other way — it takes a coordinate in the
+   * composite's source space (which every fill here keeps equal to device
+   * space) to a texel — so it is the inverse.
+   *
+   * Returns false when that composition collapses (a zero scale), which
+   * paints nothing, exactly as the canvas spec says.
+   */
+  _sync(ctm) {
+    const m = matMultiply(ctm, this._m);
+    const inv = matInvert(m);
+    if (!inv) return false;
+    const a = this._applied;
+    if (
+      inv[0] !== a[0] ||
+      inv[1] !== a[1] ||
+      inv[2] !== a[2] ||
+      inv[3] !== a[3] ||
+      inv[4] !== a[4] ||
+      inv[5] !== a[5]
+    ) {
+      this.Render.SetPictureTransform(this.id, [
+        inv[0],
+        inv[2],
+        inv[4],
+        inv[1],
+        inv[3],
+        inv[5],
+        0,
+        0,
+        1,
+      ]);
+      this._applied = inv;
+    }
+    // A tile landing on whole pixels wants its own pixels back, not a blend
+    // of them: nearest is both exact and cheaper. Anything else is resampled.
+    const filter =
+      m[0] === 1 &&
+      m[1] === 0 &&
+      m[2] === 0 &&
+      m[3] === 1 &&
+      Number.isInteger(m[4]) &&
+      Number.isInteger(m[5])
+        ? "nearest"
+        : "bilinear";
+    if (filter !== this._filter) {
+      this.picture.setFilter(filter);
+      this._filter = filter;
+    }
+    return true;
+  }
+
+  /** free the repeating picture; the tile it read is the caller's */
+  destroy() {
+    if (this._picture) {
+      this._picture.destroy();
+      this._picture = null;
+    }
+    this._applied = [1, 0, 0, 1, 0, 0];
+    this._filter = "nearest";
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
+  }
+}
+
 // register context
 Drawable.renderingContextFactory["2d"] = (window) =>
   new RenderingContext2d(window);
 
 export default RenderingContext2d;
-export { CanvasGradient };
+export { CanvasGradient, CanvasPattern };

--- a/test/pattern.test.js
+++ b/test/pattern.test.js
@@ -1,0 +1,412 @@
+// ctx.createPattern: a tile repeated by the server as one composite, in
+// place of the caller drawing thousands of little subpaths that rasterize
+// client-side into a pane-sized coverage mask (issue #263).
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed. It
+// implements the two things this rests on — Repeat on a source picture and
+// SetPictureTransform — so the tiling can be asserted pixel by pixel.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { CanvasPattern, Image, StaticFontSource, Surface, createClient } from '../lib/index.js';
+
+const docsDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs');
+
+let app = null;
+const W = 64;
+const H = 64;
+
+const RED = [255, 0, 0];
+const BLUE = [0, 0, 255];
+const WHITE = [255, 255, 255];
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+/** a fresh context painted opaque white, so every test owns its pixels */
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+/**
+ * A 4x4 tile: red in the top-left 2x2, blue in the bottom-right 2x2, the
+ * other two quadrants transparent. Every quadrant tells the phase of the
+ * tiling apart from every other, which is what these tests read off.
+ */
+function checkerTile(size = 4) {
+  const half = size / 2;
+  const tile = new Surface(app, { width: size, height: size });
+  tile.render((c) => {
+    c.fillStyle = 'red';
+    c.fillRect(0, 0, half, half);
+    c.fillStyle = 'blue';
+    c.fillRect(half, half, half, half);
+  });
+  return tile;
+}
+
+const pixels = async (ctx) => {
+  const img = await ctx.getImageData(0, 0, W, H);
+  return (x, y) => [...img.data.slice((y * W + x) * 4, (y * W + x) * 4 + 3)];
+};
+
+test('a repeating tile fills the whole rectangle', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+  ctx.fillRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  // every 4x4 cell repeats the tile: (0,0) red, (2,2) blue, (2,0) untouched
+  for (const [ox, oy] of [
+    [0, 0],
+    [16, 0],
+    [0, 20],
+    [60, 60],
+  ]) {
+    assert.deepEqual(at(ox, oy), RED, `red quadrant of the tile at ${ox},${oy}`);
+    assert.deepEqual(at(ox + 2, oy + 2), BLUE, `blue quadrant at ${ox},${oy}`);
+    assert.deepEqual(at(ox + 2, oy), WHITE, `transparent quadrant at ${ox},${oy}`);
+  }
+  tile.destroy();
+});
+
+test('tiling is anchored in user space, not to the rectangle being filled', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+  // a rect starting mid-tile shows the phase of the surface grid, exactly as
+  // a background grid must when it is repainted one damaged strip at a time
+  ctx.fillRect(2, 2, 8, 8);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(2, 2), BLUE, 'the rect starts on the tile blue quadrant');
+  assert.deepEqual(at(4, 4), RED, 'and picks up the next tile at 4,4');
+  assert.deepEqual(at(1, 1), WHITE, 'nothing outside the rect was touched');
+  tile.destroy();
+});
+
+test("'no-repeat' places one tile and leaves the rest of the fill alone", async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  ctx.fillStyle = ctx.createPattern(tile, 'no-repeat');
+  ctx.fillRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(0, 0), RED, 'the one tile is painted');
+  assert.deepEqual(at(3, 3), BLUE);
+  assert.deepEqual(at(4, 0), WHITE, 'and does not repeat');
+  assert.deepEqual(at(0, 4), WHITE);
+  tile.destroy();
+});
+
+test("'pad' extends the edge pixels, 'reflect' mirrors every other tile", async () => {
+  const tile = checkerTile();
+
+  const pad = freshCtx();
+  pad.fillStyle = pad.createPattern(tile, 'pad');
+  pad.fillRect(0, 0, W, H);
+  const padded = await pixels(pad);
+  assert.deepEqual(padded(0, 0), RED, 'the tile itself');
+  assert.deepEqual(padded(20, 1), WHITE, 'the top-right quadrant is transparent, and stays so');
+  assert.deepEqual(padded(20, 3), BLUE, 'the bottom-right edge pixel is held past the tile');
+
+  const reflect = freshCtx();
+  reflect.fillStyle = reflect.createPattern(tile, 'reflect');
+  reflect.fillRect(0, 0, W, H);
+  const mirrored = await pixels(reflect);
+  assert.deepEqual(mirrored(0, 0), RED);
+  // x in [4,8) mirrors x in [0,4): column 7 samples column 0
+  assert.deepEqual(mirrored(7, 0), RED, 'the next tile across is mirrored');
+  assert.deepEqual(mirrored(4, 0), WHITE, 'and column 4 samples column 3');
+  tile.destroy();
+});
+
+test('setTransform moves the tile, which is how a grid follows a scroll', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  const pattern = ctx.createPattern(tile, 'repeat');
+  pattern.setTransform([1, 0, 0, 1, 2, 1]);
+  ctx.fillStyle = pattern;
+  ctx.fillRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(2, 1), RED, 'the tile origin moved to (2,1)');
+  assert.deepEqual(at(0, 0), BLUE, 'and the tile that wrapped in shows its blue quadrant');
+
+  // the DOMMatrix-shaped form is the same matrix
+  pattern.setTransform({ a: 1, b: 0, c: 0, d: 1, e: 2, f: 1 });
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, W, H);
+  ctx.fillStyle = pattern;
+  ctx.fillRect(0, 0, W, H);
+  const again = await pixels(ctx);
+  assert.deepEqual(again(2, 1), RED);
+  tile.destroy();
+});
+
+test('a pattern is painted in user space: the CTM moves it', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+
+  ctx.save();
+  ctx.translate(1, 2);
+  ctx.fillRect(0, 0, 16, 16);
+  ctx.restore();
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(1, 2), RED, 'the tile origin followed the translate');
+  assert.deepEqual(at(3, 4), BLUE);
+  assert.deepEqual(at(0, 0), WHITE, 'and the fill itself moved with it');
+  tile.destroy();
+});
+
+test('a scaled CTM scales the tile with the drawing', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+  ctx.save();
+  ctx.scale(4, 4);
+  ctx.fillRect(0, 0, 8, 8); // 32x32 device pixels, tiles every 16
+  ctx.restore();
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(3, 3), RED, 'the 2x2 red quadrant covers 8x8 device pixels');
+  assert.deepEqual(at(12, 12), BLUE, 'and the blue one lands at 8..15');
+  assert.deepEqual(at(19, 3), RED, 'the second tile starts at 16');
+  tile.destroy();
+});
+
+test('a degenerate pattern transform paints nothing rather than the last one', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  const pattern = ctx.createPattern(tile, 'repeat');
+  pattern.setTransform([0, 0, 0, 0, 0, 0]);
+  ctx.fillStyle = pattern;
+  ctx.fillRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(0, 0), WHITE, 'a collapsed tile has nothing to sample');
+  tile.destroy();
+});
+
+test('patterns fill paths and stroke them, like any other style', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  const pattern = ctx.createPattern(tile, 'repeat');
+
+  ctx.fillStyle = pattern;
+  ctx.beginPath();
+  ctx.arc(20, 20, 10, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = pattern;
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.moveTo(0, 48);
+  ctx.lineTo(W, 48);
+  ctx.stroke();
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(20, 20), RED, 'inside the disc, on a red quadrant');
+  assert.deepEqual(at(22, 22), BLUE, 'and on a blue one two pixels along');
+  assert.deepEqual(at(2, 2), WHITE, 'outside the disc');
+  assert.deepEqual(at(48, 48), RED, 'the stroke picks up the same tiling');
+  tile.destroy();
+});
+
+test('a stroked style samples in canvas space, gradients included', async () => {
+  // RENDER aligns the source of a Triangles request with the first vertex,
+  // so a stroke used to sample its paint from wherever the stroke started —
+  // visible on a pattern as a tile phase that moves with the line, and on a
+  // gradient as a stroke whose colours do not agree with a fill of the same
+  // gradient. Both are the same offset, so assert it on the gradient too.
+  const ctx = freshCtx();
+  const gradient = ctx.createLinearGradient(0, 0, W, 0);
+  gradient.addColorStop(0, 'red');
+  gradient.addColorStop(1, 'blue');
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, W, 8);
+  ctx.strokeStyle = gradient;
+  ctx.lineWidth = 8;
+  ctx.beginPath();
+  ctx.moveTo(0, 20);
+  ctx.lineTo(W, 20);
+  ctx.stroke();
+
+  const at = await pixels(ctx);
+  for (const x of [4, 32, 60]) {
+    const [fr, fg, fb] = at(x, 4);
+    const [sr, sg, sb] = at(x, 20);
+    assert.ok(
+      Math.abs(fr - sr) <= 2 && Math.abs(fg - sg) <= 2 && Math.abs(fb - sb) <= 2,
+      `x=${x}: stroke ${sr},${sg},${sb} matches the fill ${fr},${fg},${fb}`
+    );
+  }
+});
+
+test('globalAlpha applies to a pattern fill', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+  ctx.globalAlpha = 0.5;
+  ctx.fillRect(0, 0, W, H);
+  ctx.globalAlpha = 1;
+
+  const at = await pixels(ctx);
+  const [r, g, b] = at(0, 0);
+  assert.ok(r > 200 && g < 160 && b < 160, `half-strength red over white, got ${r},${g},${b}`);
+  assert.deepEqual(at(2, 0), WHITE, 'the transparent quadrant is still transparent');
+  tile.destroy();
+});
+
+test('a pane-sized pattern fill is one request, whatever the tile pitch', async () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  const pattern = ctx.createPattern(tile, 'repeat');
+  ctx.fillStyle = pattern;
+  // warm up: the repeating picture is created on first use
+  ctx.fillRect(0, 0, 1, 1);
+  await app.X.sync();
+
+  // seq_num counts requests; a client-rasterized grid would show up here as
+  // the PutImage of its mask, and a per-dot one as thousands of composites
+  const before = app.X.seq_num;
+  ctx.fillRect(0, 0, W, H);
+  const emitted = app.X.seq_num - before;
+  await app.X.sync();
+  assert.equal(emitted, 1, 'one Composite covers the pane');
+  tile.destroy();
+});
+
+test('an Image tiles too, over the pixmap its pixels were uploaded to', async () => {
+  const ctx = freshCtx();
+  // 2x2: red, transparent / transparent, blue — straight (non-premultiplied) RGBA
+  const data = Uint8Array.from([
+    255, 0, 0, 255, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 255, 255,
+  ]);
+  const image = new Image({ width: 2, height: 2, data: Buffer.from(data) });
+  ctx.fillStyle = ctx.createPattern(image, 'repeat');
+  ctx.fillRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(0, 0), RED);
+  assert.deepEqual(at(1, 1), BLUE);
+  assert.deepEqual(at(2, 0), RED, 'tiled every 2 pixels');
+  assert.deepEqual(at(1, 0), WHITE, 'the transparent texel leaves the surface alone');
+  // the same upload backs both: a pattern must not re-send the pixels
+  assert.equal(image.pixmap(app), image.pixmap(app));
+  image.destroy();
+});
+
+test('a pattern outlives the context that created it and works on another', async () => {
+  const first = freshCtx();
+  const tile = checkerTile();
+  const pattern = first.createPattern(tile, 'repeat');
+  first.fillStyle = pattern;
+  first.fillRect(0, 0, 8, 8);
+  first.destroy();
+
+  const second = freshCtx();
+  second.fillStyle = pattern;
+  second.fillRect(0, 0, 8, 8);
+  const at = await pixels(second);
+  assert.deepEqual(at(0, 0), RED, 'the same pattern paints on a second context');
+
+  // destroy is idempotent, and the picture comes back if it is used again
+  pattern.destroy();
+  pattern.destroy();
+  const third = freshCtx();
+  third.fillStyle = pattern;
+  third.fillRect(0, 0, 8, 8);
+  const later = await pixels(third);
+  assert.deepEqual(later(2, 2), BLUE, 'a destroyed pattern re-creates its picture on use');
+  pattern.destroy();
+  tile.destroy();
+});
+
+test('a pattern is a CanvasPattern, and an unknown style still throws', () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  assert.ok(ctx.createPattern(tile) instanceof CanvasPattern, "'repeat' is the default");
+  assert.equal(ctx.createPattern(tile, null).repetition, 'repeat', 'null means repeat, per the spec');
+  assert.throws(() => {
+    ctx.fillStyle = { not: 'a style' };
+  }, /Unknown fill style/);
+  tile.destroy();
+});
+
+test('the repetitions XRender has no mode for say what to do instead', () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  for (const repetition of ['repeat-x', 'repeat-y']) {
+    assert.throws(
+      () => ctx.createPattern(tile, repetition),
+      (err) => {
+        assert.match(err.message, /per-axis/, 'names why it cannot be mapped');
+        assert.match(err.message, /tile\.height/, 'and the fillRect that does the same thing');
+        assert.match(err.message, /'repeat'.*'no-repeat'/, 'and lists what is supported');
+        return true;
+      },
+      repetition
+    );
+  }
+  assert.throws(() => ctx.createPattern(tile, 'sideways'), /unsupported repetition "sideways"/);
+  tile.destroy();
+});
+
+test('the docs anchor the pattern errors point at exists', () => {
+  // nothing else in CI checks a doc anchor referenced from a string literal
+  const doc = readFileSync(join(docsDir, 'context-2d.md'), 'utf8');
+  assert.ok(/^## Patterns$/m.test(doc), 'docs/context-2d.md#patterns');
+});
+
+test('a coverage tile is refused, with the two ways to paint one', () => {
+  const ctx = freshCtx();
+  const mask = new Surface(app, { width: 4, height: 4, format: 'a8' });
+  assert.throws(
+    () => ctx.createPattern(mask, 'repeat'),
+    (err) => {
+      assert.match(err.message, /a8/);
+      assert.match(err.message, /drawImage/, 'points at the call that paints coverage');
+      return true;
+    }
+  );
+  mask.destroy();
+});
+
+test('a source that is not a drawable names what would have worked', () => {
+  const ctx = freshCtx();
+  for (const bad of [null, undefined, 42, 'tile.png', {}]) {
+    assert.throws(() => ctx.createPattern(bad, 'repeat'), /expected a Surface, an Image, a Pixmap or a Window/);
+  }
+});
+
+test('setTransform rejects a matrix it cannot use', () => {
+  const ctx = freshCtx();
+  const tile = checkerTile();
+  const pattern = ctx.createPattern(tile, 'repeat');
+  assert.throws(() => pattern.setTransform([1, 0, 0, 1, NaN, 0]), /finite numbers/);
+  assert.throws(() => pattern.setTransform([1, 0, 0, 1]), /finite numbers/);
+  tile.destroy();
+});

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict';
 import { after, before, test } from 'node:test';
 
-import { createClient, HtmlView, MarkdownView, Path2D, SvgView } from '../lib/index.js';
+import { createClient, HtmlView, MarkdownView, Path2D, Surface, SvgView } from '../lib/index.js';
 import { invalidation, withTimeout } from './helpers/async.js';
 
 let app = null;
@@ -293,5 +293,47 @@ test('SvgView draws a document into any 2d context', async (t) => {
   assert.deepEqual(px(image, 64, 32, 32), [255, 0, 0], 'scaled circle center is red');
   assert.deepEqual(px(image, 64, 4, 4), [0, 0, 255], 'background rect is blue');
   assert.deepEqual(px(image, 64, 32, 6), [0, 0, 255], 'above circle is blue');
+  pixmap.destroy();
+});
+
+test('createPattern: a tile repeats across a fill, on a real server', async (t) => {
+  if (skip) return t.skip(skip);
+  const { pixmap, ctx } = freshCtx();
+
+  // 4x4 tile: red top-left quadrant, blue bottom-right, the rest transparent
+  const tile = new Surface(app, { width: 4, height: 4 });
+  tile.render((c) => {
+    c.fillStyle = 'red';
+    c.fillRect(0, 0, 2, 2);
+    c.fillStyle = 'blue';
+    c.fillRect(2, 2, 2, 2);
+  });
+  ctx.fillStyle = ctx.createPattern(tile, 'repeat');
+  ctx.fillRect(0, 0, 32, 32);
+
+  // a stroke samples the same paint in canvas space (RENDER aligns the
+  // source of a Triangles request with its first vertex, not the surface)
+  ctx.lineWidth = 4;
+  ctx.strokeStyle = ctx.fillStyle;
+  ctx.beginPath();
+  ctx.moveTo(0, 50);
+  ctx.lineTo(64, 50);
+  ctx.stroke();
+
+  const image = await readPixels(ctx, 64, 64);
+  for (const [x, y] of [
+    [0, 0],
+    [16, 8],
+    [28, 28],
+  ]) {
+    assert.deepEqual(px(image, 64, x, y), [255, 0, 0], `tile red quadrant at ${x},${y}`);
+    assert.deepEqual(px(image, 64, x + 2, y + 2), [0, 0, 255], `blue quadrant at ${x},${y}`);
+    assert.deepEqual(px(image, 64, x + 2, y), [255, 255, 255], `transparent quadrant at ${x},${y}`);
+  }
+  assert.deepEqual(px(image, 64, 40, 40), [255, 255, 255], 'nothing outside the filled rect');
+  assert.deepEqual(px(image, 64, 48, 48), [255, 0, 0], 'the stroke tiles in canvas space');
+  assert.deepEqual(px(image, 64, 50, 50), [0, 0, 255], 'and shows the next quadrant along');
+
+  tile.destroy();
   pixmap.destroy();
 });


### PR DESCRIPTION
Closes #263.

A background grid at a fixed pitch is thousands of tiny subpaths per full-frame pass. Batched into one path or drawn singly, they rasterize client-side into one a8 coverage mask the size of the ink bbox — which for a background *is* the pane — then upload and composite, every frame.

`ctx.createPattern(source, repetition)` hands the job to Render: a tile-sized repeating picture, composited over the region in the one request the fill already costs.

```js
const tile = new Surface(app, { width: 24, height: 24 });
const c = tile.getContext('2d');
c.fillStyle = '#39445a';
c.fillRect(0, 0, 2, 2);              // one dot per cell
c.destroy();

ctx.fillStyle = ctx.createPattern(tile, 'repeat');
ctx.fillRect(0, 0, ctx.width, ctx.height);   // one Composite, no mask
```

## What it costs

A 1100x700 dot grid at a 24px pitch, drawn into a pixmap on XQuartz, 20 frames each, measured with this branch:

| | per frame | on the wire | requests |
| --- | --- | --- | --- |
| one batched `Path2D` of dots | 12.4 ms | 740.1 KB | 4 |
| `createPattern` | 5.1 ms | 0.1 KB | 3 |

740 KB is the pane-sized a8 mask, and it does not shrink when the caller batches better — it is the pane. The pattern's wire cost stops scaling with the pane entirely.

## The seam

- **`source`** is a `Surface`, an `Image`, a `Pixmap` or a `Window`. A repeating Picture is created *over* those pixels rather than the source's own picture being changed, so tiling a surface leaves `drawImage` of that same surface exactly as it was. `Image` grew `image.pixmap(app)` for this — the upload it already has, so a pattern re-sends nothing.
- **`repetition`** is `'repeat'`, `'no-repeat'`, plus the two XRender modes the canvas spec has no name for: `'pad'` and `'reflect'`. The spec's per-axis `'repeat-x'`/`'repeat-y'` have no XRender equivalent — a source picture repeats on both axes or on neither — so they throw, naming the fix: tile with `'repeat'` and bound the fill to the one row of tiles. A coverage tile is refused for a related reason: a8 has no colour to paint with, and `drawImage` is what paints coverage in the current `fillStyle`.
- **Painted in user space.** The CTM at fill time applies to the tile as well as to the shape, so a scaled context scales its grid; `pattern.setTransform` positions the tile on top of that, which is how a grid stays glued to a scrolled viewport. Whole-pixel tiling samples `nearest`, anything else bilinear. A collapsed transform paints nothing, as the spec says.
- Patterns work anywhere a colour does — `fillRect`, path fills, strokes, `fillText` — through the clip, `globalAlpha` and the composite op.

## A stroke-alignment fix that came with it

RENDER samples the source of a `Triangles` request relative to the **first triangle's first vertex**, not the destination, and the direct stroke path passed `0, 0`. Solid colours never noticed; a gradient stroke sampled its colours from wherever the stroke happened to start and disagreed with a fill of the same gradient, and moving the line shifted them. Passing that vertex back is the convention `drawGlyphRuns` and `compositeTraps` already use, and there is a test pinning a gradient stroke to a gradient fill of the same object.

## Pictures

Both rendered by this branch's own code, headless: drawn into a pixmap, read back with `getImageData`, written with `pngjs`.

A pannable graph pane on a tiled dot grid — the whole background is one `fillRect` — the same scene as the new `examples/pattern-grid.js`:

<img width="720" alt="pannable graph pane on a tiled dot grid" src="https://github.com/user-attachments/assets/a8db0a0e-7a62-4e07-8ed8-4d13af105a8a" />

The tile is whatever you draw: grid kinds, a checkerboard under transparency, a hatch, and the same hatch tile with `'reflect'` instead of `'repeat'`:

<img width="720" alt="dot, line, cross, checkerboard, hatch and reflected hatch tiles" src="https://github.com/user-attachments/assets/c8eb0499-1659-4cbb-ad3f-40561e48e23c" />

## Tests

- `test/pattern.test.js` — 20 hermetic tests against node-x11's pure-JS X server, which implements both things this rests on: tiling and phase, anchoring in user space rather than to the rectangle, `no-repeat`/`pad`/`reflect`, `setTransform` in both matrix forms, CTM translate and scale, a degenerate transform, path fills and strokes, `globalAlpha`, an `Image` tile, one-request-per-pane-fill, lifetime across contexts, and every error message including the docs anchor it points at.
- `test/smoke-canvas.test.js` — the same tiling and the stroke alignment against a real X server.
- `npm test`: 950 tests, 946 pass, 3 skipped; the one failure is the pre-existing `glx.test.js` case that assumes a server with indirect GLX disabled, which XQuartz is not — it fails the same way on `master`.

## Docs

`docs/context-2d.md` gets a Patterns section, with the fillStyle and `fillRects` bullets updated; `docs/images.md` documents `image.pixmap(app)`; `docs/surface.md` notes that a surface is what a pattern tiles.
