### PR TITLE
fix(text): draw glyph runs through the transform, not past it

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -195,7 +195,11 @@ run        = { font, size, glyphs }             // a Font and a pixel size
 glyphs     = [{ id, ax, dx, dy }, …]            // drawing order
 ```
 
-- `x`, `y` — the run's baseline origin in device pixels.
+- `x`, `y` — the run's baseline origin, in the context's **user space**:
+  the current transform moves it, the same way it moves `fillText`'s
+  anchor and `fillRect`'s corner. The glyphs themselves are not rotated
+  or scaled by the transform — set `run.size` (or `ctx.font`) instead —
+  so the advances and offsets below stay device pixels.
 - `id` — a font glyph id: `shape()`'s `glyphs[].id`, or
   `font.glyphIdFor(codepoint)` for the unshaped cmap lookup. `glyphIdFor`
   is the lookup twin of `hasGlyph(codepoint)` and returns `null` where the
@@ -319,8 +323,11 @@ Results are inspectable before drawing: `layout.width`, `layout.height`,
 `layout.truncated`, `layout.lines[] = { x, y, height, baseline, width,
 ascent, descent, runs, start, end }` where `runs[] = { x, width, run, span,
 start, end }` in visual order (`start`/`end` are the logical UTF-16 ranges
-the line/run covers). `layout.draw(ctx, x, y)` draws, batching consecutive
-same-color runs into single requests.
+the line/run covers). `layout.draw(ctx, x, y)` draws at (x, y) in the
+context's user space — the transform applies to the origin, so a paragraph
+in a translated context lands with the rest of the drawing — batching
+consecutive same-color runs into single requests. Geometry and hit testing
+(`caretPosition`, `indexAt`, `lines[]`) are relative to that same origin.
 
 Line breaking is UAX#14 (`linebreak` package); `\n` forces breaks; a word
 wider than `maxWidth` force-breaks at the widest grapheme prefix that fits;

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -2131,7 +2131,9 @@ class RenderingContext2d {
    * @param {Picture} src source picture the glyphs paint with — a solid
    *   (`ctx.createSolidPicture(r, g, b, a)`, premultiplied 0..1) or a gradient
    * @param {Array<{run, x, y, textRendering?}>} positioned runs in visual
-   *   order; `x`/`y` is the run's baseline origin in device space. `run` is
+   *   order; `x`/`y` is the run's baseline origin in **user space** — the
+   *   current transform applies to it, as it does to every other drawing
+   *   call. `run` is
    *   `{ font, size, glyphs }` — a `Font`, a pixel size, and glyphs
    *   `{ id, ax, dx, dy }` in drawing order: `id` a font glyph id
    *   (`Font.shape()`'s `glyphs[].id`, or `Font.glyphIdFor(cp)`), `ax` the
@@ -2142,6 +2144,32 @@ class RenderingContext2d {
    *   (`codePoints`, `width`, …) are ignored. `textRendering` optionally
    *   overrides the bitmap/vector routing per run (docs/text.md).
    *
+   * The transform moves each run's origin, exactly as `fillText` moves its
+   * anchor; the glyphs themselves are not rotated or scaled by it (size the
+   * font via `ctx.font`, or `run.size`, instead). Advances and `dx`/`dy` are
+   * therefore device pixels on both calls. Without this, a `TextLayout`
+   * drawn into a translated context — which is every react-x11 canvas that
+   * is not at the window's origin — landed at the untransformed coordinates
+   * and was then cut by the clip, while the neighbouring `fillRect` and
+   * `drawImage` moved (issue #280).
+   */
+  drawGlyphs(op, src, positioned) {
+    const m = this._m;
+    if (!matIsIdentity(m)) {
+      positioned = positioned.map((p) => {
+        const [x, y] = matApply(m, p.x, p.y);
+        return { ...p, x, y };
+      });
+    }
+    this._drawGlyphsDevice(op, src, positioned);
+  }
+
+  /**
+   * `drawGlyphs` with the origins already in device space — the primitive
+   * under it, for callers that place glyphs themselves (`fillText`, which
+   * has to add the alignment and baseline offsets *after* the transform,
+   * because glyph advances are device pixels).
+   *
    * CompositeGlyphs writes straight to the destination picture, so it has
    * no way to consult our clip mask — text drawn through it used to spill
    * out of clipped boxes while every fill and stroke stayed inside. With a
@@ -2150,7 +2178,7 @@ class RenderingContext2d {
    * through the result — the same shape as _fillPolys. A rectangular clip
    * takes the server-side fast path below instead of the mask.
    */
-  drawGlyphs(op, src, positioned) {
+  _drawGlyphsDevice(op, src, positioned) {
     const app = this.window.app;
     const R = this.Render;
     if (!prepareStyle(src, this._m)) return;
@@ -3314,7 +3342,9 @@ class RenderingContext2d {
       });
       cursor += run.width;
     }
-    this.drawGlyphs(
+    // already device space: the anchor went through the matrix above, and
+    // the offsets and advances added to it are device pixels
+    this._drawGlyphsDevice(
       this.Render.PictOp.Over,
       this._backgroundPicture,
       positioned,

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -468,9 +468,21 @@ export class TextLayout {
   }
 
   /**
-   * Draw onto a 2d context at (x, y) = top-left of the layout box.
+   * Draw onto a 2d context at (x, y) = top-left of the layout box, in the
+   * context's **user space**: the current transform applies to the origin,
+   * the same way it applies to `fillText`, `fillRect` and `drawImage`, so a
+   * paragraph drawn into a translated context lands where the rest of the
+   * drawing does (issue #280). The glyphs themselves are not rotated or
+   * scaled by it — set the span size instead.
+   *
    * Span `color`s override the context fillStyle; consecutive same-color
    * runs are batched into single CompositeGlyphs requests.
+   *
+   * `caretPosition`/`indexAt` and the line/run geometry speak the same
+   * layout-relative coordinates as the (x, y) here, so hit testing stays
+   * `layout.indexAt(px - x, py - y)` — with (px, py) in user space too,
+   * which for a pointer event under a transformed context means undoing
+   * `ctx.getTransform()` first.
    */
   draw(ctx, x = 0, y = 0) {
     const app = ctx.window.app;
@@ -484,8 +496,9 @@ export class TextLayout {
     const flush = () => {
       if (batch.length === 0) return;
       const src = batchColor ? ctx._stylePicture(batchColor) : ctx._backgroundPicture;
-      // via the context so the clip is applied (drawGlyphRuns composites
-      // straight onto the picture and cannot see it)
+      // via the context so the clip and the transform are applied
+      // (drawGlyphRuns composites straight onto the picture and can see
+      // neither)
       if (typeof ctx.drawGlyphs === 'function') {
         ctx.drawGlyphs(Render.PictOp.Over, src, batch);
       } else {

--- a/test/glyph-transform.test.js
+++ b/test/glyph-transform.test.js
@@ -1,0 +1,219 @@
+// Glyph drawing must honour the context transform, like every other drawing
+// call (issue #280). `ctx.drawGlyphs` composited runs at the coordinates it
+// was handed while applying the clip, so a `TextLayout` drawn into a
+// translated context — every react-x11 <canvas> that is not at the window's
+// origin — landed at the untransformed spot and was then cut away, and the
+// two text APIs disagreed: `fillText` moved with the transform, `draw` did
+// not.
+//
+// Hermetic: node-x11's in-process pure-JS X server + the fixture font.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { after, before, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const VF = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'MonelogicsSubset[wght].ttf');
+
+const W = 240;
+const H = 90;
+
+let app = null;
+let font = null;
+
+before(async () => {
+  const server = xserver.createServer({ width: 480, height: 240 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(VF), { family: 'Fixture' });
+  fontSource.alias('sans-serif', 'Fixture');
+  app = await createClient({ stream: clientEnd, fontSource });
+  font = app.fonts.match('Fixture');
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, W, H);
+  ctx.fillStyle = 'black';
+  return { pixmap, ctx };
+}
+
+/** paint with `draw`, read the pixels back, and drop the pixmap */
+async function paint(draw) {
+  const { pixmap, ctx } = freshCtx();
+  draw(ctx);
+  const image = await ctx.getImageData(0, 0, W, H);
+  pixmap.destroy();
+  return image;
+}
+
+const isInk = (image, x, y) => image.data[(y * W + x) * 4] < 200;
+
+/** ink pixels inside a box, counted from the red channel (black on white) */
+function inkInBox(image, x0, y0, x1, y1) {
+  let n = 0;
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) if (isInk(image, x, y)) n++;
+  }
+  return n;
+}
+
+const samePixels = (a, b) => {
+  let diff = 0;
+  for (let i = 0; i < a.data.length; i += 4) {
+    if (Math.abs(a.data[i] - b.data[i]) > 0) diff++;
+  }
+  return diff;
+};
+
+const runOf = (text, size) => ({
+  font,
+  size,
+  glyphs: Array.from(text, (ch) => ({
+    id: font.glyphIdFor(ch.codePointAt(0)) ?? 0,
+    ax: 18,
+    dx: 0,
+    dy: 0
+  }))
+});
+
+const layoutOf = (text = 'Handgloves') =>
+  app.fonts.layout([{ text, family: 'sans-serif', size: 20, color: 'black' }], {
+    family: 'sans-serif',
+    size: 20
+  });
+
+// ------------------------------------------------------------- drawGlyphs
+
+test('drawGlyphs: a translated context moves the run, pixel for pixel', async () => {
+  const run = runOf('0123456', 22);
+  const black = (ctx) => ctx.createSolidPicture(0, 0, 0, 1);
+
+  const translated = await paint((ctx) => {
+    ctx.translate(90, 20);
+    ctx.drawGlyphs(ctx.Render.PictOp.Over, black(ctx), [{ run, x: 12, y: 30 }]);
+  });
+  const byHand = await paint((ctx) => {
+    ctx.drawGlyphs(ctx.Render.PictOp.Over, black(ctx), [{ run, x: 102, y: 50 }]);
+  });
+
+  assert.ok(inkInBox(byHand, 0, 0, W, H) > 0, 'the reference actually drew');
+  assert.equal(samePixels(translated, byHand), 0, 'translate moved the glyphs exactly');
+});
+
+test('drawGlyphs: the run origin goes through the whole matrix', async () => {
+  const run = runOf('012', 22);
+  const black = (ctx) => ctx.createSolidPicture(0, 0, 0, 1);
+
+  // a scale moves the origin the way it moves fillText's anchor; the glyphs
+  // themselves keep their size, which is what fillText documents too
+  const scaled = await paint((ctx) => {
+    ctx.scale(2, 3);
+    ctx.drawGlyphs(ctx.Render.PictOp.Over, black(ctx), [{ run, x: 20, y: 15 }]);
+  });
+  const byHand = await paint((ctx) => {
+    ctx.drawGlyphs(ctx.Render.PictOp.Over, black(ctx), [{ run, x: 40, y: 45 }]);
+  });
+  assert.ok(inkInBox(byHand, 0, 0, W, H) > 0, 'the reference actually drew');
+  assert.equal(samePixels(scaled, byHand), 0, 'the origin took the matrix');
+});
+
+test('drawGlyphs: save/restore puts the transform back', async () => {
+  const run = runOf('0123456', 22);
+  const black = (ctx) => ctx.createSolidPicture(0, 0, 0, 1);
+  const draw = (ctx, x, y) =>
+    ctx.drawGlyphs(ctx.Render.PictOp.Over, black(ctx), [{ run, x, y }]);
+
+  const nested = await paint((ctx) => {
+    ctx.save();
+    ctx.translate(40, 10);
+    ctx.translate(20, 20);
+    draw(ctx, 10, 20);
+    ctx.restore();
+    draw(ctx, 10, 80);
+  });
+  const byHand = await paint((ctx) => {
+    draw(ctx, 70, 50);
+    draw(ctx, 10, 80);
+  });
+  assert.equal(samePixels(nested, byHand), 0, 'nested translates compose, restore undoes them');
+});
+
+// -------------------------------------------------------- TextLayout.draw
+
+test('TextLayout.draw: the layout origin is in user space', async () => {
+  const translated = await paint((ctx) => {
+    ctx.translate(80, 24);
+    layoutOf().draw(ctx, 6, 4);
+  });
+  const byHand = await paint((ctx) => {
+    layoutOf().draw(ctx, 86, 28);
+  });
+  assert.ok(inkInBox(byHand, 0, 0, W, H) > 0, 'the reference actually drew');
+  assert.equal(samePixels(translated, byHand), 0, 'the paragraph moved with the transform');
+});
+
+test('TextLayout.draw and fillText agree under a transform', async () => {
+  // the same string at the same coordinates must land in the same place
+  // whichever call draws it — the disagreement in #280
+  const text = 'Handgloves';
+  const viaLayout = await paint((ctx) => {
+    ctx.translate(70, 12);
+    const layout = layoutOf(text);
+    layout.draw(ctx, 8, 20);
+  });
+  const viaFillText = await paint((ctx) => {
+    ctx.translate(70, 12);
+    ctx.font = '20px sans-serif';
+    ctx.fillStyle = 'black';
+    const layout = layoutOf(text);
+    // fillText anchors on the baseline; the layout's top-left is 20 above it
+    ctx.fillText(text, 8, 20 + layout.lines[0].baseline);
+  });
+  assert.ok(inkInBox(viaFillText, 0, 0, W, H) > 0, 'fillText actually drew');
+  assert.equal(samePixels(viaLayout, viaFillText), 0, 'both text APIs land together');
+});
+
+test('TextLayout.draw: a translated, clipped box keeps its paragraph', async () => {
+  // the shape of the react-x11 report: the element translates to its own
+  // origin and clips to its own box. Before the fix the glyphs were composited
+  // at the untranslated coordinates and the clip then destroyed all but a
+  // sliver of them.
+  const BOX = { x: 120, y: 10, w: 110, h: 70 };
+  const image = await paint((ctx) => {
+    ctx.save();
+    ctx.translate(BOX.x, BOX.y);
+    ctx.beginPath();
+    ctx.rect(0, 0, BOX.w, BOX.h);
+    ctx.clip();
+    layoutOf('Handgloves').draw(ctx, 4, 4);
+    ctx.restore();
+  });
+
+  const inside = inkInBox(image, BOX.x, BOX.y, BOX.x + BOX.w, BOX.y + BOX.h);
+  const outside = inkInBox(image, 0, 0, W, H) - inside;
+  assert.equal(outside, 0, 'nothing painted outside the clipped box');
+
+  // and the paragraph survives whole: the same ink as an unclipped draw at
+  // the box's origin, not the sliver a clipped-away paragraph leaves
+  const unclipped = await paint((ctx) => {
+    layoutOf('Handgloves').draw(ctx, BOX.x + 4, BOX.y + 4);
+  });
+  assert.equal(
+    inside,
+    inkInBox(unclipped, BOX.x, BOX.y, BOX.x + BOX.w, BOX.y + BOX.h),
+    'every glyph that fits the box is drawn'
+  );
+  assert.ok(inside > 0, 'and there is something to see');
+});


### PR DESCRIPTION
Both panels are rendered by this branch; the left one reaches the old code
path by pointing `drawGlyphs` at the device-space primitive underneath it.

![before and after](https://github.com/user-attachments/assets/6bbd96b0-8c79-4013-b8c7-0969d8f506e4)

`ctx.drawGlyphs` composited runs at the coordinates it was handed while
applying the clip, so a `TextLayout` drawn into a translated context landed
at the untransformed spot and was then cut away by the clip. In react-x11
that is every canvas element not at the window's origin: the renderer
translates to the node before the paint callback, so a paragraph moved 264px
left and lost all but a sliver of its ink. `fillText` had always moved with
the transform, so the two text APIs disagreed about where the same string at
the same coordinates goes.

`drawGlyphs` now maps each run's origin through the current matrix and
delegates to `_drawGlyphsDevice`, the device-space primitive underneath it.
`fillText` calls that primitive directly: its anchor already went through the
matrix, and the alignment, baseline and advance offsets added to it are
device pixels. Identity transforms allocate nothing and take the same path as
before.

The transform moves run origins, exactly as it moves `fillText`'s anchor; the
glyphs themselves are still not rotated or scaled by it, and `run.size` is
still the way to size them. Text under rotation and scale stays on the
missing list in AGENTS.md.

Note for hand-built runs: `drawGlyphs` positions are documented as user space
now, where they were device space before. Nothing changes under an identity
transform, which is what a terminal grid drawing straight into a window has;
a caller that was compensating by hand under a transform should drop the
compensation.

`TextLayout.caretPosition`, `indexAt` and the line and run geometry are
unchanged: they stay relative to the same origin `draw` takes, so hit testing
stays `layout.indexAt(px - x, py - y)`, now with the point in user space.

test/glyph-transform.test.js covers a translated `drawGlyphs` pixel for
pixel, an origin through a full matrix, save/restore nesting, a translated
`TextLayout.draw`, agreement between `draw` and `fillText` under the same
translation, and the reported case of a translated and clipped element
keeping its whole paragraph. All six fail without the fix.

Fixes #280
