### PR TITLE
feat(fonts): fc-match answers with the family name too

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -102,12 +102,38 @@ A source is any object with:
 
 - `matchSorted({ family, weight, style })` → non-empty array of candidates,
   best first — the fallback chain. `family` may be a comma-separated list.
-  A candidate is `{ key?, path?, data?, font?, postscriptName? }` — one of
-  `path` (font file, node only), `data` (font file bytes) or `font` (an
-  open `Font`).
+  A candidate is
+  `{ key?, path?, data?, font?, postscriptName?, family?, families? }` — one
+  of `path` (font file, node only), `data` (font file bytes) or `font` (an
+  open `Font`) says how to open it; `family`/`families` say what to call it
+  (see [Naming a match](#naming-a-match)).
 - `covers(candidate, codepoint)` → boolean *(optional)* — cheap coverage
   pre-filter for fallback; when absent, candidates are opened and checked
   with `hasGlyph()`.
+
+### Naming a match
+
+Every candidate carries the family name its source already knew, so a match
+list can be *shown* — a font picker, a specimen, or a diagnostic answering
+"which face did `sans-serif` actually resolve to" — without opening the
+files:
+
+```js
+const ranked = app.fonts.source.matchSorted({ family: 'sans-serif' });
+for (const c of ranked.slice(0, 5)) console.log(c.family, '—', c.path);
+```
+
+- `family` — the name to display. From fontconfig this is the first name in
+  its family list, which is the one it leads with for the current locale.
+- `families` — every name the face answers to, in fontconfig's order.
+  Families are a list there: `Hiragino Sans`, `ヒラギノ角ゴシック` and the
+  style-suffixed forms of both are one face. A `StaticFontSource` candidate
+  has a one-element list.
+
+Neither field is needed to *choose* a font — the machinery matches on paths
+and coverage — which is why the cost matters: naming the list by opening it
+is ~1.2ms per file, and `sans-serif` matches 139 faces on a stock macOS box.
+fontconfig hands both names over in the same call as the rest of the match.
 
 Related environment hooks: `app.fonts.load()` accepts font bytes as well as
 a path, and `loadImage()` accepts encoded bytes — so an app that ships its

--- a/docs/text.md
+++ b/docs/text.md
@@ -486,8 +486,9 @@ resolved in 2026:
   No native dependency needed.
 - **#11 char coverage / #18 substituteFont** — both asked for
   `font-manager` (a native module). Solved instead with fontconfig's CLI:
-  `fc-match -s --format '%{file}\t%{postscriptname}\t%{charset}\n'` returns
-  the whole fallback chain *with coverage data* in one ~50ms call (cached).
+  `fc-match -s --format '%{file}\t%{postscriptname}\t%{family}\t%{charset}\n'`
+  returns the whole fallback chain *with coverage data and names* in one
+  ~50ms call (cached).
   `fontkit.hasGlyphForCodePoint` confirms before use.
 - **#16 custom fonts api** — `app.fonts.load(path)`, mirroring
   node-canvas's `registerFont`.

--- a/lib/fontconfig.js
+++ b/lib/fontconfig.js
@@ -109,16 +109,37 @@ function patternFor({ family, weight, style }) {
 
 // One command shared by the sync and async paths, so a prewarmed cache entry
 // is byte-for-byte what the sync call would have computed.
-const fcMatchArgs = ['-s', '--format', '%{file}\t%{postscriptname}\t%{charset}\n'];
+//
+// `%{family}` is a *list*: fontconfig keeps every name a face answers to,
+// localized aliases included (`Hiragino Sans`, `ヒラギノ角ゴシック`, and the
+// style-suffixed forms of both are one face), and `--format` joins them with
+// commas. The fields are tab-separated so a comma inside one costs nothing,
+// and `charset` stays last because it is by far the longest.
+const fcMatchArgs = [
+  '-s',
+  '--format',
+  '%{file}\t%{postscriptname}\t%{family}\t%{charset}\n'
+];
 const fcMatchOpts = { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 };
 
 /** fc-match -s output -> candidates, filtered to formats fontkit can parse */
 function parseMatches(out) {
   const list = [];
   for (const line of out.split('\n')) {
-    const [path, postscriptName, charset] = line.split('\t');
+    const [path, postscriptName, family, charset] = line.split('\t');
     if (path && supported.test(path)) {
-      list.push({ path, postscriptName, charset: charset || '', _ranges: null });
+      // `families` keeps fontconfig's whole list, in its order; `family` is
+      // the first of them, which is the name fontconfig leads with for the
+      // current locale and the one to show in a UI.
+      const families = family ? family.split(',').filter(Boolean) : [];
+      list.push({
+        path,
+        postscriptName,
+        family: families[0] || '',
+        families,
+        charset: charset || '',
+        _ranges: null
+      });
     }
   }
   return list;
@@ -174,11 +195,15 @@ export function prewarm(pattern = {}) {
  * Full fontconfig match list for a pattern, best match first — this is the
  * system's font fallback chain. Each candidate carries the unicode coverage
  * fontconfig knows about (`charset`, lazily parsed via `charsetHas`), so a
- * fallback font for a codepoint can be chosen without opening font files.
+ * fallback font for a codepoint can be chosen without opening font files —
+ * and the family name fontconfig already knows, so a *list* of matches can be
+ * shown without opening them either (issue #273: `sans-serif` returns 139
+ * candidates here, and `Font.loadSync` is ~1.2ms a file).
  *
  * Cached per pattern; one fc-match invocation (~50ms) per distinct pattern.
  *
- * @returns {Array<{path, postscriptName, charset: string}>}
+ * @returns {Array<{path, postscriptName, family: string, families: string[],
+ *   charset: string}>}
  */
 export function matchSortedSync(pattern) {
   const fc = patternFor(pattern);
@@ -218,14 +243,19 @@ export function matchSortedSync(pattern) {
 
 /**
  * Resolve a font pattern ({family, weight, style}) to the best matching font
- * file. Returns { path, postscriptName } or throws if nothing suitable is
- * installed. Requires the fc-match CLI (fontconfig) — usual on a Linux
- * desktop, absent from slim containers and from stock macOS. Where it is
- * missing, hand ntk the fonts instead (see docs/fonts.md).
+ * file. Returns { path, postscriptName, family, families } or throws if
+ * nothing suitable is installed. Requires the fc-match CLI (fontconfig) —
+ * usual on a Linux desktop, absent from slim containers and from stock
+ * macOS. Where it is missing, hand ntk the fonts instead (see docs/fonts.md).
  */
 export function listFontsSync(pattern) {
   const [best] = matchSortedSync(pattern);
-  return { path: best.path, postscriptName: best.postscriptName };
+  return {
+    path: best.path,
+    postscriptName: best.postscriptName,
+    family: best.family,
+    families: best.families
+  };
 }
 
 /**

--- a/lib/text/fontsource.js
+++ b/lib/text/fontsource.js
@@ -9,11 +9,14 @@
 //     Full match list for a pattern, best first — the fallback chain.
 //     `family` may be a CSS-style comma-separated list. Must return at
 //     least one candidate or throw. A candidate is openable:
-//       { key?, path?, data?, font?, postscriptName? }
+//       { key?, path?, data?, font?, postscriptName?, family?, families? }
 //     - `font`: an already-open Font instance (preferred when available)
 //     - `data`: font file bytes (Uint8Array/Buffer) for fontkit
 //     - `path`: font file path (node only)
 //     - `key`: stable cache key (defaults to `${path}#${postscriptName}`)
+//     - `family`: the face's family name, for showing a match list without
+//       opening every file in it; `families` its aliases, first one first
+//       (both optional, but both sources here fill them in)
 //
 //   covers(candidate, codepoint) -> boolean   [optional]
 //     Cheap coverage pre-filter used during per-codepoint fallback, ideally
@@ -237,7 +240,15 @@ export class StaticFontSource {
     scored.sort((a, b) => a.score - b.score);
     return scored.map(({ face }) => {
       if (!face.candidate) {
-        face.candidate = { key: face.font.key, font: face.font };
+        // the font's own family name, not the (lowercased, possibly aliased)
+        // one it is matched by — this field is the one to show a reader
+        const name = face.font.familyName || '';
+        face.candidate = {
+          key: face.font.key,
+          font: face.font,
+          family: name,
+          families: name ? [name] : []
+        };
       }
       return face.candidate;
     });

--- a/test/fontconfig.test.js
+++ b/test/fontconfig.test.js
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
 
-import { listFontsSync } from '../lib/fontconfig.js';
+import { listFontsSync, matchSortedSync } from '../lib/fontconfig.js';
 
 let hasFontconfig = true;
 try {
@@ -53,6 +53,25 @@ test('resolves sans-serif to a parseable font file', { skip: !hasFontconfig && '
   assert.match(match.path, /\.(ttf|otf|woff|woff2|ttc|dfont)$/i);
 });
 
+// Issue #273: a ranked match list is the natural thing to *show*, and naming
+// it by opening every file costs ~1.2ms a face over 139 of them. fontconfig
+// knows the names already, so the format string asks for them.
+
+test('a match is named, not just located', { skip: !hasFontconfig && 'fc-match not installed' }, () => {
+  const match = listFontsSync({ family: 'sans-serif', style: 'normal', weight: 'normal' });
+  assert.ok(match.family, 'the best match carries a family name');
+  assert.equal(match.family, match.families[0], 'family is the first of the aliases');
+});
+
+test('every candidate in the chain is named', { skip: !hasFontconfig && 'fc-match not installed' }, () => {
+  const ranked = matchSortedSync({ family: 'sans-serif', style: 'normal', weight: 'normal' });
+  assert.ok(ranked.length > 0);
+  for (const c of ranked) {
+    assert.equal(typeof c.family, 'string', `${c.path} has a family`);
+    assert.ok(c.family.length > 0, `${c.path} has a non-empty family`);
+  }
+});
+
 test('resolves bold and italic patterns', { skip: !hasFontconfig && 'fc-match not installed' }, () => {
   const bold = listFontsSync({ family: 'sans-serif', style: 'normal', weight: 'bold' });
   const italic = listFontsSync({ family: 'sans-serif', style: 'italic', weight: 400 });
@@ -85,7 +104,7 @@ test('fontconfig installed with no font packages is its own message', () => {
 
 test('fonts fc-match found but fontkit cannot parse are named as such', () => {
   // a bitmap-only image: fc-match exits 0 and lists .pcf files
-  const err = matchWithout('#!/bin/sh\nprintf "/usr/share/fonts/misc/fixed.pcf\\tFixed\\t20-7e\\n"\n');
+  const err = matchWithout('#!/bin/sh\nprintf "/usr/share/fonts/misc/fixed.pcf\\tFixed\\tFixed\\t20-7e\\n"\n');
   assert.equal(err.code, 'ERR_NTK_NO_FONTS');
   assert.match(err.message, /matched no font ntk can parse/);
   assert.match(err.message, /bitmap \.pcf\/\.bdf fonts are not usable/);
@@ -137,7 +156,7 @@ function prewarmProbe(body, stubs = {}) {
 // assert a spawn did not happen rather than merely not crash. $0 stands in
 // for dirname: the probe's PATH holds only stub directories, no coreutils.
 const counting = (path) =>
-  '#!/bin/sh\n' + 'echo x >> "$0.spawns"\n' + `printf "${path}\\tStub\\t20-7e\\n"\n`;
+  '#!/bin/sh\n' + 'echo x >> "$0.spawns"\n' + `printf "${path}\\tStub\\tStub Family\\t20-7e\\n"\n`;
 
 test('prewarm seeds the cache the sync path reads', () => {
   const out = prewarmProbe(
@@ -167,8 +186,8 @@ test('a sync call racing the prewarm wins; the late async result is discarded', 
       slow:
         '#!/bin/sh\n' +
         '{ /bin/sleep 0.3 || /usr/bin/sleep 0.3; } 2>/dev/null\n' +
-        'printf "/async/LATE.ttf\\tLate\\t20-7e\\n"\n',
-      fast: '#!/bin/sh\nprintf "/sync/WINNER.ttf\\tWinner\\t20-7e\\n"\n'
+        'printf "/async/LATE.ttf\\tLate\\tLate Family\\t20-7e\\n"\n',
+      fast: '#!/bin/sh\nprintf "/sync/WINNER.ttf\\tWinner\\tWinner Family\\t20-7e\\n"\n'
     }
   );
   assert.equal(out.duringRace, '/sync/WINNER.ttf');
@@ -223,6 +242,37 @@ test('constructing FontconfigFontSource starts the prewarm', () => {
     { warm: counting('/constructed/A.ttf') }
   );
   assert.equal(out.path, '/constructed/A.ttf');
+});
+
+// Families are a list in fontconfig — localized aliases and style-suffixed
+// forms of one face — and `--format` joins them with commas. Runs everywhere:
+// the stub is the fc-match on the child's PATH.
+test('a family list keeps its order, and the field after it still parses', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.hiragino;\n' +
+      'const [best] = matchSortedSync(PATTERN);\n' +
+      'console.log(JSON.stringify({ family: best.family, families: best.families, charset: best.charset }));\n',
+    {
+      hiragino:
+        '#!/bin/sh\n' +
+        'printf "/f/Hiragino.ttc\\tHiraginoSans-W4\\tHiragino Sans,\u30d2\u30e9\u30ae\u30ce\u89d2\u30b4\u30b7\u30c3\u30af,Hiragino Sans W4\\t20-7e a0-ff\\n"\n'
+    }
+  );
+  assert.equal(out.family, 'Hiragino Sans');
+  assert.deepEqual(out.families, ['Hiragino Sans', '\u30d2\u30e9\u30ae\u30ce\u89d2\u30b4\u30b7\u30c3\u30af', 'Hiragino Sans W4']);
+  assert.equal(out.charset, '20-7e a0-ff', 'charset is still the last field');
+});
+
+test('a face fontconfig cannot name is not a parse failure', () => {
+  const out = prewarmProbe(
+    'process.env.PATH = BIN.nameless;\n' +
+      'const [best] = matchSortedSync(PATTERN);\n' +
+      'console.log(JSON.stringify({ path: best.path, family: best.family, families: best.families }));\n',
+    { nameless: '#!/bin/sh\nprintf "/f/A.ttf\\tA\\t\\t20-7e\\n"\n' }
+  );
+  assert.equal(out.path, '/f/A.ttf', 'the match is still usable');
+  assert.equal(out.family, '');
+  assert.deepEqual(out.families, []);
 });
 
 test('the docs anchor the error points at exists', () => {

--- a/test/fontsource.test.js
+++ b/test/fontsource.test.js
@@ -162,6 +162,18 @@ test('directory order is sorted, not readdir order', () => {
   assert.equal(order()[0], 'KaTeX_AMS-Regular'); // alphabetical, not copy order
 });
 
+// Issue #273: a match list is shown, not just opened — so a candidate names
+// its face whichever source produced it, and a StaticFontSource answers with
+// the font's own family name rather than the (lowercased, aliased) key it is
+// matched by.
+test('candidates carry a family name for showing a match list', () => {
+  const source = new StaticFontSource();
+  source.add(bytes('KaTeX_SansSerif-Regular.ttf'), { family: 'ui-sans' });
+  const [best] = source.matchSorted({ family: 'ui-sans' });
+  assert.equal(best.family, 'KaTeX_SansSerif');
+  assert.deepEqual(best.families, ['KaTeX_SansSerif']);
+});
+
 test('subdirectories need recursive: true', () => {
   const dir = fontsDir();
   mkdirSync(join(dir, 'extra'));


### PR DESCRIPTION
Closes #273.

`matchSorted` answered `{path, postscriptName, charset}` because that is what the format string asked for, so there was no name in a match. An app that wants to *show* the ranking — the natural thing to do with a ranked list — had to open every file to get one: `Font.loadSync` is ~1.2ms a face and `sans-serif` matches 139 of them here, so naming the list cost ~170ms of blocking work fontconfig already knew the answer to.

```js
const fcMatchArgs = ['-s', '--format', '%{file}\t%{postscriptname}\t%{family}\t%{charset}\n'];
```

Candidates now carry:

- **`family`** — the name to display. From fontconfig this is the first name in its family list, which is the one it leads with for the current locale.
- **`families`** — every name the face answers to, in fontconfig's order.

Families are a *list* in fontconfig, not a string: `Hiragino Sans`, `ヒラギノ角ゴシック` and the style-suffixed forms of both are one face, and `--format` joins them with commas. Rather than let that fall out of the parse, both are kept and documented — `family` for the picker, `families` for a search that should match the alias someone typed. The fields stay tab-separated, so a comma inside a name costs nothing, and `charset` stays last because it is by far the longest.

`listFontsSync` carries both through. A `StaticFontSource` candidate fills them in too, from the font's own family name rather than the lowercased/aliased key it is matched by — so the field is there whichever source produced the match, which is what the seam is for.

```js
const ranked = app.fonts.source.matchSorted({ family: 'sans-serif' });
for (const c of ranked.slice(0, 5)) console.log(c.family, '—', c.path);
```

```
Hiragino Sans — /System/Library/Fonts/ヒラギノ角ゴシック W4.ttc
Comic Sans MS — /System/Library/Fonts/Supplemental/Comic Sans MS.ttf
Microsoft Sans Serif — /System/Library/Fonts/Supplemental/Microsoft Sans Serif.ttf
…
```

That first line is also the practical shape of react-x11#86 — `sans-serif` silently resolving to a CJK face on macOS — which is much better answered with a name than with a path.

### Tests

- with fontconfig: the best match is named, `family` is `families[0]`, and every candidate in the chain has a non-empty name.
- everywhere (fc-match stubbed on the child's PATH): a comma-joined family list keeps its order, `charset` still parses as the field after it, and a face fontconfig cannot name yields `''`/`[]` rather than a broken match.
- `StaticFontSource` candidates answer with the font's own family name.
- the existing stubs were updated to emit the four fields the real format string does.

`docs/fonts.md` gains a "Naming a match" section and the candidate shape in the FontSource contract; `docs/text.md`'s design note quotes the new command.
