### PR TITLE
ci: check the squash commit as it will be wrapped, not as it is written

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,13 +305,21 @@ release and publishes to npm via OIDC trusted publishing (no token secrets).
   release PR appears (this happened to #85 → the empty re-record commit
   e523667, and again to #103 → 9fdbe38). Squash-merge puts the PR
   description in the body, so this applies to PR descriptions too.
+- **Keep a parenthetical short enough to survive the wrap.** The same grammar
+  rejects a `(` still open at the end of a line, and squash-merge wraps the
+  body at 72 columns — so an aside that is whole in the PR description can
+  arrive at release-please split across two lines. That is what skipped #278,
+  over a one-line `*(rendered by this branch: ...)*` caption 106 characters
+  long — restored, as #85 and #103 were, by an empty commit.
 - **CI checks this for you** — the `release-message` job runs
   `npm run check-release-message` over the title and body the squash would
   produce, using release-please's own parser, and names the line and column
-  it chokes on. Whether a given nested call trips the grammar depends on its
-  surroundings, so do not try to predict it from the rule above: the same
-  construct that broke #103 parses fine inside a fenced block. Run the
-  script locally against a file if you want to check before pushing.
+  it chokes on. It checks the message twice, as written and wrapped, because
+  the wrap is invisible until the merge. Whether a given nested call trips
+  the grammar depends on its surroundings, so do not try to predict it from
+  the rules above: the same construct that broke #103 parses fine inside a
+  fenced block. Run the script locally against a file if you want to check
+  before pushing.
 
 ## Gotchas
 

--- a/scripts/check-release-message.mjs
+++ b/scripts/check-release-message.mjs
@@ -5,64 +5,156 @@
 // release-please parses the whole thing with @conventional-commits/parser. A
 // message the grammar rejects is **silently skipped**: the Release workflow
 // goes green, logs "No user facing commits found", and no release PR appears.
-// That has now cost two releases — #85 and #103 — so this checks it in CI
-// rather than trusting anyone to remember the rule.
+// That has now cost three releases — #85, #103 and #278 — so this checks it in
+// CI rather than trusting anyone to remember the rules.
 //
-// The usual offender is nested parentheses, which the grammar does not
-// accept: `foo(a, b)` is fine, `premultiply(cssColorStraight(x))` is not.
-// Whether a given line trips it depends on the surrounding context, which is
-// exactly why this runs the real parser instead of a regex.
+// Two ways in, and the second is why this does not just parse the text it is
+// given:
+//
+//   1. nested parentheses, which the grammar does not accept: `foo(a, b)` is
+//      fine, `premultiply(cssColorStraight(x))` is not
+//   2. a parenthetical that GitHub's squash **wraps**, leaving the `(` on one
+//      line and the `)` on the next — which the grammar rejects just as
+//      firmly, and which is invisible in the PR body, where the line is whole
+//
+// (2) is what skipped #278: the body line
+//
+//   *(rendered by this branch: `node examples/shadows.js`, captured headless into a pixmap with `getImageData`)*
+//
+// parses on its own and fails once it is 72 columns wide. So the message is
+// checked twice, as written and as the squash would write it.
+//
+// Whether a given line trips the grammar depends on the surrounding context,
+// which is exactly why this runs the real parser instead of a regex.
 //
 //   node scripts/check-release-message.mjs <file>
 //   MESSAGE="..." node scripts/check-release-message.mjs
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 import { parser, toConventionalChangelogFormat } from '@conventional-commits/parser';
 
-const file = process.argv[2];
-const message = file ? readFileSync(file, 'utf8') : (process.env.MESSAGE ?? '');
+/** the column GitHub's squash wraps a commit body at */
+export const SQUASH_WIDTH = 72;
 
-if (!message.trim()) {
-  console.error('check-release-message: nothing to check (pass a file or set MESSAGE)');
-  process.exit(2);
+/**
+ * The message as the squash commit will hold it: the subject is left alone,
+ * and every body line longer than `width` is word-wrapped, greedily and never
+ * mid-token — a URL past the margin stays on one long line of its own.
+ *
+ * Close enough to GitHub's own wrapping that a body which will break in the
+ * squash breaks here too — which is the whole job. It is not byte-identical:
+ * GitHub also appends the PR number to the subject, and the squash UI is free
+ * to change its mind about blank lines.
+ */
+export function wrapLikeSquash(message, width = SQUASH_WIDTH) {
+  const [subject, ...body] = message.split('\n');
+  const wrap = (line) => {
+    if (line.length <= width) return [line];
+    const out = [];
+    let cur = '';
+    for (const word of line.split(' ')) {
+      if (!cur.length) cur = word;
+      else if (cur.length + 1 + word.length <= width) cur += ` ${word}`;
+      else {
+        out.push(cur);
+        cur = word;
+      }
+    }
+    out.push(cur);
+    return out;
+  };
+  return [subject, ...body.flatMap(wrap)].join('\n');
 }
 
-let ast;
-try {
-  ast = parser(message);
-} catch (err) {
-  const text = String(err.message);
+/**
+ * Parse one message. Returns the commit release-please would see, or the
+ * error it choked on with the line and column it named.
+ */
+export function parseMessage(message) {
+  let ast;
+  try {
+    ast = parser(message);
+  } catch (err) {
+    const text = String(err.message);
+    const at = /at (\d+):(\d+)/.exec(text);
+    return {
+      ok: false,
+      reason: text.split('\n')[0],
+      line: at ? Number(at[1]) : null,
+      column: at ? Number(at[2]) : null,
+    };
+  }
+  const commit = toConventionalChangelogFormat(ast);
+  return {
+    ok: true,
+    type: commit.type,
+    breaking: commit.notes.some((n) => n.title === 'BREAKING CHANGE'),
+  };
+}
+
+function report(message, failure, wrapped) {
   console.error('release-please could not parse this commit message.\n');
-  console.error(text.split('\n')[0]);
+  console.error(failure.reason);
+  if (wrapped) {
+    console.error(
+      `\nThis is the message *as the squash commit will hold it* — the body\n` +
+        `wrapped at ${SQUASH_WIDTH} columns. It parses as written, which is why the line\n` +
+        `below may look fine in the PR: the wrap is what splits it.`,
+    );
+  }
 
   // point at the line the parser named, since the column alone is no help
-  const at = /at (\d+):(\d+)/.exec(text);
-  if (at) {
-    const lines = message.split('\n');
-    const n = Number(at[1]);
-    const line = lines[n - 1];
+  if (failure.line !== null) {
+    const line = message.split('\n')[failure.line - 1];
     if (line !== undefined) {
-      console.error(`\n  ${n} | ${line}`);
-      console.error(`  ${' '.repeat(String(n).length)} | ${' '.repeat(Math.max(0, Number(at[2]) - 1))}^`);
+      console.error(`\n  ${failure.line} | ${line}`);
+      console.error(
+        `  ${' '.repeat(String(failure.line).length)} | ${' '.repeat(Math.max(0, failure.column - 1))}^`,
+      );
     }
   }
   console.error(
     '\nA message it cannot read is skipped silently: the Release workflow goes\n' +
-      'green and no release PR appears. Nested parentheses are the usual cause —\n' +
-      'rewrite them, e.g. "premultiply of cssColorStraight" rather than\n' +
-      'premultiply wrapping a call. See the Releases section of AGENTS.md.',
+      'green and no release PR appears. Two causes — nested parentheses, and a\n' +
+      'parenthesis left open at the end of a line. Rewrite them, e.g.\n' +
+      '"premultiply of cssColorStraight" rather than premultiply wrapping a\n' +
+      'call, and keep an aside short enough to survive the wrap. See the\n' +
+      'Releases section of AGENTS.md.',
   );
-  process.exit(1);
 }
 
-const commit = toConventionalChangelogFormat(ast);
-const RELEASING = new Set(['feat', 'fix', 'perf', 'revert']);
-const breaking = commit.notes.some((n) => n.title === 'BREAKING CHANGE');
-const bumps = breaking || RELEASING.has(commit.type);
+function main() {
+  const file = process.argv[2];
+  const message = file ? readFileSync(file, 'utf8') : (process.env.MESSAGE ?? '');
 
-console.log(`parses: type=${commit.type}${breaking ? ' (breaking)' : ''}`);
-console.log(
-  bumps
-    ? '  -> release-please will cut a version for this'
-    : `  -> no version bump for "${commit.type}", which is expected for docs/chore/test/ci`,
-);
+  if (!message.trim()) {
+    console.error('check-release-message: nothing to check (pass a file or set MESSAGE)');
+    process.exit(2);
+  }
+
+  // as written, then as the squash will write it — a message can pass the
+  // first and fail the second, which is the whole reason for the second
+  const wrapped = wrapLikeSquash(message);
+  for (const [text, isWrapped] of [
+    [message, false],
+    [wrapped, true],
+  ]) {
+    const result = parseMessage(text);
+    if (!result.ok) {
+      report(text, result, isWrapped);
+      process.exit(1);
+    }
+    if (isWrapped) {
+      console.log(`parses: type=${result.type}${result.breaking ? ' (breaking)' : ''}`);
+      const RELEASING = new Set(['feat', 'fix', 'perf', 'revert']);
+      console.log(
+        result.breaking || RELEASING.has(result.type)
+          ? '  -> release-please will cut a version for this'
+          : `  -> no version bump for "${result.type}", which is expected for docs/chore/test/ci`,
+      );
+    }
+  }
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) main();

--- a/test/release-message.test.js
+++ b/test/release-message.test.js
@@ -1,0 +1,105 @@
+// The guard in scripts/check-release-message.mjs, which stands between a PR
+// description and a release that silently does not happen.
+//
+// Both cases below are real. The nested call is #103's; the split parenthetical
+// is #278's, and it is the one the guard used to miss — the line is whole in
+// the PR body and only breaks once the squash wraps it.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+import {
+  SQUASH_WIDTH,
+  parseMessage,
+  wrapLikeSquash,
+} from '../scripts/check-release-message.mjs';
+
+const SCRIPT = fileURLToPath(new URL('../scripts/check-release-message.mjs', import.meta.url));
+
+/** run the guard as CI runs it; returns its exit code and stderr */
+function guard(message) {
+  const file = join(mkdtempSync(join(tmpdir(), 'ntk-relmsg-')), 'message.txt');
+  writeFileSync(file, message);
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, file], { encoding: 'utf8' });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { code: err.status, stdout: String(err.stdout), stderr: String(err.stderr) };
+  }
+}
+
+// the aside that got away, from PR #278's description
+const ASIDE =
+  '*(rendered by this branch: `node examples/shadows.js`, captured headless into a pixmap with `getImageData`)*';
+
+test('the subject line is never wrapped, however long it is', () => {
+  const subject = `feat(context2d): ${'x'.repeat(200)}`;
+  assert.equal(wrapLikeSquash(`${subject}\n\nbody`).split('\n')[0], subject);
+});
+
+test('body lines wrap at the squash column, on spaces only', () => {
+  const long = `${'word '.repeat(40).trim()}`;
+  const lines = wrapLikeSquash(`feat: x\n\n${long}`).split('\n').slice(2);
+  assert.ok(lines.length > 1, 'a 199-character line is wrapped');
+  for (const line of lines) assert.ok(line.length <= SQUASH_WIDTH, `"${line}" fits`);
+  assert.equal(lines.join(' '), long, 'and nothing is lost or added but the breaks');
+});
+
+test('a token wider than the column keeps its own line rather than being split', () => {
+  const url = `https://github.com/user-attachments/assets/${'0'.repeat(60)}`;
+  const lines = wrapLikeSquash(`feat: x\n\nsee ![img](${url})`).split('\n').slice(2);
+  assert.equal(lines.length, 2, 'the short words wrap off the front');
+  assert.ok(lines[1].includes(url), 'the unbreakable token survives whole');
+});
+
+test('a parenthetical that survives as written breaks once the squash wraps it', () => {
+  const message = `feat(context2d): shadows\n\n${ASIDE}\n`;
+  assert.equal(parseMessage(message).ok, true, 'the PR body parses — this is the false negative');
+
+  const wrapped = wrapLikeSquash(message);
+  const failure = parseMessage(wrapped);
+  assert.equal(failure.ok, false, 'and the commit GitHub writes from it does not');
+  assert.equal(
+    wrapped.split('\n')[failure.line - 1],
+    '*(rendered by this branch: `node examples/shadows.js`, captured headless',
+    'the guard names the line the wrap left an open paren on',
+  );
+});
+
+test('the guard fails on it, and says the wrap is why', () => {
+  const { code, stderr } = guard(`feat(context2d): shadows\n\n${ASIDE}\n`);
+  assert.equal(code, 1);
+  assert.match(stderr, /could not parse/);
+  assert.match(stderr, /as the squash commit will hold it/);
+});
+
+test('nested parentheses still fail, wrapped or not (#103)', () => {
+  // the real line from #103 — an invented one may well parse, which is why
+  // the guard runs the parser rather than looking for nested parens itself
+  const message =
+    'feat: export cssColorStraight and premultiply\n\n' +
+    '`premultiply(cssColorStraight(x))` equals `cssColor(x)`.\n';
+  assert.equal(parseMessage(message).ok, false);
+  assert.equal(guard(message).code, 1);
+});
+
+test('an ordinary message passes, and is reported as releasing', () => {
+  const { code, stdout } = guard(
+    'feat(context2d): shadows, with the blur run as two passes\n\n' +
+      'The four canvas properties, applied to fill, stroke and fillText. The\n' +
+      'blur runs as two 1d passes rather than one 2d kernel.\n',
+  );
+  assert.equal(code, 0);
+  assert.match(stdout, /parses: type=feat/);
+  assert.match(stdout, /will cut a version/);
+});
+
+test('a chore parses but is reported as not releasing', () => {
+  const { code, stdout } = guard('chore: bump the lockfile\n');
+  assert.equal(code, 0);
+  assert.match(stdout, /no version bump for "chore"/);
+});


### PR DESCRIPTION
#278 merged and release-please skipped it. The Release workflow went green, logged `commits: 3` for four commits since v8.0.0, and left the release PR untouched — no shadows entry in 8.1.0's changelog.

The run says why:

```
❯ commit could not be parsed: 6eba5a7 feat(context2d): shadows, ... (#278)
❯ error message: Error: unexpected token '\n' at 24:73, valid tokens [)]
❯ commits: 3
✔ PR #279 remained the same
```

Line 24 of the squash commit is the screenshot caption, and column 73 is its end: the line stops after `captured headless`, with the next one starting at `into a pixmap`. The caption's opening bracket is left unclosed at the newline, and the grammar rejects that.

In the PR description the same caption is a single 106-character line, whole and balanced. Squash-merge wraps the body at 72 columns on its way to becoming a commit, and the wrap is what splits it.

I cannot quote the two lines here as they appear in the commit: this description is checked by the very rule it is about, and quoting them would fail the check. That is the failure mode, exactly.

## Why the guard missed it

`release-message` passed on #278. It composes `MESSAGE` from `pull_request.title` and `pull_request.body` and parses that — the text before the transformation that breaks it. Verified in both directions against the real message:

| input | longest line | guard, before this branch |
| --- | --- | --- |
| title + body, as CI composed it | 526 | `parses: type=feat` |
| the same text wrapped at 72 | 72 | fails at the caption |
| the real squash commit `6eba5a7` | 91 | fails, `24:73` |

So the miss is not about nested parentheses, the failure mode the guard was written for after #85 and #103. It is a second, independent way in: any parenthetical long enough to be wrapped, which is a property of length rather than of nesting.

## What changed

- **The message is parsed twice**, as written and as the squash will write it. When only the second fails, the error says so, because the line it names looks fine in the PR.
- **`wrapLikeSquash` is the emulation**: the subject is left alone, body lines are word-wrapped at 72 columns, and a token wider than the margin keeps its own line rather than being split. Close to GitHub's wrapping rather than byte-identical to it, which is all the guard needs.
- **`.github/workflows/ci.yml` is unchanged** — the job already passed the right text. The script simply stops trusting it.

Run against the exact title and body CI had for #278, the guard now exits 1:

```
release-please could not parse this commit message.

unexpected token '

This is the message *as the squash commit will hold it* — the body
wrapped at 72 columns. It parses as written, which is why the line
below may look fine in the PR: the wrap is what splits it.

  23 | ...the caption line, elided here for the reason above...
     |                                                        ^
```

## Tests

New `test/release-message.test.js`, 8 cases: the wrapper's three rules, #278's caption parsing as written and failing once wrapped, the guard's exit code and its explanation, #103's nested call, and a passing feat plus a chore for the no-bump branch.

Both failure cases use the **real** lines. My first draft of the #103 case used an invented nested call in a plain sentence, and it parsed; the real line, the same call inside backticks, does not. Whether the grammar trips depends on the surroundings, which is the argument for running the parser rather than grepping for parentheses.

Full suite green locally against XQuartz, apart from the usual two that need a server this machine does not have: `glx` wants `+iglx` and `xi2-live` wants pointer warps to deliver motion.

## Still outstanding

The changelog entry for #278 itself. 8.1.0 is already a minor bump so the version is unaffected, but the line is missing, and an empty commit on master is what restores it — as it did for #85 and #103.
