### PR TITLE
feat(context2d): shadows, with the blur run as two passes and text coverage cached

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ client) with familiar, modern API concepts:
 
 1. Keep growing toward "write simple X11 UIs with the APIs you know from the
    web" — canvas 2d parity first (paths/Path2D, transforms, save/restore,
-   clip, `globalAlpha` and Porter-Duff `globalCompositeOperation` are done;
-   still missing: line dashes, round caps/joins, shadows, text under
+   clip, `globalAlpha`, Porter-Duff `globalCompositeOperation` and shadows
+   are done; still missing: line dashes, round caps/joins, text under
    rotation/scale, blend-mode composite ops), webgl-like ideas where they
    fit.
 2. This library is intended to become the host for a **separate react
@@ -73,6 +73,9 @@ lib/glswapchain.js         its buffers: dma-buf -> DRI3 pixmap -> Present,
                            recycled on IdleNotify, generations across resizes
 lib/renderingcontext_x11.js     raw core-X drawing context
 lib/picture.js             XRender Picture wrapper (+ blur filter)
+lib/shadow.js              canvas shadows: the blur (sigma = shadowBlur/2,
+                           run as two separable passes), the coverage
+                           surfaces it needs and their per-connection cache
 lib/glyphset.js            XRender GlyphSet wrapper
 lib/rasterize.js           pure-JS coverage rasterizer (signed-area
                            accumulation): glyph outlines and path/stroke

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -45,6 +45,9 @@ ctx.fillRect(0, 0, 100, 100);
   unless a gap lands there)
 - `ctx.globalAlpha` — multiplies fills, strokes, `fillRect` and `drawImage`
   (not text)
+- `ctx.shadowColor`, `ctx.shadowBlur`, `ctx.shadowOffsetX`,
+  `ctx.shadowOffsetY` — drop shadows, off by default (a transparent
+  `shadowColor`). See **Shadows** below
 - `ctx.globalCompositeOperation` — Porter-Duff subset mapped to XRender ops:
   `source-over` (default), `copy`, `destination-over`, `source-in`,
   `destination-in`, `source-out`, `destination-out`, `source-atop`,
@@ -104,7 +107,7 @@ is inside 0..1 on every component, so only rendering catches it.
 ## State and transforms
 
 - `save()` / `restore()` — full state stack: styles, line settings, font,
-  text alignment, `globalAlpha`, composite op, transform and clip
+  text alignment, shadow, `globalAlpha`, composite op, transform and clip
 - `translate(x, y)`, `rotate(angle)`, `scale(x[, y])`,
   `transform(a, b, c, d, e, f)`, `setTransform(...)`, `resetTransform()`,
   `getTransform()` → `{a, b, c, d, e, f}`
@@ -618,6 +621,83 @@ chart fills and any texture-shaped background.
 Patterns work anywhere a colour does — `fillRect`, path fills, strokes,
 `fillText` — and go through the clip, `globalAlpha` and the composite op
 like any other style.
+
+## Shadows
+
+The four canvas shadow properties, applied to every drawing operation —
+`fill`, `stroke`, `fillText`, `fillRect`, `strokeRect`, `fillRects` and
+`drawImage`:
+
+```js
+ctx.shadowColor = '#05070a';
+ctx.shadowBlur = 7;
+ctx.shadowOffsetX = ctx.shadowOffsetY = 3;
+ctx.fillText('Specimen', x, baseline);
+```
+
+- `shadowColor` — any colour string or premultiplied array. The default,
+  `'rgba(0, 0, 0, 0)'`, is what turns the whole thing off: a transparent
+  shadow colour skips the path entirely, so an app that never sets it pays
+  one array read per drawing operation and nothing else
+- `shadowBlur` — the canvas spec's **diameter**, not a radius: the gaussian
+  it names has σ = `shadowBlur / 2`, so a value here looks like the same
+  value in a browser. `0` (the default) is a hard-edged copy of the shape
+- `shadowOffsetX` / `shadowOffsetY` — in **device** pixels, and deliberately
+  outside the current transform, exactly as the spec has it: a rotated
+  drawing casts an upright shadow, the way a rotated element's `box-shadow`
+  is upright in CSS. Offsets are rounded to whole pixels when the shadow is
+  composited (the drawing's own sub-pixel position is untouched)
+
+A shadow goes through everything the drawing itself does: the clip,
+`globalAlpha` and the composite operation all apply to it, and it is painted
+first so the drawing lands on top. With no offset and no blur it sits exactly
+under the shape, where it shows through anything translucent — that is the
+spec's behaviour, not an oversight.
+
+### How it is drawn, and what it costs
+
+A shadow is the drawing's *coverage*, blurred, offset and painted in one
+colour. All three steps are server-side:
+
+1. the shape is drawn into a padded `a8` [`Surface`](surface.md) — white on
+   transparent, so every pixel is its own alpha
+2. two `convolution` filter passes blur it, horizontal then vertical
+3. the result composites as a mask with `shadowColor` as the source
+
+The padding in (1) is why an app should not assemble this by hand: a
+convolution samples outside the picture, where RepeatNone reads transparent,
+so a shape drawn flush to the surface edge ends in a straight line where the
+kernel ran out of pixels. Everything here pads by the blur's full reach.
+
+Step (2) is two 1d passes rather than one 2d kernel because a gaussian is
+separable, and that is the difference between a shadow you can animate and
+one you cannot: a k-wide 2d kernel costs k² multiplies per pixel where two
+passes cost 2k. At `shadowBlur: 30` that is 8281 against 182.
+
+**Text shadows are cached** — keyed by (text, font, blur) on the connection —
+because text is the one drawing with a short, stable name. A label redrawn
+every frame, or a specimen redrawn on every slider tick, builds its coverage
+once and composites it afterwards. Paths, rectangles and images have no such
+key and rebuild their coverage per draw, so a large blurred path shadow in a
+render loop is the shape to watch for; draw it into a `Surface` yourself and
+`drawImage` that instead.
+
+`app.shadowPolicy` tunes the ceilings (partial objects merge over the
+defaults):
+
+- `cacheBytes` (4 MB) — LRU budget for retained shadow coverage;
+  least-recently-drawn surfaces are freed server-side past it
+- `maxSigma` (32) — the widest gaussian actually run. The kernel is 6σ+1
+  taps, every tap rides the request, and the server multiplies each of them
+  per pixel per pass, so an unbounded `shadowBlur` would be an unbounded
+  stall. This is the one place a shadow stops matching a browser
+- `maxPixels` (8 M) — the largest coverage surface built for one shadow;
+  past it the shadow is dropped and the drawing is unaffected
+
+Only what could be seen is rendered: a shape's ink is clipped to the part
+whose shadow can land on the target at all (its own bounds, moved back by
+the offset and grown by the blur's reach), so a shape mostly off-screen does
+not allocate a surface the size of its bounding box.
 
 ## Text
 

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -49,6 +49,17 @@ answers that question for SVG documents.
 `globalAlpha` still applies — it folds into the source colour rather than the
 mask, since the mask slot is taken.
 
+Coverage is also what a *filter* wants, and blur is the filter worth knowing
+about: `surface.picture().setFilter('convolution', [w, h, ...kernel])` is
+applied by the server every time the picture is sampled, so an a8 surface
+blurred this way composites as a soft version of whatever was drawn into it.
+That is exactly how [shadows](context-2d.md#shadows) are built — reach for
+those first — and if you build your own, note the two things that are easy
+to get wrong: the surface needs **padding of the kernel's half-width on every
+side**, or the blur ends in a straight line where it ran out of pixels
+(outside a picture, RepeatNone reads transparent), and a 2d kernel costs k²
+multiplies per pixel where two 1d passes cost 2k.
+
 ## Scrolling and panning: `copyWithin`
 
 A widget that keeps its content in a retained surface — a terminal grid, a

--- a/examples/shadows.js
+++ b/examples/shadows.js
@@ -1,0 +1,123 @@
+// Drop shadows (ntk#272): shadowColor / shadowBlur / shadowOffsetX / Y.
+//
+// Left/right change the blur, up/down the offset. The point of making it
+// interactive: a text shadow's coverage is cached by (text, font, blur), so
+// sliding the *offset* redraws with no new server-side work at all, while
+// sliding the blur builds one coverage surface per distinct value.
+//
+// usage: node shadows.js
+import { createClient } from '../lib/index.js';
+
+const BG = '#eef1f6';
+const CARD = '#ffffff';
+const INK = '#1b2130';
+const MUTED = '#6b7688';
+const ACCENT = '#2f6feb';
+const WARM = '#e8853a';
+const SHADOW = 'rgba(20, 26, 40, 0.55)';
+
+const app = await createClient();
+const wnd = app.createWindow({
+  title: 'ntk shadows — left/right blur, up/down offset',
+  width: 820,
+  height: 430
+});
+wnd.map();
+const ctx = wnd.getContext('2d');
+
+let blur = 14;
+let offset = 6;
+
+function draw() {
+  const { width, height } = wnd;
+  ctx.fillStyle = BG;
+  ctx.fillRect(0, 0, width, height);
+
+  // a font specimen: the case the feature came from
+  ctx.save();
+  ctx.shadowColor = SHADOW;
+  ctx.shadowBlur = blur;
+  ctx.shadowOffsetX = offset;
+  ctx.shadowOffsetY = offset;
+  ctx.font = '64px sans-serif';
+  ctx.fillStyle = ACCENT;
+  ctx.fillText('Specimen', 40, 96);
+  ctx.restore();
+
+  ctx.font = '13px sans-serif';
+  ctx.fillStyle = MUTED;
+  ctx.fillText(
+    `shadowBlur ${blur} (sigma ${blur / 2})   shadowOffsetX/Y ${offset}`,
+    42,
+    126
+  );
+
+  // the same shape at four blurs, so the scale is visible at a glance
+  [0, 6, 14, 30].forEach((b, i) => {
+    const x = 40 + i * 195;
+    ctx.save();
+    ctx.shadowColor = SHADOW;
+    ctx.shadowBlur = b;
+    ctx.shadowOffsetX = 4;
+    ctx.shadowOffsetY = 6;
+    ctx.fillStyle = CARD;
+    ctx.beginPath();
+    ctx.roundRect(x, 165, 170, 84, 12);
+    ctx.fill();
+    ctx.restore();
+
+    ctx.font = '17px sans-serif';
+    ctx.fillStyle = INK;
+    ctx.fillText(`shadowBlur ${b}`, x + 20, 206);
+    ctx.font = '13px sans-serif';
+    ctx.fillStyle = MUTED;
+    ctx.fillText(`sigma ${b / 2}`, x + 20, 226);
+  });
+
+  // and it follows any drawing, not just boxes and text
+  ctx.save();
+  ctx.shadowColor = SHADOW;
+  ctx.shadowBlur = blur;
+  ctx.shadowOffsetX = offset;
+  ctx.shadowOffsetY = offset;
+  ctx.strokeStyle = ACCENT;
+  ctx.lineWidth = 6;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.beginPath();
+  ctx.moveTo(60, 390);
+  ctx.lineTo(140, 310);
+  ctx.lineTo(220, 370);
+  ctx.lineTo(300, 305);
+  ctx.stroke();
+
+  ctx.fillStyle = WARM;
+  ctx.beginPath();
+  ctx.arc(390, 350, 40, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.font = '30px sans-serif';
+  ctx.fillStyle = INK;
+  ctx.fillText('strokes, arcs, text', 460, 362);
+  ctx.restore();
+}
+
+// arrows type no character, so they arrive as keysyms rather than codepoints
+const LEFT = 0xff51;
+const UP = 0xff52;
+const RIGHT = 0xff53;
+const DOWN = 0xff54;
+const ESCAPE = 0xff1b;
+
+wnd.on('expose', draw);
+wnd.on('keydown', (ev) => {
+  const typed = String.fromCodePoint(ev.codepoint ?? 0).toLowerCase();
+  if (ev.baseKeysym === LEFT) blur = Math.max(0, blur - 2);
+  else if (ev.baseKeysym === RIGHT) blur = Math.min(60, blur + 2);
+  else if (ev.baseKeysym === UP) offset = Math.max(-40, offset - 2);
+  else if (ev.baseKeysym === DOWN) offset = Math.min(40, offset + 2);
+  else if (typed === 'q' || ev.baseKeysym === ESCAPE) return app.close();
+  else return;
+  draw();
+});
+wnd.on('close', () => app.close());

--- a/lib/app.js
+++ b/lib/app.js
@@ -5,6 +5,7 @@ import { chooseGLXConfig } from './glx.js';
 import Picture from './picture.js';
 import Pixmap from './pixmap.js';
 import { DEFAULT_RASTER_POLICY, defaultRasterizer } from './rasterize.js';
+import { dropShadowSurfaces } from './shadow.js';
 import { ShmUploader } from './shm-upload.js';
 import FontManager from './text/fontmanager.js';
 import Window from './window.js';
@@ -543,6 +544,9 @@ export default class App {
       this._shm.dispose();
       this._shm = undefined;
     }
+    // shadow coverage is cached per connection for the same reason solids
+    // are: the contexts that drew it are long gone (see lib/shadow.js)
+    dropShadowSurfaces(this);
     // shared by every context that ever asked (see solidPicture), so their
     // lifetime is the connection's — context teardown must not free them
     for (const picture of this._solidPictures.values()) {

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -27,6 +27,13 @@ import {
 import Picture from "./picture.js";
 import Pixmap from "./pixmap.js";
 import { routeRaster } from "./rasterize.js";
+import {
+  blurCoverage,
+  cachedShadow,
+  shadowPolicyOf,
+  shadowReach,
+  shadowSigma,
+} from "./shadow.js";
 import { Surface } from "./surface.js";
 import {
   BL,
@@ -76,6 +83,37 @@ function intersectBox(a, b) {
   return { x, y, w: right - x, h: bottom - y };
 }
 
+/** The device-space ink bounds of a flattened path, unclamped. */
+function polysInk(polys) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const poly of polys) {
+    const pts = poly.pts;
+    for (let i = 0; i < pts.length; i += 2) {
+      if (pts[i] < minX) minX = pts[i];
+      if (pts[i] > maxX) maxX = pts[i];
+      if (pts[i + 1] < minY) minY = pts[i + 1];
+      if (pts[i + 1] > maxY) maxY = pts[i + 1];
+    }
+  }
+  return maxX === -Infinity ? null : { minX, minY, maxX, maxY };
+}
+
+/** the same list, moved — the shadow's copy of a drawing is the same
+ * geometry in the coverage surface's coordinates */
+function shiftPolys(polys, dx, dy) {
+  return polys.map((poly) => {
+    const pts = new Array(poly.pts.length);
+    for (let i = 0; i < pts.length; i += 2) {
+      pts[i] = poly.pts[i] + dx;
+      pts[i + 1] = poly.pts[i + 1] + dy;
+    }
+    return { ...poly, pts };
+  });
+}
+
 const DEFAULT_FONT = "20px sans-serif";
 
 // `"wght" 460, "wdth" 87.5` — the CSS grammar, quotes optional. An object is
@@ -93,6 +131,17 @@ function parseVariationSettings(val) {
     any = true;
   }
   return any ? out : null;
+}
+
+/** a stable string for a variation setting, for cache keys — two Fonts of
+ * one file at different axis positions share a `key`, so the coordinates
+ * have to be part of anything keyed on the rendered result */
+function variationsKey(variations) {
+  if (!variations) return "";
+  return Object.keys(variations)
+    .sort()
+    .map((tag) => `${tag}=${variations[tag]}`)
+    .join(",");
 }
 
 /**
@@ -422,6 +471,15 @@ class RenderingContext2d {
     this._lineDash = [];
     this._lineDashOffset = 0;
 
+    this._shadowBlur = 0;
+    this._shadowOffsetX = 0;
+    this._shadowOffsetY = 0;
+    // "transparent black" — the spec's default, and the one value that
+    // skips the whole shadow path, so an app that never asks for a shadow
+    // never pays for one
+    this._shadowColor = "rgba(0, 0, 0, 0)";
+    this._shadowRgba = [0, 0, 0, 0];
+
     this.fillStyle = "white";
     this.strokeStyle = "black";
     this.lineWidth = 1;
@@ -660,6 +718,11 @@ class RenderingContext2d {
       textRendering: this._textRendering,
       textAlign: this.textAlign,
       textBaseline: this.textBaseline,
+      shadowBlur: this._shadowBlur,
+      shadowColor: this._shadowColor,
+      shadowRgba: this._shadowRgba,
+      shadowOffsetX: this._shadowOffsetX,
+      shadowOffsetY: this._shadowOffsetY,
       m: this._m.slice(),
       clips: this._clips,
     });
@@ -684,11 +747,408 @@ class RenderingContext2d {
     this._textRendering = s.textRendering;
     this.textAlign = s.textAlign;
     this.textBaseline = s.textBaseline;
+    this._shadowBlur = s.shadowBlur;
+    this._shadowColor = s.shadowColor;
+    this._shadowRgba = s.shadowRgba;
+    this._shadowOffsetX = s.shadowOffsetX;
+    this._shadowOffsetY = s.shadowOffsetY;
     this._m = s.m;
     if (s.clips !== this._clips) {
       this._clips = s.clips;
       this._rebuildClipMask();
     }
+  }
+
+  // ------------------------------------------------------------------
+  // shadows (issue #272)
+  //
+  // The canvas properties, and the three server-side steps behind them: the
+  // drawing's coverage into a padded `a8` surface, a separable gaussian over
+  // it, and one masked composite in `shadowColor`. See lib/shadow.js for the
+  // blur and the cache, and docs/context-2d.md for what an app sees.
+
+  /**
+   * Gaussian blur applied to the shadow, in pixels. Canvas-spec units: this
+   * is a **diameter**, and the gaussian it names has σ = `shadowBlur / 2`,
+   * so a value here looks the same as the same value in a browser.
+   *
+   * Negative and non-finite values are ignored, as the spec requires.
+   */
+  set shadowBlur(value) {
+    const v = Number(value);
+    if (Number.isFinite(v) && v >= 0) this._shadowBlur = v;
+  }
+
+  get shadowBlur() {
+    return this._shadowBlur;
+  }
+
+  /**
+   * The shadow's colour. Defaults to fully transparent black, which is the
+   * spec's default and the switch that keeps every drawing operation on
+   * exactly the path it was on before shadows existed.
+   *
+   * A value that is not a colour is ignored (the spec's rule), so a
+   * mistyped colour leaves the previous shadow rather than throwing from
+   * inside a paint.
+   */
+  set shadowColor(value) {
+    let rgba;
+    try {
+      rgba = parseColor(value);
+    } catch {
+      return;
+    }
+    this._shadowColor = value;
+    this._shadowRgba = rgba;
+  }
+
+  get shadowColor() {
+    return this._shadowColor;
+  }
+
+  /**
+   * How far the shadow is offset. In **device** pixels: the spec puts
+   * shadow offsets outside the current transform, so a rotated drawing has
+   * an upright shadow, the same way a rotated element's box-shadow is
+   * upright in CSS.
+   *
+   * Offsets are rounded to whole pixels when the shadow is composited. The
+   * drawing's own sub-pixel position is preserved either way; what rounds
+   * is where its blurred copy lands.
+   */
+  set shadowOffsetX(value) {
+    const v = Number(value);
+    if (Number.isFinite(v)) this._shadowOffsetX = v;
+  }
+
+  get shadowOffsetX() {
+    return this._shadowOffsetX;
+  }
+
+  set shadowOffsetY(value) {
+    const v = Number(value);
+    if (Number.isFinite(v)) this._shadowOffsetY = v;
+  }
+
+  get shadowOffsetY() {
+    return this._shadowOffsetY;
+  }
+
+  /**
+   * Is there a shadow to paint at all?
+   *
+   * A shadow with no offset and no blur still paints — it lands exactly
+   * under the drawing, where it shows through anything translucent, which
+   * is what the spec says and what browsers do. Only a transparent
+   * `shadowColor` (the default) skips the work, so the answer is one array
+   * read on every fill of every app that never mentioned shadows.
+   */
+  _shadowed() {
+    return this._shadowRgba[3] > 0 && this.globalAlpha > 0;
+  }
+
+  /**
+   * The coverage surface's box in device space: the drawing's ink, padded by
+   * `reach` on every side so the blur has room to spread into, and clipped
+   * to the part of the drawing whose shadow could land on the target at all.
+   *
+   * That clip is exact rather than a heuristic. A source pixel at `s`
+   * spreads to shadow pixels `s + offset ± reach`, so ink further than
+   * `reach` outside the target (once the offset is undone) cannot contribute
+   * a single pixel of visible shadow — dropping it costs nothing and keeps a
+   * shape far off-screen from allocating a surface the size of its own
+   * bounding box.
+   */
+  _shadowBox(ink, reach) {
+    const ox = Math.round(this._shadowOffsetX);
+    const oy = Math.round(this._shadowOffsetY);
+    // a pixel of slack for the antialiased edge, as _clampBBox takes
+    const x0 = Math.max(Math.floor(ink.minX) - 1, -ox - reach);
+    const y0 = Math.max(Math.floor(ink.minY) - 1, -oy - reach);
+    const x1 = Math.min(Math.ceil(ink.maxX) + 1, this.width - ox + reach);
+    const y1 = Math.min(Math.ceil(ink.maxY) + 1, this.height - oy + reach);
+    if (x1 <= x0 || y1 <= y0) return null;
+    return {
+      x: x0 - reach,
+      y: y0 - reach,
+      w: x1 - x0 + reach * 2,
+      h: y1 - y0 + reach * 2,
+    };
+  }
+
+  /**
+   * Put this context's drawing state onto the coverage surface's context.
+   *
+   * `fillStyle` is opaque white and nothing else: an `a8` surface stores
+   * coverage, so what is drawn into it has to be at full alpha and takes its
+   * colour later, at the composite. `globalAlpha`, the composite op and the
+   * clip are deliberately *not* copied — they belong to that composite, not
+   * to the shape, and applying them twice would square the alpha.
+   */
+  _loadShadowState(sctx, dx, dy) {
+    // a device-space translation in front of the transform, so a user-space
+    // call replayed here lands where the surface expects it. Translation
+    // does not change the determinant, so the transform-aware line width
+    // in _strokePolys is the same one the real stroke will use.
+    sctx._m = matMultiply([1, 0, 0, 1, dx, dy], this._m);
+    sctx.fillStyle = "#fff";
+    sctx.strokeStyle = "#fff";
+    sctx.lineWidth = this.lineWidth;
+    sctx.lineCap = this.lineCap;
+    sctx.lineJoin = this.lineJoin;
+    sctx.miterLimit = this.miterLimit;
+    sctx._lineDash = this._lineDash;
+    sctx._lineDashOffset = this._lineDashOffset;
+    sctx._textStyle = this._textStyle;
+    sctx._lastFontString = this._lastFontString;
+    sctx._fontVariations = this._fontVariations;
+    sctx._textRendering = this._textRendering;
+    sctx.textAlign = this.textAlign;
+    sctx.textBaseline = this.textBaseline;
+    return sctx;
+  }
+
+  /**
+   * Composite finished shadow coverage: the surface is the mask,
+   * `shadowColor` is the source.
+   *
+   * Borrowing `fillStyle` for the length of the call is what puts the
+   * shadow through the same route a coverage `drawImage` takes — clip,
+   * `globalAlpha`, composite op and damage reporting all apply to it exactly
+   * as they do to the drawing it belongs to.
+   */
+  _paintShadow(surface, dx, dy) {
+    const style = this._fillStyle;
+    const picture = this._backgroundPicture;
+    this.fillStyle = this._shadowColor;
+    try {
+      this._drawCoverage(
+        surface.picture(this.window.app),
+        0,
+        0,
+        surface.width,
+        surface.height,
+        dx,
+        dy,
+        surface.width,
+        surface.height,
+        this._op(),
+      );
+    } finally {
+      this._fillStyle = style;
+      this._backgroundPicture = picture;
+    }
+  }
+
+  /**
+   * Paint the shadow of one drawing, given its device-space ink bounds and
+   * a way to draw it again into the coverage surface.
+   *
+   * `replay(sctx, dx, dy)` gets a context on that surface with this one's
+   * state already on it, and the device offset that maps this context's
+   * coordinates into it. Nothing is cached: the geometry of a path has no
+   * short name to key it by. Text does, and takes `_shadowOfText` instead.
+   */
+  _shadowOfDrawing(ink, replay) {
+    if (!ink) return;
+    const app = this.window.app;
+    const policy = shadowPolicyOf(app);
+    const sigma = shadowSigma(this._shadowBlur, policy);
+    const reach = shadowReach(sigma);
+    const box = this._shadowBox(ink, reach);
+    if (!box || box.w * box.h > policy.maxPixels) return;
+
+    let surface = new Surface(app, {
+      width: box.w,
+      height: box.h,
+      format: "a8",
+    });
+    surface.render((sctx) => {
+      this._loadShadowState(sctx, -box.x, -box.y);
+      replay(sctx, -box.x, -box.y);
+    });
+    if (sigma > 0) surface = blurCoverage(surface, sigma);
+    this._paintShadow(
+      surface,
+      box.x + Math.round(this._shadowOffsetX),
+      box.y + Math.round(this._shadowOffsetY),
+    );
+    surface.destroy();
+  }
+
+  /** the shadow of a path fill or stroke, from its device-space polys */
+  _shadowOfPolys(polys, { rule = "nonzero", stroke = false } = {}) {
+    const ink = polysInk(polys);
+    if (!ink) return;
+    if (stroke) {
+      // the stroke's ink is the extruded outline, which is not built yet —
+      // over-estimate it. Half the width covers the band, the miter limit
+      // covers the spike a sharp corner can throw, and the cost of guessing
+      // high is blur over a few empty pixels.
+      const det = this._m[0] * this._m[3] - this._m[1] * this._m[2];
+      const scale = Math.sqrt(Math.abs(det)) || 1;
+      const half = (this.lineWidth * scale) / 2;
+      const spike =
+        this.lineJoin === "miter" ? Math.min(Math.max(this.miterLimit, 1), 10) : 1.5;
+      const slack = half * spike + 1;
+      ink.minX -= slack;
+      ink.minY -= slack;
+      ink.maxX += slack;
+      ink.maxY += slack;
+    }
+    this._shadowOfDrawing(ink, (sctx, dx, dy) => {
+      const moved = shiftPolys(polys, dx, dy);
+      if (stroke) sctx._strokePolys(moved);
+      else sctx._fillPolys(moved, rule);
+    });
+  }
+
+  /**
+   * The shadow of a run of text, cached.
+   *
+   * Text is the one drawing with a short, stable name — the string, the
+   * font and the blur — so its coverage is built once and composited on
+   * every frame afterwards, which is the difference between a specimen that
+   * rebuilds two surfaces and a blur per slider tick and one that does not.
+   *
+   * The cached copy is position-independent: the run's origin sits at a
+   * whole pixel inside the surface, and the composite carries it to wherever
+   * the text is. Glyph origins are rounded to whole pixels on the way to the
+   * server anyway, so nothing is lost by it.
+   */
+  _shadowOfText(text, x, y) {
+    const app = this.window.app;
+    const policy = shadowPolicyOf(app);
+    const sigma = shadowSigma(this._shadowBlur, policy);
+    const reach = shadowReach(sigma);
+    const style = this._resolvedTextStyle();
+    // the same shaping memo fillText draws from, so a shadowed label shapes
+    // once per frame rather than twice
+    const shaped = app.fonts._shapeCachedWhole(text, style);
+    const ink = this._shapedInk(shaped);
+    // rounded outwards, with a pixel of antialiasing slack
+    const left = Math.ceil(-ink.minX) + 1;
+    const right = Math.ceil(ink.maxX) + 1;
+    const ascent = Math.ceil(-ink.minY) + 1;
+    const descent = Math.ceil(ink.maxY) + 1;
+    const width = left + right + reach * 2;
+    const height = ascent + descent + reach * 2;
+    if (width <= 0 || height <= 0) return;
+    // the run's origin inside the surface — whole pixels, so the coverage
+    // is the same wherever on the target the text is drawn
+    const originX = reach + left;
+    const originY = reach + ascent;
+
+    // where the run's origin lands on the target, exactly as fillText puts it
+    const [tx, ty] = matApply(this._m, x, y);
+    const runX = tx + this._alignOffset(shaped);
+    const runY = ty + this._baselineOffset(style.font.metrics(style.size));
+
+    // A run whose padded ink is larger than a shadow surface may be does not
+    // get one: fall back to the clipped, uncached path, which sizes itself
+    // to the part of the shadow that can actually be seen.
+    if (width * height > policy.maxPixels) {
+      this._shadowOfDrawing(
+        {
+          minX: runX + ink.minX,
+          maxX: runX + ink.maxX,
+          minY: runY + ink.minY,
+          maxY: runY + ink.maxY,
+        },
+        (sctx) => sctx.fillText(text, x, y),
+      );
+      return;
+    }
+
+    const key = [
+      text,
+      this._lastFontString,
+      style.font.key,
+      variationsKey(this._fontVariations),
+      this._textRendering ?? "",
+      sigma,
+    ].join("\u0000");
+    const surface = cachedShadow(app, key, () => {
+      let coverage = new Surface(app, { width, height, format: "a8" });
+      coverage.render((sctx) => {
+        this._loadShadowState(sctx, 0, 0);
+        // the origin is placed by hand, so neither alignment nor the
+        // baseline may move it again
+        sctx._m = [1, 0, 0, 1, 0, 0];
+        sctx.textAlign = "left";
+        sctx.textBaseline = "alphabetic";
+        sctx.fillText(text, originX, originY);
+      });
+      if (sigma > 0) coverage = blurCoverage(coverage, sigma);
+      return coverage;
+    });
+    if (!surface) return;
+    this._paintShadow(
+      surface,
+      Math.round(runX + this._shadowOffsetX) - originX,
+      Math.round(runY + this._shadowOffsetY) - originY,
+    );
+  }
+
+  /** the shadow of a `fill()`/`stroke()`-shaped call, from its arguments */
+  _shadowOfPath(args, stroke) {
+    if (stroke) {
+      const polys =
+        args[0] instanceof Path2D
+          ? flattenPath(args[0]._cmds, this._m)
+          : flattenPath(this._path._cmds, null);
+      this._shadowOfPolys(polys, { stroke: true });
+      return;
+    }
+    const { polys, rule } = this._polysFor(args);
+    this._shadowOfPolys(polys, { rule });
+  }
+
+  /**
+   * The shadow of a `drawImage`, from the destination rectangle its
+   * arguments describe.
+   *
+   * The image is drawn again into the coverage surface rather than its alpha
+   * being read out: an `a8` destination *is* the alpha channel, so an
+   * ordinary composite of the image onto one leaves exactly the coverage the
+   * shadow needs — including a translucent image's soft edges, and whatever
+   * scaling or transform the call asked for.
+   */
+  _shadowOfImage(image, args) {
+    const iw = image?.width;
+    const ih = image?.height;
+    if (!Number.isFinite(iw) || !Number.isFinite(ih)) return;
+    let rect;
+    if (args.length >= 8) rect = args.slice(4, 8);
+    else if (args.length >= 4) rect = args.slice(0, 4);
+    else rect = [args[0] ?? 0, args[1] ?? 0, iw, ih];
+    const [dx, dy, dw, dh] = rect;
+    if (!(dw > 0) || !(dh > 0)) return;
+    const corners = [
+      matApply(this._m, dx, dy),
+      matApply(this._m, dx + dw, dy),
+      matApply(this._m, dx, dy + dh),
+      matApply(this._m, dx + dw, dy + dh),
+    ];
+    const xs = corners.map((c) => c[0]);
+    const ys = corners.map((c) => c[1]);
+    this._shadowOfDrawing(
+      {
+        minX: Math.min(...xs),
+        maxX: Math.max(...xs),
+        minY: Math.min(...ys),
+        maxY: Math.max(...ys),
+      },
+      (sctx) => sctx.drawImage(image, ...args),
+    );
+  }
+
+  /** the shadow of an axis-aligned rectangle in user space */
+  _shadowOfRect(x, y, w, h, stroke) {
+    const tmp = new Path2D();
+    tmp.rect(x, y, w, h);
+    this._shadowOfPolys(flattenPath(tmp._cmds, this._m), { stroke });
   }
 
   // ------------------------------------------------------------------
@@ -1905,6 +2365,13 @@ class RenderingContext2d {
   }
 
   fillRect(x, y, w, h) {
+    if (this._shadowed()) this._shadowOfRect(x, y, w, h, false);
+    this._fillRect(x, y, w, h);
+  }
+
+  /** fillRect minus the shadow — the batch in `fillRects` paints one shadow
+   * for the whole list and then draws the rectangles through here */
+  _fillRect(x, y, w, h) {
     if (matIsIdentity(this._m)) {
       if (!preparePattern(this._backgroundPicture, this._m)) return;
       const mask = this._compositeMask();
@@ -1965,6 +2432,17 @@ class RenderingContext2d {
     }
     if (!flat.length) return;
 
+    // one shadow for the batch, not one per rectangle: the shadow of a
+    // group of rectangles is their combined coverage blurred once, and N
+    // separate shadows would darken every overlap
+    if (this._shadowed()) {
+      const rectPath = new Path2D();
+      for (let i = 0; i < flat.length; i += 4) {
+        rectPath.rect(flat[i], flat[i + 1], flat[i + 2], flat[i + 3]);
+      }
+      this._shadowOfPolys(flattenPath(rectPath._cmds, this._m), {});
+    }
+
     const clip = this._clips.length ? this._clipRect() : null;
     if (
       !matIsIdentity(this._m) ||
@@ -1972,7 +2450,7 @@ class RenderingContext2d {
       (this._clips.length && !clip)
     ) {
       for (let i = 0; i < flat.length; i += 4)
-        this.fillRect(flat[i], flat[i + 1], flat[i + 2], flat[i + 3]);
+        this._fillRect(flat[i], flat[i + 1], flat[i + 2], flat[i + 3]);
       return;
     }
     if (clip && (clip.w === 0 || clip.h === 0)) return; // clipped away
@@ -2005,6 +2483,7 @@ class RenderingContext2d {
   }
 
   strokeRect(x, y, w, h) {
+    if (this._shadowed()) this._shadowOfRect(x, y, w, h, true);
     const m = this._m;
     if (m[0] === 1 && m[1] === 0 && m[2] === 0 && m[3] === 1) {
       const zero = { x: 0, y: 0 };
@@ -2025,12 +2504,14 @@ class RenderingContext2d {
   }
 
   fill(...args) {
+    if (this._shadowed()) this._shadowOfPath(args, false);
     if (this._tryRoundRectFill(args)) return;
     const { polys, rule } = this._polysFor(args);
     this._fillPolys(polys, rule);
   }
 
   stroke(...args) {
+    if (this._shadowed()) this._shadowOfPath(args, true);
     const box = this._shapeBoxFor(args);
     if (box && this._tryStrokeBox(box)) return;
     const polys =
@@ -2803,6 +3284,7 @@ class RenderingContext2d {
   fillText(text, x, y) {
     text = String(text ?? "");
     if (!text) return;
+    if (this._shadowed()) this._shadowOfText(text, x, y);
     const style = this._resolvedTextStyle();
     const app = this.window.app;
     // through the shaping memo TextLayout uses: a label repainted every
@@ -2835,9 +3317,13 @@ class RenderingContext2d {
    * `width` (advance), actual bounding box (ink extents relative to the
    * origin), and font bounding box (from font metrics).
    */
-  measureText(text) {
-    const style = this._resolvedTextStyle();
-    const shaped = this.window.app.fonts.shape(String(text ?? ""), style);
+  /**
+   * Ink extents of a shaped run, relative to its origin: the loop behind
+   * `measureText`'s actual bounding box, shared with the shadow path so a
+   * shadowed `fillText` does not shape its text a second time to find out
+   * how big its coverage surface has to be.
+   */
+  _shapedInk(shaped) {
     let minX = 0;
     let maxX = 0;
     let minY = 0;
@@ -2855,6 +3341,13 @@ class RenderingContext2d {
         cursor += g.ax;
       }
     }
+    return { minX, maxX, minY, maxY };
+  }
+
+  measureText(text) {
+    const style = this._resolvedTextStyle();
+    const shaped = this.window.app.fonts.shape(String(text ?? ""), style);
+    const { minX, maxX, minY, maxY } = this._shapedInk(shaped);
     const m = style.font.metrics(style.size);
     return {
       width: shaped.width,
@@ -3419,6 +3912,7 @@ class RenderingContext2d {
   }
 
   drawImage(image, ...args) {
+    if (this._shadowed()) this._shadowOfImage(image, args);
     if (isPictureSource(image)) {
       let sx = 0;
       let sy = 0;

--- a/lib/shadow.js
+++ b/lib/shadow.js
@@ -1,0 +1,199 @@
+// Drop shadows for the 2d context (issue #272): the blur, the surfaces it
+// runs on, and the cache that keeps a redrawn shadow from being rebuilt.
+//
+// The drawing itself lives in renderingcontext_2d.js — everything here is
+// the part with no X connection in it (the kernel maths) or the part every
+// shadowed operation shares (the coverage surfaces and their budget).
+//
+// ## How a shadow is drawn
+//
+// A shadow is the drawing's *coverage*, blurred, offset, and painted in one
+// colour. Coverage is what an `a8` Surface holds and what XRender composites
+// a solid through, so the whole thing is three server-side steps:
+//
+//   1. draw the shape into a padded a8 surface — white on transparent, so
+//      every pixel is its own alpha
+//   2. blur it: two convolution passes, horizontal then vertical
+//   3. composite the result as a mask, with `shadowColor` as the source
+//
+// The padding in (1) is not optional. A convolution samples outside the
+// picture, where RepeatNone reads transparent, so a shape drawn flush to the
+// surface edge ends in a straight line where the kernel ran out of pixels.
+// `reach` is how far coverage can spread, and every surface carries it on
+// all four sides.
+//
+// ## Why two passes
+//
+// A gaussian is separable, and that is the difference between a shadow you
+// can animate and one you cannot: a k-wide 2d kernel costs k² multiplies per
+// pixel where two 1d passes cost 2k. At `shadowBlur: 30` that is 8281 against
+// 182. RENDER has no separable-convolution filter, but it does not need one —
+// two `convolution` filters and two composites are the same thing, and the
+// second pass leaves a surface with the blur already in its pixels, so the
+// cached copy composites as a plain mask rather than re-running a kernel on
+// every frame.
+import { Surface } from './surface.js';
+
+/**
+ * Shadow policy — the cost ceilings, per app via `app.shadowPolicy`
+ * (partial objects are merged over the defaults). See docs/context-2d.md.
+ *
+ * - `cacheBytes` — LRU budget for retained shadow coverage per connection.
+ *   Keyed by (text, font, blur) for text; least-recently-drawn surfaces are
+ *   destroyed server-side once the total goes over.
+ * - `maxSigma` — the widest gaussian actually run. The kernel is 6σ+1 wide,
+ *   the request carries every tap, and the server multiplies each of them
+ *   per pixel per pass, so an unbounded `shadowBlur` is an unbounded
+ *   request and an unbounded stall. Past this the blur stops widening.
+ * - `maxPixels` — the largest coverage surface built for one shadow. Beyond
+ *   it the shadow is dropped rather than turning one drawing into a
+ *   multi-megabyte allocation; the drawing itself is unaffected.
+ */
+export const DEFAULT_SHADOW_POLICY = {
+  cacheBytes: 4 << 20,
+  maxSigma: 32,
+  maxPixels: 8 << 20
+};
+
+/** the policy for one app, merged over the defaults */
+export function shadowPolicyOf(app) {
+  return app?.shadowPolicy
+    ? { ...DEFAULT_SHADOW_POLICY, ...app.shadowPolicy }
+    : DEFAULT_SHADOW_POLICY;
+}
+
+/**
+ * The gaussian a `shadowBlur` asks for.
+ *
+ * `shadowBlur` is a **diameter**, not a radius: the canvas spec says a
+ * shadow is blurred by a gaussian whose standard deviation is half of it.
+ * Getting this wrong is invisible until someone compares against a browser,
+ * so it is one line with a test on it — `shadowBlur: 8` must be σ = 4 here
+ * exactly as it is in Chrome and Firefox.
+ *
+ * Clamped to the policy's `maxSigma`, which is the only place a shadow
+ * silently stops matching a browser; the cap is chosen so that no shadow a
+ * UI actually draws reaches it.
+ */
+export function shadowSigma(blur, policy = DEFAULT_SHADOW_POLICY) {
+  const sigma = blur / 2;
+  return sigma > policy.maxSigma ? policy.maxSigma : sigma;
+}
+
+/**
+ * How far the blur spreads coverage, in pixels — the kernel's half-width,
+ * and therefore the padding every coverage surface needs on each side.
+ *
+ * Truncating a gaussian at 3σ leaves 0.3% of its weight outside, which is
+ * below one step of the 8-bit coverage it is convolving.
+ */
+export function shadowReach(sigma) {
+  return sigma > 0 ? Math.ceil(sigma * 3) : 0;
+}
+
+/**
+ * A normalized 1d gaussian, `2 * reach + 1` taps wide.
+ *
+ * Normalizing the *truncated* kernel rather than the ideal one is what keeps
+ * a flat interior at full coverage: a shadow under an opaque box must stay
+ * opaque in the middle, and a kernel summing to 0.997 would leave it at 254.
+ */
+export function gaussianKernel1d(sigma, reach = shadowReach(sigma)) {
+  const values = new Array(reach * 2 + 1);
+  let sum = 0;
+  for (let i = -reach; i <= reach; i++) {
+    const v = Math.exp(-(i * i) / (2 * sigma * sigma));
+    values[i + reach] = v;
+    sum += v;
+  }
+  for (let i = 0; i < values.length; i++) values[i] /= sum;
+  return values;
+}
+
+/**
+ * Blur an a8 coverage surface, returning a new one holding the result.
+ *
+ * The input is destroyed: a caller has no use for the sharp copy afterwards,
+ * and leaving it alive would double what the cache is holding. The output
+ * carries no filter of its own, so compositing it is an ordinary masked
+ * composite no matter how wide the blur was.
+ */
+export function blurCoverage(shape, sigma) {
+  const app = shape.app;
+  const R = app.display.Render;
+  const { width, height } = shape;
+  const kernel = gaussianKernel1d(sigma);
+  const scratch = new Surface(app, { width, height, format: 'a8' });
+  const out = new Surface(app, { width, height, format: 'a8' });
+
+  const pass = (src, dst, params) => {
+    src.picture().setFilter('convolution', params);
+    // Src, not Over: each pass replaces the destination, which was cleared
+    // to transparent on creation. Over would accumulate the sharp copy's
+    // coverage under the blurred one and give the shadow a hard core.
+    R.Composite(R.PictOp.Src, src.picture().id, 0, dst.picture().id, 0, 0, 0, 0, 0, 0, width, height);
+  };
+  pass(shape, scratch, [kernel.length, 1, ...kernel]);
+  pass(scratch, out, [1, kernel.length, ...kernel]);
+
+  shape.destroy();
+  scratch.destroy();
+  return out;
+}
+
+/**
+ * A shadow's coverage, from the cache when it has been seen before.
+ *
+ * `build()` returns the finished (blurred) surface, or null when there is
+ * nothing to draw. A null `key` means "not cacheable" — the geometry has no
+ * short name, as a path's does not — and the caller owns the surface it gets
+ * back. With a key, the cache owns it and the caller must not destroy it.
+ *
+ * Cached on the app rather than the context because contexts are short-lived
+ * (`Surface.render` builds one per call) while a shadow is a property of the
+ * drawing, which outlives them — the same reason `solidPicture` and the
+ * glyph pages live there.
+ */
+export function cachedShadow(app, key, build) {
+  if (key === null) return build();
+  const cache = (app._shadowSurfaces ??= new Map());
+  const hit = cache.get(key);
+  if (hit) {
+    // Map iteration order is insertion order — re-insert to mark recent
+    cache.delete(key);
+    cache.set(key, hit);
+    return hit;
+  }
+  const surface = build();
+  if (!surface) return null;
+  cache.set(key, surface);
+  trimShadowSurfaces(app, shadowPolicyOf(app), surface);
+  return surface;
+}
+
+/**
+ * Evict least-recently-drawn shadow coverage until the cache fits its
+ * budget. `keep` is never evicted: it is the surface the caller is about to
+ * composite, and a budget smaller than one shadow must not free it mid-draw.
+ */
+export function trimShadowSurfaces(app, policy = shadowPolicyOf(app), keep = null) {
+  const cache = app._shadowSurfaces;
+  if (!cache) return;
+  let total = 0;
+  for (const surface of cache.values()) total += surface.bytes;
+  for (const [key, surface] of cache) {
+    if (total <= policy.cacheBytes) break;
+    if (surface === keep) continue;
+    cache.delete(key);
+    total -= surface.bytes;
+    surface.destroy();
+  }
+}
+
+/** free every cached shadow surface — connection teardown */
+export function dropShadowSurfaces(app) {
+  const cache = app._shadowSurfaces;
+  if (!cache) return;
+  for (const surface of cache.values()) surface.destroy();
+  cache.clear();
+}

--- a/test/shadow.test.js
+++ b/test/shadow.test.js
@@ -1,0 +1,372 @@
+// Canvas shadows (issue #272): the four properties, and the coverage
+// surface + separable gaussian behind them.
+//
+// The kernel maths is asserted on its own (no X at all), and everything else
+// runs against node-x11's in-process pure-JS X server, which implements the
+// convolution filter — so the blur is checked as *pixels*, including the one
+// number that decides whether a shadow looks like a browser's: shadowBlur is
+// a diameter, and the gaussian it names has sigma = blur / 2.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource, Surface } from '../lib/index.js';
+import {
+  DEFAULT_SHADOW_POLICY,
+  gaussianKernel1d,
+  shadowReach,
+  shadowSigma
+} from '../lib/shadow.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(dirname(require.resolve('katex/package.json')), 'dist', 'fonts');
+
+const W = 120;
+const H = 80;
+
+let app = null;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), { family: 'Test Main' });
+  fontSource.alias('sans-serif', 'Test Main');
+  app = await createClient({ stream: clientEnd, fontSource });
+});
+
+after(async () => {
+  await app?.close();
+});
+
+/** a transparent depth-32 target and its context */
+function target(w = W, h = H) {
+  const pixmap = app.createPixmap({ width: w, height: h, depth: 32 });
+  const ctx = pixmap.getContext('2d');
+  const R = app.display.Render;
+  R.FillRectangles(R.PictOp.Src, ctx.picture.id, [0, 0, 0, 0], [0, 0, w, h]);
+  return ctx;
+}
+
+const readAll = async (ctx, w = W, h = H) => {
+  const img = await ctx.getImageData(0, 0, w, h);
+  return (x, y) => [...img.data.slice((y * w + x) * 4, (y * w + x) * 4 + 4)];
+};
+
+// ------------------------------------------------------------------
+// the mapping, on its own
+
+describe('the blur a shadowBlur asks for', () => {
+  test('shadowBlur is a diameter: sigma is half of it', () => {
+    assert.equal(shadowSigma(8), 4);
+    assert.equal(shadowSigma(0), 0);
+    assert.equal(shadowSigma(1), 0.5);
+  });
+
+  test('sigma is capped, so a kernel cannot grow without bound', () => {
+    const max = DEFAULT_SHADOW_POLICY.maxSigma;
+    assert.equal(shadowSigma(max * 4), max);
+    assert.equal(shadowReach(shadowSigma(max * 4)), Math.ceil(max * 3));
+  });
+
+  test('the kernel is normalized, symmetric and 3 sigma wide', () => {
+    const kernel = gaussianKernel1d(4);
+    assert.equal(kernel.length, 2 * 12 + 1, '3 sigma each side');
+    const sum = kernel.reduce((a, b) => a + b, 0);
+    assert.ok(Math.abs(sum - 1) < 1e-12, `sums to 1, got ${sum}`);
+    for (let i = 0; i < kernel.length; i++) {
+      assert.equal(kernel[i], kernel[kernel.length - 1 - i], 'symmetric');
+    }
+  });
+
+  test('the kernel really has the standard deviation it claims', () => {
+    // The truncated kernel's own second moment: what the server convolves
+    // with, not the ideal gaussian it was sampled from.
+    const sigma = 5;
+    const kernel = gaussianKernel1d(sigma);
+    const reach = (kernel.length - 1) / 2;
+    let variance = 0;
+    for (let i = 0; i < kernel.length; i++) variance += kernel[i] * (i - reach) ** 2;
+    // 1% under the ideal: what truncating at 3 sigma and renormalizing costs
+    assert.ok(
+      Math.abs(Math.sqrt(variance) - sigma) < 0.1,
+      `sigma ${Math.sqrt(variance)} should be ~${sigma}`
+    );
+  });
+});
+
+// ------------------------------------------------------------------
+// the properties
+
+describe('shadow properties', () => {
+  test('default to no shadow at all', () => {
+    const ctx = target();
+    assert.equal(ctx.shadowBlur, 0);
+    assert.equal(ctx.shadowOffsetX, 0);
+    assert.equal(ctx.shadowOffsetY, 0);
+    assert.equal(ctx.shadowColor, 'rgba(0, 0, 0, 0)');
+    ctx.destroy();
+  });
+
+  test('invalid values are ignored, not thrown or coerced', () => {
+    const ctx = target();
+    ctx.shadowBlur = 4;
+    ctx.shadowColor = '#f00';
+    ctx.shadowOffsetX = 3;
+    ctx.shadowBlur = -1;
+    ctx.shadowBlur = NaN;
+    ctx.shadowColor = 'not-a-colour';
+    ctx.shadowOffsetX = Infinity;
+    assert.equal(ctx.shadowBlur, 4);
+    assert.equal(ctx.shadowColor, '#f00');
+    assert.equal(ctx.shadowOffsetX, 3);
+    ctx.destroy();
+  });
+
+  test('save/restore carries them', () => {
+    const ctx = target();
+    ctx.shadowColor = '#00f';
+    ctx.shadowBlur = 2;
+    ctx.save();
+    ctx.shadowColor = '#0f0';
+    ctx.shadowBlur = 9;
+    ctx.shadowOffsetY = 4;
+    ctx.restore();
+    assert.equal(ctx.shadowColor, '#00f');
+    assert.equal(ctx.shadowBlur, 2);
+    assert.equal(ctx.shadowOffsetY, 0);
+    ctx.destroy();
+  });
+});
+
+// ------------------------------------------------------------------
+// pixels
+
+describe('drawing a shadow', () => {
+  test('a transparent shadowColor changes nothing', async () => {
+    const ctx = target();
+    ctx.shadowBlur = 8;
+    ctx.shadowOffsetX = 10;
+    ctx.shadowOffsetY = 10;
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(20, 20, 20, 20);
+    const at = await readAll(ctx);
+    assert.deepEqual(at(30, 30), [255, 0, 0, 255], 'the rect itself');
+    assert.deepEqual(at(45, 45), [0, 0, 0, 0], 'where the shadow would be');
+    ctx.destroy();
+  });
+
+  test('an unblurred shadow is the shape, offset and recoloured', async () => {
+    const ctx = target();
+    ctx.shadowColor = '#0000ff';
+    ctx.shadowOffsetX = 12;
+    ctx.shadowOffsetY = 8;
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(20, 20, 20, 20);
+    const at = await readAll(ctx);
+    assert.deepEqual(at(30, 30), [255, 0, 0, 255], 'the shape is drawn over its shadow');
+    assert.deepEqual(at(50, 45), [0, 0, 255, 255], 'the shadow is offset by (12, 8)');
+    assert.deepEqual(at(38, 25), [255, 0, 0, 255], 'the overlap belongs to the shape');
+    assert.deepEqual(at(19, 19), [0, 0, 0, 0], 'nothing before the shape');
+    assert.deepEqual(at(53, 49), [0, 0, 0, 0], 'nothing past the shadow');
+    ctx.destroy();
+  });
+
+  test('the blur has the profile of a gaussian with sigma = blur / 2', async () => {
+    // A half-plane's blurred edge is the gaussian's cumulative distribution,
+    // so the coverage at the edge is 0.5 and at n sigma either side is
+    // Phi(-n). That is the whole browser-compatibility claim, in pixels.
+    const blur = 8;
+    const sigma = blur / 2;
+    const ctx = target();
+    ctx.shadowColor = '#000000';
+    ctx.shadowBlur = blur;
+    ctx.fillStyle = 'rgba(0, 0, 0, 0)'; // shape invisible: only the shadow shows
+    // starts off the left edge, so the only edge in view is the one at x=40
+    ctx.fillRect(-30, 0, 70, H);
+    const at = await readAll(ctx);
+    const alphaAt = (x) => at(x, H / 2)[3] / 255;
+    // the edge is between pixel 39 and 40; sample pixel centres either side
+    const expected = [
+      [40 - 2 * sigma, 0.977],
+      [40 - sigma, 0.841],
+      [40, 0.5],
+      [40 + sigma, 0.159],
+      [40 + 2 * sigma, 0.023]
+    ];
+    for (const [x, want] of expected) {
+      const got = alphaAt(Math.round(x));
+      assert.ok(
+        Math.abs(got - want) < 0.06,
+        `coverage at x=${x} is ${got.toFixed(3)}, expected ~${want}`
+      );
+    }
+    assert.ok(alphaAt(5) > 0.99, 'the interior stays fully covered');
+    assert.ok(alphaAt(40 + Math.ceil(3 * sigma) + 2) < 0.01, 'and it ends');
+    ctx.destroy();
+  });
+
+  test('a blurred shadow spreads on every side, not just into the offset', async () => {
+    const ctx = target();
+    ctx.shadowColor = '#000000';
+    ctx.shadowBlur = 6;
+    ctx.fillStyle = 'rgba(0, 0, 0, 0)';
+    ctx.fillRect(40, 30, 20, 20);
+    const at = await readAll(ctx);
+    for (const [x, y, what] of [
+      [50, 26, 'above'],
+      [50, 53, 'below'],
+      [36, 40, 'left'],
+      [63, 40, 'right']
+    ]) {
+      assert.ok(at(x, y)[3] > 10, `${what} of the rect has shadow, got ${at(x, y)[3]}`);
+    }
+    ctx.destroy();
+  });
+
+  test('globalAlpha scales the shadow, and the clip clips it', async () => {
+    const ctx = target();
+    ctx.shadowColor = '#000000';
+    ctx.shadowOffsetX = 15;
+    ctx.globalAlpha = 0.5;
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(20, 20, 20, 20);
+    let at = await readAll(ctx);
+    assert.ok(
+      Math.abs(at(50, 30)[3] - 128) <= 1,
+      `the shadow is composited at globalAlpha, got ${at(50, 30)[3]}`
+    );
+    ctx.destroy();
+
+    const clipped = target();
+    clipped.shadowColor = '#000000';
+    clipped.shadowOffsetX = 15;
+    clipped.beginPath();
+    clipped.rect(0, 0, 45, H);
+    clipped.clip();
+    clipped.fillStyle = '#ff0000';
+    clipped.fillRect(20, 20, 20, 20);
+    at = await readAll(clipped);
+    assert.equal(at(44, 30)[3], 255, 'inside the clip');
+    assert.deepEqual(at(46, 30), [0, 0, 0, 0], 'the shadow stops at the clip');
+    clipped.destroy();
+  });
+
+  test('a stroke casts one too, and it follows the line width', async () => {
+    const ctx = target();
+    ctx.shadowColor = '#000000';
+    ctx.shadowOffsetY = 20;
+    ctx.strokeStyle = '#ff0000';
+    ctx.lineWidth = 6;
+    ctx.beginPath();
+    ctx.moveTo(20, 20);
+    ctx.lineTo(90, 20);
+    ctx.stroke();
+    const at = await readAll(ctx);
+    assert.ok(at(50, 20)[0] > 200, 'the line');
+    assert.ok(at(50, 40)[3] > 200, 'its shadow, 20px below');
+    assert.ok(at(50, 42)[3] > 200, 'as thick as the line');
+    assert.equal(at(50, 46)[3], 0, 'and no thicker');
+    ctx.destroy();
+  });
+
+  test('an image casts the shadow of its own alpha', async () => {
+    // a surface with a transparent right half: the shadow must have one too
+    const tile = new Surface(app, { width: 20, height: 20 });
+    tile.render((c) => {
+      c.fillStyle = '#ffffff';
+      c.fillRect(0, 0, 10, 20);
+    });
+    const ctx = target();
+    ctx.shadowColor = '#000000';
+    ctx.shadowOffsetX = 30;
+    ctx.drawImage(tile, 20, 20);
+    const at = await readAll(ctx);
+    assert.equal(at(55, 30)[3], 255, 'the shadow of the drawn half');
+    assert.equal(at(65, 30)[3], 0, 'nothing where the image was transparent');
+    tile.destroy();
+    ctx.destroy();
+  });
+
+  test('a shadow with no offset and no blur still shows under a translucent shape', async () => {
+    const ctx = target();
+    ctx.shadowColor = '#0000ff';
+    ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
+    ctx.fillRect(20, 20, 20, 20);
+    const at = await readAll(ctx);
+    const [r, g, b, a] = at(30, 30);
+    assert.equal(a, 255, 'shape over shadow is opaque');
+    assert.ok(r > 100 && b > 100 && g < 20, `red over blue, got ${[r, g, b]}`);
+    ctx.destroy();
+  });
+});
+
+// ------------------------------------------------------------------
+// text, and the cache it earns
+
+describe('text shadows', () => {
+  test('the glyphs cast one, offset from the text', async () => {
+    const ctx = target();
+    ctx.font = '30px sans-serif';
+    ctx.shadowColor = '#0000ff';
+    ctx.shadowOffsetX = 4;
+    ctx.shadowOffsetY = 4;
+    ctx.fillStyle = '#ff0000';
+    ctx.fillText('II', 20, 50);
+    const img = await ctx.getImageData(0, 0, W, H);
+    let red = 0;
+    let blue = 0;
+    for (let i = 0; i < img.data.length; i += 4) {
+      if (img.data[i] > 128 && img.data[i + 2] < 128) red++;
+      if (img.data[i + 2] > 128 && img.data[i] < 128) blue++;
+    }
+    assert.ok(red > 20, `the glyphs are drawn (${red} red pixels)`);
+    assert.ok(blue > 20, `and shadowed (${blue} blue pixels)`);
+    ctx.destroy();
+  });
+
+  test('the same text, font and blur is built once and kept', async () => {
+    app._shadowSurfaces?.clear(); // other tests in this file drew text too
+    const ctx = target();
+    ctx.font = '20px sans-serif';
+    ctx.shadowColor = '#000000';
+    ctx.shadowBlur = 4;
+    ctx.fillText('cached', 10, 30);
+    const built = app._shadowSurfaces.size;
+    const [surface] = [...app._shadowSurfaces.values()];
+    assert.equal(built, 1, 'one coverage surface');
+
+    ctx.fillText('cached', 40, 60); // same string, different place
+    assert.equal(app._shadowSurfaces.size, 1, 'the second draw reuses it');
+    assert.equal([...app._shadowSurfaces.values()][0], surface, 'the same one');
+
+    ctx.shadowBlur = 9; // a different blur is a different shadow
+    ctx.fillText('cached', 10, 30);
+    assert.equal(app._shadowSurfaces.size, 2);
+    ctx.destroy();
+    app._shadowSurfaces.clear();
+  });
+
+  test('the cache stays inside its budget', async () => {
+    const ctx = target();
+    ctx.font = '20px sans-serif';
+    ctx.shadowColor = '#000000';
+    app._shadowSurfaces?.clear();
+    app.shadowPolicy = { cacheBytes: 4096 };
+    for (const word of ['one', 'two', 'three', 'four', 'five']) {
+      ctx.fillText(word, 10, 30);
+    }
+    let bytes = 0;
+    for (const surface of app._shadowSurfaces.values()) bytes += surface.bytes;
+    assert.ok(bytes <= 4096, `${bytes} bytes retained, budget 4096`);
+    assert.ok(app._shadowSurfaces.size >= 1, 'the last one drawn is still there');
+    delete app.shadowPolicy;
+    app._shadowSurfaces.clear();
+    ctx.destroy();
+  });
+});

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -285,3 +285,53 @@ test('createPattern: a tile repeats across a fill, on a real server', async (t) 
   tile.destroy();
   pixmap.destroy();
 });
+
+test('shadows: offset, blurred and coloured, on a real server', async (t) => {
+  if (skip) return t.skip(skip);
+  // The hermetic run (test/shadow.test.js) proves the blur against node-x11's
+  // JS server. This one proves the same shadow survives the round trip to
+  // Xorg's RENDER: the convolution filter is what carries it, and a server
+  // that silently ignored the filter would still return a shadow — just an
+  // unblurred one, which the profile below would catch.
+  const { pixmap, ctx } = freshCtx();
+
+  ctx.shadowColor = 'black';
+  ctx.shadowOffsetX = 8;
+  ctx.shadowOffsetY = 8;
+  ctx.fillStyle = 'red';
+  ctx.fillRect(8, 8, 24, 24);
+
+  let image = await readPixels(ctx, 64, 64);
+  assert.deepEqual(px(image, 64, 20, 20), [255, 0, 0], 'the rect');
+  assert.deepEqual(px(image, 64, 36, 36), [0, 0, 0], 'its shadow, offset by (8, 8)');
+  assert.deepEqual(px(image, 64, 41, 41), [255, 255, 255], 'and nothing past it');
+
+  const blurred = freshCtx();
+  const bctx = blurred.ctx;
+  const blur = 8;
+  bctx.shadowColor = 'black';
+  bctx.shadowBlur = blur;
+  bctx.fillStyle = 'rgba(0, 0, 0, 0)'; // only the shadow paints
+  bctx.fillRect(-16, 0, 48, 64); // one edge in view, at x = 32
+
+  image = await readPixels(bctx, 64, 64);
+  // white background, black shadow: the grey level is 1 - coverage, and a
+  // blurred edge follows the gaussian's CDF (sigma = blur / 2)
+  const coverage = (x) => 1 - px(image, 64, x, 32)[0] / 255;
+  for (const [x, want] of [
+    [32 - blur / 2, 0.841],
+    [32, 0.5],
+    [32 + blur / 2, 0.159],
+  ]) {
+    const got = coverage(x);
+    assert.ok(
+      Math.abs(got - want) < 0.08,
+      `coverage at x=${x} is ${got.toFixed(3)}, expected ~${want}`
+    );
+  }
+  assert.ok(coverage(8) > 0.98, 'the interior is fully covered');
+  assert.ok(coverage(50) < 0.02, 'and the blur ends');
+
+  blurred.pixmap.destroy();
+  pixmap.destroy();
+});


### PR DESCRIPTION
Closes #272.

```js
ctx.shadowBlur = 7;
ctx.shadowColor = '#05070a';
ctx.shadowOffsetX = ctx.shadowOffsetY = 3;
ctx.fillText(text, x, baseline);
```

The four canvas properties, applied to `fill`, `stroke`, `fillText`, `fillRect`, `strokeRect`, `fillRects` and `drawImage`. Everything behind them was already here and server-side; what was missing was the API, and the three facts an app had to know to assemble one by hand — that `a8` means "mask for the fill", that the surface needs padding or the gaussian clips square at its edge, and that the surface's own baseline has to be offset by the ascent to land where `fillText` would have put it.

![shadows](https://github.com/user-attachments/assets/69165d0e-fbaa-4d82-8b90-06616afc4197)

*(rendered by this branch: `node examples/shadows.js`, captured headless into a pixmap with `getImageData`)*

## How it works

A shadow is the drawing's **coverage**, blurred, offset and painted in one colour — three server-side steps:

1. the shape is drawn into a padded `a8` `Surface`, white on transparent, so every pixel is its own alpha
2. two `convolution` filter passes blur it, horizontal then vertical
3. the result composites as a mask with `shadowColor` as the source

Because step 3 is the coverage `drawImage` route, the clip, `globalAlpha`, the composite op and damage reporting all apply to the shadow exactly as they do to the drawing it belongs to. The shadow is painted first, so the drawing lands on top.

**Two 1d passes, not one 2d kernel.** A gaussian is separable, and that is the difference between a shadow you can animate and one you cannot: a k-wide 2d kernel costs k² multiplies per pixel where two passes cost 2k. At `shadowBlur: 30` that is 8281 against 182. RENDER has no separable-convolution filter and does not need one — two filters and two composites are the same thing, and the second pass leaves the blur *in the pixels*, so a cached copy composites as a plain mask rather than re-running a kernel every frame.

**The mapping the issue asked to pin.** `shadowBlur` is a diameter, so σ = `shadowBlur / 2`. A blurred half-plane edge is the gaussian's CDF, which makes the claim testable in pixels rather than in kernel coefficients: coverage is 0.5 at the edge, 0.841/0.159 one σ either side, 0.977/0.023 at two. That is asserted against node-x11's pure-JS server (which implements the convolution filter, so the hermetic run is a real pixel test) and again against a real server in `smoke-canvas`.

**Text coverage is cached**, keyed by `(text, font, blur)` on the connection, because text is the one drawing with a short stable name. The run's origin sits at a whole pixel inside the surface and the composite carries it to wherever the text is, so one surface serves every position — glyph origins are rounded to whole pixels on the way to the server anyway. Paths, rectangles and images rebuild theirs per draw.

**Nothing is rendered that cannot be seen.** A shape's ink is clipped to the part whose shadow could land on the target at all — its own bounds, moved back by the offset and grown by the blur's reach — which is exact rather than a heuristic: ink further away than the reach cannot contribute a single visible pixel.

**Zero cost when unused.** `shadowColor` defaults to transparent black, and that is the switch: one array read per drawing operation and nothing else.

## Spec details worth naming

- offsets are in **device** pixels, outside the current transform, as the spec has it — a rotated drawing casts an upright shadow, like a rotated element's `box-shadow` in CSS. They are rounded to whole pixels at composite time; the drawing's own sub-pixel position is untouched
- a shadow with no offset and no blur still paints, under the shape, where it shows through anything translucent. That is the spec's behaviour and browsers do it; only a transparent colour skips
- invalid values are ignored rather than thrown or coerced (`shadowBlur = -1`, `shadowColor = 'nope'`), and all four join `save()`/`restore()`

## Cost ceilings

`app.shadowPolicy`, partial objects merged over the defaults:

- `cacheBytes` (4 MB) — LRU budget for retained shadow coverage
- `maxSigma` (32) — the widest gaussian actually run; the kernel is 6σ+1 taps and every tap rides the request and is multiplied per pixel per pass, so an unbounded `shadowBlur` would be an unbounded stall. The one place a shadow stops matching a browser
- `maxPixels` (8 M) — the largest coverage surface for one shadow; past it the shadow is dropped and the drawing is unaffected

## Changes

- `lib/shadow.js` — new: the kernel maths, the two-pass blur, and the per-connection coverage cache with its budget. Freed in `app.close()`
- `lib/renderingcontext_2d.js` — the four properties, the state entries, and one seam per drawing kind: paths replay their device polys, user-space calls replay through a device translation in front of the transform, text takes the cached route
- `test/shadow.test.js` — 18 tests: the kernel on its own, the properties, and pixels for the offset copy, the gaussian profile, spread on all four sides, `globalAlpha`, the clip, strokes, image alpha, the no-offset case, text, and the cache and its budget
- `test/smoke-canvas.test.js` — the same shadow and the same profile against a real server, which is what proves the convolution filter survives the round trip to Xorg
- `examples/shadows.js` — arrows change blur and offset; sliding the offset is the cached case
- docs: a `Shadows` section in `context-2d.md`, and the a8-surface-as-filter-target note `surface.md` was owed
