### PR TITLE
feat(fonts): an async matchSorted, so a font picker stops blocking on fc-match

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -44,6 +44,20 @@ regular weight) is prewarmed with a non-blocking `fc-match` while
 spawn. Other patterns still pay one synchronous `fc-match` (~50ms) the
 first time they are used.
 
+Text layout is synchronous, so it always pays that cost inline. Code that
+can await — a font picker matching as the user types, a preferences page —
+should ask the source instead, and not block the event loop at all:
+
+```js
+const source = app.fonts.source;                       // or defaultFontSource()
+const candidates = await source.matchSortedAsync({ family: 'Iosevka' });
+```
+
+The spawn runs off the event loop and seeds the same cache, so a later
+layout for that pattern is a cache hit. Every source implements it, including
+`StaticFontSource` (which resolves immediately), so the calling code does not
+have to know which one it is holding.
+
 ## Loading a font file directly
 
 ```js
@@ -107,6 +121,10 @@ A source is any object with:
   of `path` (font file, node only), `data` (font file bytes) or `font` (an
   open `Font`) says how to open it; `family`/`families` say what to call it
   (see [Naming a match](#naming-a-match)).
+- `matchSortedAsync({ family, weight, style })` → a promise for the same
+  list. Layout always uses the synchronous one; this is the entry point for
+  an app that can await, and it rejects with the same `ERR_NTK_NO_FONTS`
+  rather than deferring the failure to a blocking call.
 - `covers(candidate, codepoint)` → boolean *(optional)* — cheap coverage
   pre-filter for fallback; when absent, candidates are opened and checked
   with `hasGlyph()`.
@@ -134,6 +152,10 @@ Neither field is needed to *choose* a font — the machinery matches on paths
 and coverage — which is why the cost matters: naming the list by opening it
 is ~1.2ms per file, and `sans-serif` matches 139 faces on a stock macOS box.
 fontconfig hands both names over in the same call as the rest of the match.
+
+A picker showing that list is also the caller that should not be blocking on
+it: `matchSortedAsync` returns the same named candidates without the
+synchronous spawn.
 
 Related environment hooks: `app.fonts.load()` accepts font bytes as well as
 a path, and `loadImage()` accepts encoded bytes — so an app that ships its

--- a/lib/fontconfig.js
+++ b/lib/fontconfig.js
@@ -7,13 +7,12 @@ function childProcess() {
   return builtin('node:child_process');
 }
 
+const NOT_NODE =
+  'fontconfig matching needs node (the fc-match CLI) and this is not a node environment';
+
 function execFileSync(...args) {
   const cp = childProcess();
-  if (!cp) {
-    throw noFontsError(
-      'fontconfig matching needs node (the fc-match CLI) and this is not a node environment'
-    );
-  }
+  if (!cp) throw noFontsError(NOT_NODE);
   return cp.execFileSync(...args);
 }
 
@@ -88,15 +87,50 @@ const sortedCache = new Map();
 let unavailable = null;
 
 /**
+ * The exit code fc-match left, or null if the child never ran at all.
+ *
+ * The two exec flavours report it differently: execFileSync puts it in
+ * `status` and leaves `code` for the spawn failure, while execFile puts both
+ * in `code`. Normalized here so one diagnosis serves the sync and async
+ * paths rather than two that can drift apart.
+ */
+function exitStatus(err) {
+  if (err.status != null) return err.status;
+  return typeof err.code === 'number' ? err.code : null;
+}
+
+/**
  * Did the spawn itself fail, as opposed to fc-match running and being
- * unhappy? `status` is null only when the child never ran, and these are the
- * codes that mean "no usable binary at this name" rather than a transient
- * failure worth reporting verbatim.
+ * unhappy? No exit code means the child never ran, and these are the codes
+ * that mean "no usable binary at this name" rather than a transient failure
+ * worth reporting verbatim.
  */
 function isSpawnFailure(err) {
-  return (
-    err.status == null && ['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR'].includes(err.code)
-  );
+  return exitStatus(err) == null && ['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR'].includes(err.code);
+}
+
+/**
+ * An fc-match failure -> the error to report for it.
+ *
+ * Only a path that actually reports belongs here: a missing binary is
+ * memoized in `unavailable` on the way through, which is exactly what
+ * `prewarm` must not do (see there). It swallows the raw failure instead.
+ */
+function fcMatchError(err) {
+  if (err.code === 'ERR_NTK_NO_FONTS') return err; // no child_process at all
+  if (isSpawnFailure(err)) {
+    unavailable = 'the fc-match CLI (fontconfig) is not installed here';
+    return noFontsError(unavailable, err);
+  }
+  const status = exitStatus(err);
+  if (status != null) {
+    // fontconfig is installed and said no — an image with fontconfig but no
+    // font package answers "No fonts installed on the system" and exits 1.
+    // Not memoized: unlike a missing binary this can depend on the pattern.
+    const stderr = String(err.stderr || '').trim().split('\n')[0];
+    return noFontsError(`fc-match exited ${status}${stderr ? `: ${stderr}` : ''}`, err);
+  }
+  return err;
 }
 
 function patternFor({ family, weight, style }) {
@@ -145,7 +179,55 @@ function parseMatches(out) {
   return list;
 }
 
-const prewarming = new Map();
+/**
+ * fc-match output -> the cached candidate list for a pattern. Throws for
+ * output that parses to nothing usable, which is a fontconfig answer rather
+ * than a fontconfig failure and so is diagnosed separately.
+ */
+function cacheMatches(fc, out) {
+  const list = parseMatches(out);
+  if (list.length === 0) {
+    throw noFontsError(
+      `fontconfig matched no font ntk can parse for "${fc}" (needs ` +
+        '.ttf/.otf/.woff/.woff2/.ttc/.dfont — bitmap .pcf/.bdf fonts are not usable)'
+    );
+  }
+  sortedCache.set(fc, list);
+  return list;
+}
+
+const inflight = new Map();
+
+/**
+ * fc-match for a pattern, off the event loop — one child per pattern however
+ * many callers ask at once, so a prewarm and an awaiting `matchSorted` share
+ * a single spawn instead of racing two.
+ *
+ * Rejects with the *raw* failure, undiagnosed: `fcMatchError` memoizes a
+ * missing binary, and whether that should happen is the caller's decision,
+ * not this one's.
+ *
+ * @returns {Promise<string>} raw fc-match stdout
+ */
+function runFcMatch(fc) {
+  const pending = inflight.get(fc);
+  if (pending) return pending;
+  const cp = childProcess();
+  if (!cp) return Promise.reject(noFontsError(NOT_NODE));
+
+  const promise = new Promise((resolve, reject) => {
+    cp.execFile('fc-match', [...fcMatchArgs, fc], fcMatchOpts, (err, out, stderr) => {
+      inflight.delete(fc);
+      if (!err) return resolve(out);
+      // execFile hands stderr to the callback; execFileSync hangs it on the
+      // error, which is where the shared diagnosis reads it from
+      if (err.stderr === undefined) err.stderr = stderr;
+      reject(err);
+    });
+  });
+  inflight.set(fc, promise);
+  return promise;
+}
 
 /**
  * Seed the match cache for a pattern ahead of time, off the event loop.
@@ -166,29 +248,60 @@ const prewarming = new Map();
  * A sync call racing this one wins — the child's result is discarded
  * whenever the pattern is already cached by the time it exits.
  *
+ * `matchSorted` is the reporting variant: same spawn, same cache, but it
+ * awaits an answer and so has somewhere to put a failure.
+ *
  * @returns {Promise<void>} resolves once the cache is seeded or the attempt
  *   abandoned
  */
 export function prewarm(pattern = {}) {
   const fc = patternFor(pattern);
   if (sortedCache.has(fc) || unavailable) return Promise.resolve();
-  const inflight = prewarming.get(fc);
-  if (inflight) return inflight;
-  const cp = childProcess();
-  if (!cp) return Promise.resolve();
-
-  const promise = new Promise((resolve) => {
-    cp.execFile('fc-match', [...fcMatchArgs, fc], fcMatchOpts, (err, out) => {
-      prewarming.delete(fc);
-      if (!err && !sortedCache.has(fc)) {
+  return runFcMatch(fc).then(
+    (out) => {
+      if (!sortedCache.has(fc)) {
         const list = parseMatches(out);
         if (list.length > 0) sortedCache.set(fc, list);
       }
-      resolve();
-    });
-  });
-  prewarming.set(fc, promise);
-  return promise;
+    },
+    () => {}
+  );
+}
+
+/**
+ * The same match list as `matchSortedSync`, without blocking for it.
+ *
+ * For a caller that is not inside text layout — a font picker matching as
+ * the user types, a preferences page, anything that can await — the sync
+ * spawn is ~100ms of stalled event loop per new pattern and buys nothing.
+ * This runs the identical command through `execFile` instead, shares the
+ * spawn with any prewarm already in flight for the pattern, and fills the
+ * same cache, so a later layout answers from memory.
+ *
+ * Unlike `prewarm` it reports: a missing fc-match rejects here rather than
+ * resolving quietly and leaving the diagnosis to a blocking sync call
+ * afterwards. Rejections carry `code: 'ERR_NTK_NO_FONTS'` exactly as the
+ * sync throws do.
+ *
+ * @returns {Promise<Array<{path, postscriptName, family: string,
+ *   families: string[], charset: string}>>}
+ */
+export async function matchSorted(pattern = {}) {
+  const fc = patternFor(pattern);
+  const cached = sortedCache.get(fc);
+  if (cached) return cached;
+  if (unavailable) throw noFontsError(unavailable);
+
+  let out;
+  try {
+    out = await runFcMatch(fc);
+  } catch (err) {
+    throw fcMatchError(err);
+  }
+  // A sync call may have answered this pattern while the child ran. Its list
+  // is the cached one, and candidates memoize their parsed charset, so hand
+  // back what everyone else already holds rather than a fresh copy.
+  return sortedCache.get(fc) ?? cacheMatches(fc, out);
 }
 
 /**
@@ -201,44 +314,25 @@ export function prewarm(pattern = {}) {
  * candidates here, and `Font.loadSync` is ~1.2ms a file).
  *
  * Cached per pattern; one fc-match invocation (~50ms) per distinct pattern.
+ * Synchronous because its main caller is text layout, which cannot await;
+ * a caller that can should use `matchSorted` and not block on the spawn.
  *
  * @returns {Array<{path, postscriptName, family: string, families: string[],
  *   charset: string}>}
  */
 export function matchSortedSync(pattern) {
   const fc = patternFor(pattern);
-  let list = sortedCache.get(fc);
-  if (list) return list;
+  const cached = sortedCache.get(fc);
+  if (cached) return cached;
   if (unavailable) throw noFontsError(unavailable);
 
   let out;
   try {
     out = execFileSync('fc-match', [...fcMatchArgs, fc], fcMatchOpts);
   } catch (err) {
-    if (err.code === 'ERR_NTK_NO_FONTS') throw err; // no child_process at all
-    if (isSpawnFailure(err)) {
-      unavailable = 'the fc-match CLI (fontconfig) is not installed here';
-      throw noFontsError(unavailable, err);
-    }
-    if (err.status != null) {
-      // fontconfig is installed and said no — an image with fontconfig but no
-      // font package answers "No fonts installed on the system" and exits 1.
-      // Not memoized: unlike a missing binary this can depend on the pattern.
-      const stderr = String(err.stderr || '').trim().split('\n')[0];
-      throw noFontsError(`fc-match exited ${err.status}${stderr ? `: ${stderr}` : ''}`, err);
-    }
-    throw err;
+    throw fcMatchError(err);
   }
-
-  list = parseMatches(out);
-  if (list.length === 0) {
-    throw noFontsError(
-      `fontconfig matched no font ntk can parse for "${fc}" (needs ` +
-        '.ttf/.otf/.woff/.woff2/.ttc/.dfont — bitmap .pcf/.bdf fonts are not usable)'
-    );
-  }
-  sortedCache.set(fc, list);
-  return list;
+  return cacheMatches(fc, out);
 }
 
 /**

--- a/lib/text/fontsource.js
+++ b/lib/text/fontsource.js
@@ -18,6 +18,14 @@
 //       opening every file in it; `families` its aliases, first one first
 //       (both optional, but both sources here fill them in)
 //
+//   matchSortedAsync({ family, weight, style }) -> Promise<candidate[]>
+//     The same answer, awaited. Text layout is synchronous and always calls
+//     matchSorted; this is for an app asking a source directly — a font
+//     picker matching as the user types — where the fontconfig source's
+//     ~100ms spawn has no business blocking the event loop. A source with
+//     nothing to await implements it by resolving immediately, so a caller
+//     can be written once against either.
+//
 //   covers(candidate, codepoint) -> boolean   [optional]
 //     Cheap coverage pre-filter used during per-codepoint fallback, ideally
 //     without opening the font. When absent, candidates are opened and
@@ -38,7 +46,14 @@
 // — its whole purpose is running the text stack without a filesystem. See
 // builtin.js for how the lazy lookup stays version-tolerant.
 import { builtin } from '../builtin.js';
-import { charsetHas, matchSortedSync, noFontsError, prewarm, supported } from '../fontconfig.js';
+import {
+  charsetHas,
+  matchSorted,
+  matchSortedSync,
+  noFontsError,
+  prewarm,
+  supported
+} from '../fontconfig.js';
 import Font from './font.js';
 
 const WEIGHTS = { normal: 400, bold: 700 };
@@ -112,6 +127,16 @@ export class FontconfigFontSource {
 
   matchSorted(pattern) {
     return matchSortedSync(pattern);
+  }
+
+  /**
+   * Non-blocking sibling: the fc-match spawn runs off the event loop and
+   * seeds the same cache, so a later synchronous layout for the pattern is
+   * a cache hit. Rejects with the same ERR_NTK_NO_FONTS the sync path
+   * throws — the failure case must not be the one that blocks.
+   */
+  matchSortedAsync(pattern) {
+    return matchSorted(pattern);
   }
 
   covers(candidate, codepoint) {
@@ -252,6 +277,14 @@ export class StaticFontSource {
       }
       return face.candidate;
     });
+  }
+
+  /**
+   * Nothing here is off-process, so matching is already instant — this
+   * exists so an app can await either source without asking which it has.
+   */
+  async matchSortedAsync(pattern = {}) {
+    return this.matchSorted(pattern);
   }
 
   covers(candidate, codepoint) {

--- a/test/fontconfig.test.js
+++ b/test/fontconfig.test.js
@@ -140,7 +140,7 @@ function prewarmProbe(body, stubs = {}) {
   const script = join(dir, 'probe.mjs');
   writeFileSync(
     script,
-    `import { matchSortedSync, prewarm } from ${JSON.stringify(join(root, 'lib/fontconfig.js'))};\n` +
+    `import { matchSorted, matchSortedSync, prewarm } from ${JSON.stringify(join(root, 'lib/fontconfig.js'))};\n` +
       `import { FontconfigFontSource } from ${JSON.stringify(join(root, 'lib/text/fontsource.js'))};\n` +
       `const BIN = ${JSON.stringify(bins)};\n` +
       `const EMPTY = ${JSON.stringify(empty)};\n` +
@@ -273,6 +273,133 @@ test('a face fontconfig cannot name is not a parse failure', () => {
   assert.equal(out.path, '/f/A.ttf', 'the match is still usable');
   assert.equal(out.family, '');
   assert.deepEqual(out.families, []);
+});
+
+// The async entry point (issue #274): the same fc-match, the same cache, for
+// a caller that is not text layout — a font picker matching as the user
+// types has no reason to block the event loop for ~100ms per new pattern.
+
+test('matchSorted answers off the event loop and seeds the sync cache', () => {
+  const out = prewarmProbe(
+    "import { readFileSync } from 'node:fs';\n" +
+      "import { join } from 'node:path';\n" +
+      'process.env.PATH = BIN.count;\n' +
+      'const list = await matchSorted(PATTERN);\n' +
+      'process.env.PATH = EMPTY; // any spawn after this point would throw ENOENT\n' +
+      'const [best] = matchSortedSync(PATTERN);\n' +
+      "const spawns = readFileSync(join(BIN.count, 'fc-match.spawns'), 'utf8').trim().split('\\n').length;\n" +
+      'console.log(JSON.stringify({ async: list[0].path, sync: best.path, spawns }));\n',
+    { count: counting('/awaited/A.ttf') }
+  );
+  assert.equal(out.async, '/awaited/A.ttf');
+  assert.equal(out.sync, '/awaited/A.ttf', 'the sync path answers from the cache it seeded');
+  assert.equal(out.spawns, 1);
+});
+
+test('matchSorted joins an in-flight prewarm rather than spawning again', () => {
+  const out = prewarmProbe(
+    "import { readFileSync } from 'node:fs';\n" +
+      "import { join } from 'node:path';\n" +
+      'process.env.PATH = BIN.slow;\n' +
+      'const warmed = prewarm(PATTERN); // spawns now, answers in ~300ms\n' +
+      'const list = await matchSorted(PATTERN); // must wait on that child, not start one\n' +
+      'await warmed;\n' +
+      "const spawns = readFileSync(join(BIN.slow, 'fc-match.spawns'), 'utf8').trim().split('\\n').length;\n" +
+      'console.log(JSON.stringify({ path: list[0].path, spawns }));\n',
+    {
+      slow:
+        '#!/bin/sh\n' +
+        'echo x >> "$0.spawns"\n' +
+        '{ /bin/sleep 0.3 || /usr/bin/sleep 0.3; } 2>/dev/null\n' +
+        'printf "/shared/A.ttf\\tShared\\tShared Family\\t20-7e\\n"\n'
+    }
+  );
+  assert.equal(out.path, '/shared/A.ttf');
+  assert.equal(out.spawns, 1, 'one child serves both callers');
+});
+
+// The error path is the point of the exercise: prewarm deliberately stays
+// silent, so `await prewarm(); matchSortedSync()` would pay a *blocking*
+// spawn exactly when fontconfig is missing — the failure case blocking is
+// backwards. matchSorted reports its own failure instead.
+test('a missing fc-match rejects matchSorted, and is not re-spawned after', () => {
+  const out = prewarmProbe(
+    '// PATH is still EMPTY: the spawn fails with ENOENT\n' +
+      'const results = [];\n' +
+      'try {\n' +
+      '  await matchSorted(PATTERN);\n' +
+      '  results.push({ ok: true });\n' +
+      '} catch (err) {\n' +
+      '  results.push({ code: err.code, cause: err.cause?.code });\n' +
+      '}\n' +
+      'try {\n' +
+      '  matchSortedSync(PATTERN);\n' +
+      '  results.push({ ok: true });\n' +
+      '} catch (err) {\n' +
+      '  results.push({ code: err.code, cause: err.cause?.code });\n' +
+      '}\n' +
+      'console.log(JSON.stringify(results));\n'
+  );
+  const [async_, sync] = out;
+  assert.equal(async_.code, 'ERR_NTK_NO_FONTS');
+  assert.equal(async_.cause, 'ENOENT', 'the rejection carries the original spawn failure');
+  assert.equal(sync.code, 'ERR_NTK_NO_FONTS');
+  assert.equal(
+    sync.cause,
+    undefined,
+    'the async failure memoized the missing binary: no second spawn, blocking or otherwise'
+  );
+});
+
+// execFileSync reports an exit code in `status`, execFile in `code` — the
+// same diagnosis has to read both, or a fontconfig that ran and said no
+// surfaces as a raw exec error from the async path.
+test('matchSorted reports an unhappy fc-match the same way the sync path does', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.nofonts;\n' +
+      'let result;\n' +
+      'try {\n' +
+      '  await matchSorted(PATTERN);\n' +
+      '  result = { ok: true };\n' +
+      '} catch (err) {\n' +
+      '  result = { code: err.code, message: err.message };\n' +
+      '}\n' +
+      'console.log(JSON.stringify(result));\n',
+    { nofonts: '#!/bin/sh\necho "No fonts installed on the system" >&2\nexit 1\n' }
+  );
+  assert.equal(out.code, 'ERR_NTK_NO_FONTS');
+  assert.match(out.message, /fc-match exited 1: No fonts installed on the system/);
+});
+
+test('matchSorted rejects for matches ntk cannot parse', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.bitmap;\n' +
+      'let result;\n' +
+      'try {\n' +
+      '  await matchSorted(PATTERN);\n' +
+      '  result = { ok: true };\n' +
+      '} catch (err) {\n' +
+      '  result = { code: err.code, message: err.message };\n' +
+      '}\n' +
+      'console.log(JSON.stringify(result));\n',
+    { bitmap: '#!/bin/sh\nprintf "/usr/share/fonts/misc/fixed.pcf\\tFixed\\tFixed\\t20-7e\\n"\n' }
+  );
+  assert.equal(out.code, 'ERR_NTK_NO_FONTS');
+  assert.match(out.message, /matched no font ntk can parse/);
+});
+
+test('FontconfigFontSource.matchSortedAsync is the same list as matchSorted', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.warm;\n' +
+      'const source = new FontconfigFontSource();\n' +
+      'const list = await source.matchSortedAsync(PATTERN);\n' +
+      'process.env.PATH = EMPTY;\n' +
+      'const same = source.matchSorted(PATTERN) === list;\n' +
+      'console.log(JSON.stringify({ path: list[0].path, same }));\n',
+    { warm: counting('/source/A.ttf') }
+  );
+  assert.equal(out.path, '/source/A.ttf');
+  assert.equal(out.same, true, 'both spellings answer with the one cached list');
 });
 
 test('the docs anchor the error points at exists', () => {

--- a/test/fontsource.test.js
+++ b/test/fontsource.test.js
@@ -254,6 +254,23 @@ test('a spec mistake is reported as a spec mistake', () => {
   assert.throws(() => createFontSource(42), (err) => err.code !== 'ERR_NTK_NO_FONTS');
 });
 
+// A caller that can await (a font picker matching as the user types) asks
+// the source instead of blocking. It must not have to know which source it
+// is holding, so the one with nothing to await implements it too — and its
+// failures arrive as rejections, not synchronous throws.
+test('StaticFontSource.matchSortedAsync mirrors the sync match', async () => {
+  const source = staticSource();
+  const sync = source.matchSorted({ family: 'Test AMS' });
+  const async_ = await source.matchSortedAsync({ family: 'Test AMS' });
+  assert.deepEqual(async_, sync);
+  assert.equal(async_[0].font.postscriptName, 'KaTeX_AMS-Regular');
+
+  await assert.rejects(
+    new StaticFontSource().matchSortedAsync({}),
+    (err) => err.code === 'ERR_NTK_NO_FONTS'
+  );
+});
+
 test('an empty source reports having no fonts, with the shared code', () => {
   assert.throws(
     () => new StaticFontSource().matchSorted({}),


### PR DESCRIPTION
Closes #274.

`matchSortedSync` was the only way to ask for a match list, and it is `execFileSync` — ~109ms of stalled event loop per cold pattern. That is correct for its main caller, text layout, which cannot await. An application asking *"what matches this pattern"* — the font explorer in react-x11#344, matching on every keystroke — is not inside layout and has no reason to block.

The work was already written. `prewarm` runs the same command through the non-blocking `execFile`, parses with the same `parseMatches`, and seeds the same cache; it just resolves `void` and tells nobody what it found.

## What this adds

- **`matchSorted(pattern)`** in `lib/fontconfig.js`, the awaited sibling of `matchSortedSync`. Same command, same cache, same candidate identity — a later synchronous layout for that pattern is a cache hit, and if a sync call answered the pattern mid-flight it hands back the list everyone else already holds rather than a fresh copy.
- **One child per pattern across both async callers.** A `matchSorted` issued while the source constructor's prewarm is still in flight waits on that spawn instead of starting a second one.
- **`matchSortedAsync` on both sources.** `FontconfigFontSource` delegates; `StaticFontSource` has nothing to await and resolves immediately, so a caller can be written once against either. `matchSorted` stays the synchronous interface method — layout still calls it, unchanged.

```js
const source = app.fonts.source;
const candidates = await source.matchSortedAsync({ family: 'Iosevka' });
```

## The error path

This was the decision the issue left open. `prewarm` deliberately never rejects and never memoizes a missing binary, because a prewarm is an optimization — so the naive `await prewarm(); matchSortedSync();` still pays one **blocking** spawn precisely when fontconfig is missing. The failure case blocking is backwards.

So `matchSorted` reports instead of prewarming: it rejects with the same `ERR_NTK_NO_FONTS` the sync path throws, original spawn failure preserved as `cause`, and memoizes the missing binary so nothing spawns again — blocking or otherwise. `prewarm` keeps its silence and its documented contract.

One wrinkle worth naming: the two exec flavours disagree about where a failure lives. `execFileSync` puts the exit code in `status` and leaves `code` for the spawn failure; `execFile` reuses `code` for both and hands stderr to the callback rather than the error. Left alone, a fontconfig that ran and said no would surface from the async path as a raw exec error. The diagnosis is now normalized and shared by both paths rather than written twice — which also collapsed the duplicated parse-and-cache tail.

## Tests

Six new probes in `test/fontconfig.test.js`, on the existing PATH-swapping harness so they run with or without fontconfig installed: the async path seeds the cache the sync path reads with exactly one spawn; a `matchSorted` joins an in-flight prewarm instead of spawning again; a missing `fc-match` rejects and is *not* re-spawned by the sync call afterwards; an unhappy `fc-match` and unparseable matches are reported identically to the sync path; and the source method answers with the one cached list. Plus one in `test/fontsource.test.js` for the `StaticFontSource` variant, including its rejection.

`npm test`: 878 pass, 3 skipped. The one failure, `glx.test.js` "getContext at 'opengl' fails with a diagnosis", is pre-existing on `master` in this XQuartz environment — no `+iglx`.

Nothing visual to screenshot; `docs/fonts.md` documents the new entry point and the source-interface method.
