### PR TITLE
fix(context2d): a gradient paints where the fill is, not where the window starts

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -551,9 +551,22 @@ ctx.fillStyle = g;
 - `createRadialGradient(x0, y0, r0, x1, y1, r1)`
 - `createConicalGradient(x0, y0, angle)` — ntk extension (XRender conical
   gradient)
+- The gradient's coordinates are **user space**, resolved against the
+  transform in force when it is *painted* — not the one that happened to be
+  current when it was created. A gradient written in a node's own
+  coordinates keeps painting in them after the context is translated to that
+  node's origin, and a scaled context scales the ramp with the shape. A
+  transform that collapses (a zero scale) paints nothing, as the canvas spec
+  says
+- Past the outermost stops the gradient **clamps** to their colours, so a
+  fill wider than the ramp keeps its end colours instead of fading to
+  transparent
+- Gradients are uploaded lazily on first use and freed with the context's
+  pictures on GC
 
-Gradients are uploaded lazily on first use and freed with the context's
-pictures on GC.
+Gradients work anywhere a colour does — `fillRect`, path fills, strokes,
+`fillText` — and go through the clip, `globalAlpha` and the composite op
+like any other style.
 
 ## Patterns
 
@@ -598,11 +611,10 @@ chart fills and any texture-shaped background.
   or a DOMMatrix-shaped `{a, b, c, d, e, f}` mapping pattern space to user
   space. Translating by the scroll offset is what keeps a grid glued to the
   content under it; a zoom step re-renders the tile and keeps the composite
-- The pattern is painted in **user space**: the transform in force at fill
-  time applies to the tile as well as to the shape, so a scaled context
-  scales its grid (this is where patterns differ from the gradients above,
-  whose coordinates are device-space). A transform that collapses (a zero
-  scale) paints nothing, as the canvas spec says
+- The pattern is painted in **user space**, like the gradients above: the
+  transform in force at fill time applies to the tile as well as to the
+  shape, so a scaled context scales its grid. A transform that collapses (a
+  zero scale) paints nothing, as the canvas spec says
 - Whole-pixel tiling samples with the `nearest` filter — the tile's own
   pixels, exactly — and anything else (a fractional offset, a scale, a
   rotation) resamples bilinearly

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -198,13 +198,21 @@ function patternSourceOf(app, source) {
 }
 
 /**
- * Point a pattern's picture transform at the transform in force for this
- * fill — patterns are painted in user space, so the CTM is part of the
- * mapping. Returns false when nothing would be painted (a singular matrix),
- * true for anything else, including every non-pattern style.
+ * Point a style's picture transform at the transform in force for this
+ * paint. Gradients and patterns are both defined in *user* space, so the CTM
+ * is part of the mapping — and per the canvas spec it is the CTM at paint
+ * time, not the one that happened to be current when the style was made
+ * (verified against browsers: a gradient created untransformed and filled
+ * after a `translate` moves with the fill, and one created under a translate
+ * and filled without it does not).
+ *
+ * Returns false when nothing would be painted (a singular matrix), true for
+ * anything else, including every plain-colour style.
  */
-function preparePattern(src, m) {
-  return src instanceof CanvasPattern ? src._sync(m) : true;
+function prepareStyle(src, m) {
+  return src instanceof CanvasPattern || src instanceof CanvasGradient
+    ? src._sync(m)
+    : true;
 }
 
 function isPictureSource(image) {
@@ -1135,7 +1143,7 @@ class RenderingContext2d {
     op = op ?? this._op();
     alpha = alpha ?? this.globalAlpha;
     if (alpha <= 0) return;
-    if (!preparePattern(src, this._m)) return;
+    if (!prepareStyle(src, this._m)) return;
 
     // one box per subpath, so a path holding disjoint ones can be masked as
     // the pieces it is rather than as the box around all of them
@@ -1178,6 +1186,7 @@ class RenderingContext2d {
   _strokePolys(polys, { src = null } = {}) {
     src = src ?? this._strokePicture;
     if (this.globalAlpha <= 0) return;
+    if (!prepareStyle(src, this._m)) return;
     // approximate transform-aware line width by the average scale factor
     const det = this._m[0] * this._m[3] - this._m[1] * this._m[2];
     const scale = Math.sqrt(Math.abs(det)) || 1;
@@ -1684,7 +1693,7 @@ class RenderingContext2d {
   drawGlyphs(op, src, positioned) {
     const app = this.window.app;
     const R = this.Render;
-    if (!preparePattern(src, this._m)) return;
+    if (!prepareStyle(src, this._m)) return;
     if (!this._clips.length) {
       drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
       this._markDirty();
@@ -1906,7 +1915,7 @@ class RenderingContext2d {
 
   fillRect(x, y, w, h) {
     if (matIsIdentity(this._m)) {
-      if (!preparePattern(this._backgroundPicture, this._m)) return;
+      if (!prepareStyle(this._backgroundPicture, this._m)) return;
       const mask = this._compositeMask();
       this.Render.Composite(
         this._op(),
@@ -3239,11 +3248,7 @@ class RenderingContext2d {
   _coverageSource() {
     const style = this._fillStyle;
     if (this.globalAlpha >= 1 || !isPlainColor(style)) {
-      // a pattern whose transform collapsed paints nothing, and "nothing" as
-      // a source is transparent black — no call site here has to know
-      return preparePattern(this._backgroundPicture, this._m)
-        ? this._backgroundPicture
-        : this.createSolidPicture(0, 0, 0, 0);
+      return this._backgroundPicture;
     }
     const c = parseColor(style);
     return this.createSolidPicture(c[0], c[1], c[2], c[3] * this.globalAlpha);
@@ -3260,6 +3265,9 @@ class RenderingContext2d {
    */
   _drawCoverage(picture, sx, sy, sw, sh, dx, dy, dw, dh, op) {
     const R = this.Render;
+    // the coverage is painted in the current fillStyle, on both branches
+    // below — a gradient/pattern whose transform collapsed paints nothing
+    if (!prepareStyle(this._backgroundPicture, this._m)) return;
     const scaled = dw !== sw || dh !== sh;
     if (scaled) {
       R.SetPictureTransform(picture.id, [
@@ -3665,6 +3673,21 @@ class RenderingContext2d {
   }
 }
 
+/**
+ * The fill/stroke style the `create*Gradient` methods return: colour stops
+ * along a line, between two circles, or around a point, backed by one
+ * XRender gradient picture.
+ *
+ * Its coordinates are **user space**, like every other coordinate a caller
+ * gives the context, and are resolved against the transform in force when
+ * the gradient is *painted* — the picture transform is that CTM's inverse,
+ * installed by `_sync` before each use, exactly as a pattern's is. A
+ * gradient made for a node's own coordinates therefore keeps painting in
+ * them after the context is translated to that node's origin (issue #271).
+ *
+ * The picture is created on first use and freed by the GC, through
+ * `Picture`'s finalizer.
+ */
 class CanvasGradient {
   constructor(type, ctx, p0, p1, p2, p3, p4, p5) {
     this.type = type;
@@ -3672,6 +3695,9 @@ class CanvasGradient {
     this.ctx = ctx;
     this._id = null;
     this._picture = null;
+    // what the server currently holds: a fresh gradient picture is
+    // untransformed, so an untransformed fill costs no extra request
+    this._applied = [1, 0, 0, 1, 0, 0];
 
     this.x0 = p0;
     this.y0 = p1;
@@ -3683,7 +3709,6 @@ class CanvasGradient {
     } else {
       this.angle = p2;
     }
-    // TODO: check if ChangePictureAttribute works on gradients ( set repeat edge pixels flag )
   }
 
   addColorStop(offset, color) {
@@ -3729,9 +3754,54 @@ class CanvasGradient {
       default:
         throw new Error("unknown gradient type");
     }
+    // Past the outermost stop a gradient clamps to that stop's colour, as
+    // the canvas and CSS specs say — which is XRender's RepeatPad, not the
+    // RepeatNone (transparent) a gradient picture is born with. Without it
+    // an app has to place its gradient exactly on the fill or lose the
+    // corners. The in-process JS server pads unconditionally, so only a real
+    // server can tell the difference.
+    Render.ChangePicture(this._id, { repeat: 2 }); // Repeat.Pad
     // wrap with picture so FreePicture is invoked on gc via FinalizationRegistry
     this._picture = new Picture(this.ctx.window.app, { id: this._id });
     return this._id;
+  }
+
+  /**
+   * Make the server-side mapping match the CTM this paint runs under. The
+   * gradient's own coordinates are user space and every fill samples the
+   * source at device coordinates, so the picture transform — which takes a
+   * source coordinate to a gradient one — is the CTM's inverse.
+   *
+   * Returns false when the CTM collapses (a zero scale), which paints
+   * nothing, exactly as the canvas spec says.
+   */
+  _sync(ctm) {
+    const inv = matInvert(ctm);
+    if (!inv) return false;
+    const id = this.id; // lazily creates the picture
+    const a = this._applied;
+    if (
+      inv[0] !== a[0] ||
+      inv[1] !== a[1] ||
+      inv[2] !== a[2] ||
+      inv[3] !== a[3] ||
+      inv[4] !== a[4] ||
+      inv[5] !== a[5]
+    ) {
+      this.ctx.Render.SetPictureTransform(id, [
+        inv[0],
+        inv[2],
+        inv[4],
+        inv[1],
+        inv[3],
+        inv[5],
+        0,
+        0,
+        1,
+      ]);
+      this._applied = inv;
+    }
+    return true;
   }
 }
 

--- a/lib/widgets/svgview.js
+++ b/lib/widgets/svgview.js
@@ -22,7 +22,7 @@
 import { textContent } from 'domutils';
 import { parseDocument } from 'htmlparser2';
 
-import { Path2D, flattenPath, matApply } from '../path.js';
+import { Path2D, flattenPath } from '../path.js';
 
 const INHERITED = {
   fill: '#000',
@@ -486,16 +486,15 @@ export default class SvgView {
       if (!bbox) return v;
       return axis === 'x' ? bbox.x + v * bbox.w : bbox.y + v * bbox.h;
     };
-    // ntk gradients live in device space: map user-space endpoints through
-    // the current transform
-    const m = ctx.getTransform();
-    const mat = [m.a, m.b, m.c, m.d, m.e, m.f];
-    const dev = (px, py) => matApply(mat, px, py);
-
+    // gradient coordinates are user space, like the path's own — the
+    // context resolves them against the transform in force when it paints,
+    // which is this one (issue #271)
     let gradient;
     if (tag(node) === 'lineargradient') {
-      const [x1, y1] = dev(coord(a.x1, 0, 'x'), coord(a.y1, 0, 'y'));
-      const [x2, y2] = dev(coord(a.x2, 1, 'x'), coord(a.y2, 0, 'y'));
+      const x1 = coord(a.x1, 0, 'x');
+      const y1 = coord(a.y1, 0, 'y');
+      const x2 = coord(a.x2, 1, 'x');
+      const y2 = coord(a.y2, 0, 'y');
       gradient = ctx.createLinearGradient(x1, y1, x2, y2);
     } else {
       const cx = coord(a.cx, 0.5, 'x');
@@ -503,9 +502,7 @@ export default class SvgView {
       let r = a.r === undefined ? 0.5 : parseFloat(a.r);
       if (String(a.r ?? '').endsWith('%')) r /= 100;
       if (bbox) r *= (bbox.w + bbox.h) / 2;
-      const [dcx, dcy] = dev(cx, cy);
-      const scale = Math.sqrt(Math.abs(mat[0] * mat[3] - mat[1] * mat[2])) || 1;
-      gradient = ctx.createRadialGradient(dcx, dcy, 0, dcx, dcy, r * scale);
+      gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
     }
 
     for (const stop of node.children || []) {

--- a/test/gradient.test.js
+++ b/test/gradient.test.js
@@ -1,0 +1,170 @@
+// CanvasGradient: a gradient's coordinates are user space, resolved against
+// the transform in force when it is *painted* (issue #271), and past its
+// outermost stop it clamps to that stop's colour.
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed. It
+// implements SetPictureTransform on gradient sources, which is what the
+// user-space mapping rests on.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { StaticFontSource, createClient } from '../lib/index.js';
+
+let app = null;
+const W = 64;
+const H = 64;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+/** a fresh context painted opaque white, so every test owns its pixels */
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+const pixels = async (ctx) => {
+  const img = await ctx.getImageData(0, 0, W, H);
+  return (x, y) => [...img.data.slice((y * W + x) * 4, (y * W + x) * 4 + 3)];
+};
+
+/** black -> white along `len` user-space units of x, from the origin */
+function rampX(ctx, len) {
+  const g = ctx.createLinearGradient(0, 0, len, 0);
+  g.addColorStop(0, 'black');
+  g.addColorStop(1, 'white');
+  return g;
+}
+
+const near = (actual, expected, tol, what) =>
+  assert.ok(Math.abs(actual - expected) <= tol, `${what}: got ${actual}, want ~${expected}`);
+
+test('a gradient is painted in user space: the CTM moves it', async () => {
+  // the bug: the gradient stayed anchored to the window origin, so a fill
+  // translated to a node's origin ran out of gradient partway across
+  const ctx = freshCtx();
+  ctx.translate(32, 0);
+  ctx.fillStyle = rampX(ctx, 32);
+  ctx.fillRect(0, 0, 32, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(16, 32), [255, 255, 255], 'left of the fill is untouched');
+  near(at(33, 32)[0], 0, 16, 'the ramp starts at the translated origin');
+  near(at(48, 32)[0], 128, 16, 'and is halfway across at the middle');
+  near(at(62, 32)[0], 255, 16, 'and reaches white at the far end');
+});
+
+test('the transform that counts is the one in force at paint time', async () => {
+  // per the canvas spec (and every browser): a gradient created under a
+  // transform and painted without it is not offset by that transform
+  const ctx = freshCtx();
+  ctx.translate(32, 0);
+  const g = rampX(ctx, 32);
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 32, H);
+
+  const at = await pixels(ctx);
+  near(at(1, 32)[0], 0, 16, 'the ramp starts at the device origin');
+  near(at(30, 32)[0], 255, 16, 'and ends where its own coordinates say');
+});
+
+test('a scaled CTM scales the gradient with the drawing', async () => {
+  const ctx = freshCtx();
+  ctx.scale(2, 1);
+  ctx.fillStyle = rampX(ctx, 32);
+  ctx.fillRect(0, 0, 32, H); // 64 device pixels wide
+
+  const at = await pixels(ctx);
+  near(at(1, 32)[0], 0, 16, 'still black at the origin');
+  near(at(32, 32)[0], 128, 16, 'the midpoint moved to device x=32');
+  near(at(62, 32)[0], 255, 16, 'and white lands at the far edge');
+});
+
+test('a stroke and a fill of one gradient agree under a transform', async () => {
+  const ctx = freshCtx();
+  ctx.translate(16, 0);
+  const g = rampX(ctx, 32);
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 32, 8);
+  ctx.strokeStyle = g;
+  ctx.lineWidth = 8;
+  ctx.beginPath();
+  ctx.moveTo(0, 20);
+  ctx.lineTo(32, 20);
+  ctx.stroke();
+
+  const at = await pixels(ctx);
+  for (const x of [20, 32, 44]) {
+    near(at(x, 20)[0], at(x, 4)[0], 4, `x=${x}: the stroke matches the fill`);
+  }
+});
+
+test('a fill through the clip mask keeps the gradient in user space', async () => {
+  // a non-rectangular-clipped fill composites through the scratch a8 mask
+  // rather than straight to the destination — a separate source path
+  const ctx = freshCtx();
+  ctx.translate(24, 0);
+  ctx.fillStyle = rampX(ctx, 32);
+  ctx.beginPath();
+  ctx.rect(0, 0, 32, H);
+  ctx.clip();
+  ctx.fillRect(0, 0, 32, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(8, 32), [255, 255, 255], 'outside the clip');
+  near(at(25, 32)[0], 0, 16, 'the clipped fill still starts its ramp at the origin');
+  near(at(54, 32)[0], 255, 16, 'and finishes it inside the clip');
+});
+
+test('globalAlpha over a gradient keeps the gradient in user space', async () => {
+  // alpha < 1 with a non-plain style routes through the scratch mask, a
+  // separate composite path from the direct one above
+  const ctx = freshCtx();
+  ctx.translate(32, 0);
+  ctx.globalAlpha = 0.5;
+  ctx.fillStyle = rampX(ctx, 32);
+  ctx.fillRect(0, 0, 32, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(16, 32), [255, 255, 255], 'left of the fill is untouched');
+  // black at half strength over white is mid gray; white over white is white
+  near(at(33, 32)[0], 128, 20, 'the ramp starts at the translated origin');
+  near(at(62, 32)[0], 255, 16, 'and still ends white');
+});
+
+test('a degenerate CTM paints nothing rather than the last transform', async () => {
+  const ctx = freshCtx();
+  ctx.fillStyle = rampX(ctx, 32);
+  ctx.scale(0, 1);
+  ctx.fillRect(0, 0, 64, H);
+
+  const at = await pixels(ctx);
+  assert.deepEqual(at(32, 32), [255, 255, 255], 'a collapsed transform has nothing to sample');
+});
+
+test('beyond its outermost stops a gradient clamps to their colours', async () => {
+  const ctx = freshCtx();
+  const g = ctx.createLinearGradient(24, 0, 40, 0);
+  g.addColorStop(0, 'black');
+  g.addColorStop(1, 'white');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, W, H);
+
+  const at = await pixels(ctx);
+  near(at(4, 32)[0], 0, 6, 'before the first stop clamps to black');
+  near(at(60, 32)[0], 255, 6, 'after the last stop clamps to white');
+});

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -285,3 +285,39 @@ test('createPattern: a tile repeats across a fill, on a real server', async (t) 
   tile.destroy();
   pixmap.destroy();
 });
+
+test('gradients: user-space coordinates and pad past the outermost stops', async (t) => {
+  if (skip) return t.skip(skip);
+  const { pixmap, ctx } = freshCtx();
+  const near = (actual, expected, tol, what) =>
+    assert.ok(Math.abs(actual - expected) <= tol, `${what}: got ${actual}, want ~${expected}`);
+
+  // a gradient in a translated context paints where the fill is, not where
+  // the window origin is (issue #271)
+  ctx.save();
+  ctx.translate(32, 0);
+  const g = ctx.createLinearGradient(0, 0, 32, 0);
+  g.addColorStop(0, 'black');
+  g.addColorStop(1, 'white');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 32, 32);
+  ctx.restore();
+
+  // and past its last stop it clamps to that stop's colour, rather than
+  // going transparent: RepeatPad, not the RepeatNone a gradient starts with
+  const wide = ctx.createLinearGradient(24, 40, 40, 40);
+  wide.addColorStop(0, 'black');
+  wide.addColorStop(1, 'white');
+  ctx.fillStyle = wide;
+  ctx.fillRect(0, 40, 64, 24);
+
+  const image = await readPixels(ctx, 64, 64);
+  assert.deepEqual(px(image, 64, 16, 16), [255, 255, 255], 'left of the fill is untouched');
+  near(px(image, 64, 33, 16)[0], 0, 16, 'the ramp starts at the translated origin');
+  near(px(image, 64, 48, 16)[0], 128, 16, 'halfway across at the middle');
+  near(px(image, 64, 62, 16)[0], 255, 16, 'and white at the far end');
+  near(px(image, 64, 4, 50)[0], 0, 6, 'before the first stop clamps to black');
+  near(px(image, 64, 60, 50)[0], 255, 6, 'after the last stop clamps to white');
+
+  pixmap.destroy();
+});

--- a/test/svgview.test.js
+++ b/test/svgview.test.js
@@ -156,7 +156,7 @@ test('fill-rule=evenodd is forwarded', () => {
   assert.equal(of(ctx.calls, 'fill')[0][2], 'evenodd');
 });
 
-test('linearGradient paint resolves via url(#id) with device coordinates', () => {
+test('linearGradient paint resolves via url(#id) in user coordinates', () => {
   const view = new SvgView(null);
   view.setSvg(`<svg viewBox="0 0 10 10">
     <defs>
@@ -172,8 +172,9 @@ test('linearGradient paint resolves via url(#id) with device coordinates', () =>
   const fill = of(ctx.calls, 'fill')[0];
   const gradient = fill[3];
   assert.equal(gradient.type, 'linear');
-  // objectBoundingBox 0..1 over a 10x10 shape, scaled 10x to device
-  assert.deepEqual([gradient.x1, gradient.y1, gradient.x2, gradient.y2], [0, 0, 100, 0]);
+  // objectBoundingBox 0..1 over a 10x10 shape, in the shape's own units:
+  // the 10x viewBox scale is the context's transform to apply, not ours
+  assert.deepEqual([gradient.x1, gradient.y1, gradient.x2, gradient.y2], [0, 0, 10, 0]);
   assert.equal(gradient.stops.length, 2);
   assert.equal(gradient.stops[1][1], 'rgba(0, 0, 255, 0.5)');
 });


### PR DESCRIPTION
Fixes #271.

`CanvasGradient` stored the coordinates it was given and never applied the current transformation matrix, so a gradient was anchored to the drawable's origin rather than to the fill. A `<canvas>` node that translates to its own origin before handing the context to the app got every gradient displaced by that origin — and, past the gradient's end, nothing at all.

## Before / after

The issue's reproduction, plus a gradient narrower than the rect it fills. Both frames are rendered by this branch's own code, off a depth-24 pixmap read back with `getImageData`; the "before" frame is the same script run against the unfixed `lib/`.

<img width="980" alt="before and after: a gradient in a translated context" src="https://github.com/user-attachments/assets/d704bf8f-59b6-49d4-8b3f-5fab6a8f8c71" />

## What changed

- **Gradients are painted in user space.** They now go through the same preparation patterns already had: the picture transform is the CTM's inverse, installed before each paint. `preparePattern` became `prepareStyle` and covers both.
- **The transform that counts is the one at paint time**, not the one current when the gradient was created. The issue suggested creation time as the likely reading of the spec; a browser check says otherwise — a gradient created untransformed and filled after a `translate` moves with the fill, and one created under a `translate` and filled without it does not. That is also what patterns here already implement, so gradients and patterns now agree.
- **Two paths were missing the preparation call entirely**, and get it now: stroking, and the coverage composite that a non-rectangular clip or a `globalAlpha` below 1 routes through the scratch mask. Patterns were affected by both.
- **Past its outermost stops a gradient clamps** to their colours instead of fading to transparent — canvas and CSS semantics, and XRender's `RepeatPad`. This answers the TODO the constructor carried: `ChangePicture` does work on a gradient picture, which is how cairo does it too. An app no longer has to place its gradient exactly on the fill or lose the corners.
- **`SvgView` stops pre-mapping its gradient endpoints into device space** — it did that only because ntk's gradients were device-space — and hands the context user-space coordinates like everything else it draws.

## Tests

New `test/gradient.test.js`, hermetic against node-x11's in-process X server: the translated fill, paint-time vs creation-time, a scaled CTM, stroke agreeing with fill, the clip-mask path, `globalAlpha` over a gradient, a collapsed CTM painting nothing, and the clamp. Four of them fail on `master`.

`test/smoke-canvas.test.js` gets the same two properties against a real server, which is the only place the clamp is observable — the in-process server pads unconditionally. It fails on `master`, and with only the `RepeatPad` line reverted it fails on the clamp assertion alone.

Full suite green locally against XQuartz, and `website`'s pixel-checked demos are green too.
