### PR TITLE
feat(window): a public wait for an adopted window's geometry

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -698,7 +698,12 @@ chart fills and any texture-shaped background.
   `Window`. A repeating Picture is created *over* those pixels, so tiling a
   surface does not change how `drawImage` samples that same surface. A
   coverage (`a8`) surface is refused: it has no colour to paint with —
-  `drawImage` is what paints coverage in the current `fillStyle`
+  `drawImage` is what paints coverage in the current `fillStyle`. A `Window`
+  has to know its depth first, because that is where the tile's picture
+  format comes from: `await wnd.getGeometry()` establishes it on any window,
+  and `await wnd.ready` is the cheaper wait on one adopted by id, which ntk
+  has already asked about — see
+  [Adopted windows](window.md#adopted-windows)
 - **`repetition`** is `'repeat'` (the default, and what `null` means),
   `'no-repeat'`, or the two XRender modes the canvas spec has no name for:
   `'pad'` (clamp to the edge pixels) and `'reflect'` (mirror every other

--- a/docs/window.md
+++ b/docs/window.md
@@ -18,7 +18,7 @@ wnd.map();
 
 Constructing a window with an existing X window id (`{ id }`) returns a
 (cached) wrapper around that foreign window; its geometry is populated
-asynchronously.
+asynchronously — see [Adopted windows](#adopted-windows).
 
 Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
 
@@ -78,6 +78,48 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
   from XInput 2 instead of the core protocol: fractional scroll deltas
   instead of wheel notches, per-device ids, touch (see
   [Wheel and smooth scrolling](#wheel-and-smooth-scrolling))
+
+## Adopted windows
+
+`app.createWindow({ id })` wraps a window this client did not create — what
+`ev.window` carries on a window manager's substructure events, what a
+compositor gets for the Composite overlay window and for every client on the
+screen. Nothing about such a window is known locally, so ntk asks: the
+constructor sends a `GetGeometry`, and until the reply lands `width`,
+`height`, `x` and `y` read `undefined` and `depth` reads `0`.
+
+```js
+const wnd = app.createWindow({ id: ev.wid });
+await wnd.ready;                    // the reply the constructor is waiting for
+const ctx = wnd.getContext('2d');   // now binds the right picture format
+```
+
+- `wnd.ready` — a promise resolving **with the window** once its geometry is
+  known. A window ntk created resolves immediately, having asked for its own
+  geometry, so awaiting unconditionally is safe: code handed a window need
+  not know where it came from. It never rejects — a window destroyed before
+  the reply arrives resolves all the same, with `width` still `undefined`,
+  and the next request sent to it is what reports that it is gone.
+- `wnd.getGeometry()` → `Promise<{ x, y, width, height, depth, borderWidth,
+  root }>` — ask the server where the window is *now*, rather than take what
+  the event stream last said. `x`/`y` are relative to the parent, as X
+  reports them, and `root` is the root window of the screen it is on. The
+  answer is written back to `wnd.x`/`y`/`width`/`height`/`depth`, and
+  settles `ready` if it was still pending.
+
+Size and position also arrive on their own, as `resize`
+([ConfigureNotify](#resize-fires-for-moves)) — the **depth** does not, and it
+is the one nothing recovers from. `getContext('2d')` picks its picture format
+from the depth when the context is created, so a context taken on a depth-32
+window before the reply lands would bind `rgb24` and quietly drop the alpha
+channel. ntk re-binds the picture if the reply turns out to change the
+format, but a context that has already drawn has already drawn into the wrong
+one; `createPattern(wnd)` has nothing to re-bind and refuses outright.
+
+A window ntk created has no reply pending, and still does not know its depth:
+`depth: 0` is CopyFromParent, which only the server ever resolves. That is
+what `getGeometry()` is for on this side — until something asks, `wnd.depth`
+reads `0`.
 
 ## Transparent windows
 
@@ -468,6 +510,12 @@ wnd.requestAnimationFrame(step); // now runs at the display's rate
 
 - `wnd.id` — X window id
 - `wnd.width`, `wnd.height`, `wnd.x`, `wnd.y` — geometry, kept in sync on `resize`
+- `wnd.depth` — bits per pixel, and so which picture format a 2d context
+  binds. `0` means "not resolved" rather than a real depth — see
+  [Adopted windows](#adopted-windows)
+- `wnd.ready` — a promise resolving with the window once its geometry is
+  known; immediate for a window ntk created (see
+  [Adopted windows](#adopted-windows))
 - `wnd.frameLatency` — how long the last frame took to be answered, ms
   (`null` before the first frame; see above for what it measures on each clock)
 - `wnd.frameInterval` — minimum ms between paced frames, and between blits;
@@ -527,6 +575,9 @@ All return `this` unless noted.
   smooth scrolling, per-device ids, touch. Returns a promise for whether the
   server has XI2, not `this` — see
   [Wheel and smooth scrolling](#wheel-and-smooth-scrolling)
+- `getGeometry()` — a promise, not `this`: `{ x, y, width, height, depth,
+  borderWidth, root }` asked of the server and written back to the window
+  (see [Adopted windows](#adopted-windows))
 - `queryTree(cb)` — `cb(err, { parent, root, children })`, all as `Window`s
 - `reparentTo(newParent, x, y)`, `raise()`, `lower()`
 - `setHints(hints)`, `setSizeHints(hints)`, `setWmHints(hints)`,
@@ -1059,6 +1110,10 @@ The counterparts of the hint setters, for reading other clients' windows:
 - `getAttributes()` — `{ mapState, overrideRedirect, ... }`. Both matter
   when adopting the windows that already existed at startup: skip
   override-redirect ones, frame only the mapped ones
+- `getGeometry()` — `{ x, y, width, height, depth, borderWidth, root }`,
+  where the window is now. `await client.ready` is the cheaper answer for a
+  window just adopted, since ntk has already asked; see
+  [Adopted windows](#adopted-windows)
 - `getProperty(name, { as })` — any property. `as` is `'buffer'` (default,
   `{ type, data }`), `'string'`, or `'numbers'` for 32-bit lists. Resolves
   to `null` when the property is not set

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -222,6 +222,35 @@ function needXFixesError() {
 }
 
 /**
+ * A window whose depth nothing has established yet, handed to createPattern.
+ *
+ * Two windows are like this, and they want different answers. One adopted by
+ * id knows nothing until the GetGeometry ntk sent for it replies, and
+ * `wnd.ready` is the wait for exactly that reply. One ntk created with the
+ * default `depth: 0` — CopyFromParent — has no reply pending at all, because
+ * only the server ever resolved that 0, so its depth has to be asked for.
+ * `getGeometry()` covers both, which is why it leads.
+ */
+function unknownDepthError() {
+  return new Error(
+    "createPattern: the tile's depth is not known yet, so there is no " +
+      "picture\nformat to read it through.\n" +
+      "\n" +
+      "Ask the server for it — the answer is written back to the window:\n" +
+      "\n" +
+      "    await wnd.getGeometry();\n" +
+      "    const pattern = ctx.createPattern(wnd, 'repeat');\n" +
+      "\n" +
+      "For a window adopted by id — `new Window(app, { id })`, or `ev.window`\n" +
+      "in a window manager — ntk has already sent that request:\n" +
+      "`await wnd.ready` waits for the reply it is expecting rather than\n" +
+      "asking for another, and resolves immediately on a window ntk created.\n" +
+      "A Surface or a Pixmap carries its own depth and needs neither wait.\n" +
+      `\n${PATTERN_DOCS}`,
+  );
+}
+
+/**
  * What a pattern tiles: a drawable holding the tile plus the picture format
  * to read it through. A repeating source Picture is created over it rather
  * than the source's own picture being changed, so tiling a `Surface` leaves
@@ -254,11 +283,7 @@ function patternSourceOf(app, source) {
     // is where a double-buffered window's current pixels actually are)
     drawable = source._backing || source;
     const depth = drawable.depth ?? source.depth;
-    if (!depth) {
-      throw new Error(
-        "createPattern: the drawable's depth is not known yet — await the window's geometry, or pass a Surface",
-      );
-    }
+    if (!depth) throw unknownDepthError();
     format = formatFor(depth);
     width = drawable.width ?? source.width;
     height = drawable.height ?? source.height;
@@ -470,6 +495,23 @@ class RenderingContext2d {
     this._gc = null;
     this.picture = null;
     this._bindTarget();
+    // A window adopted by id has depth 0 until its GetGeometry replies, and
+    // 0 binds rgb24 — so a context taken on a depth-32 window before the
+    // reply lands would silently drop the alpha channel, which is the
+    // ordinary case for a compositor taking the overlay window and its
+    // clients as bare ids (issue #293). Awaiting `wnd.ready` first is the
+    // explicit fix; re-binding when the answer changes the format is the one
+    // that does not need to be known about.
+    if (!window.depth && typeof window.ready?.then === "function") {
+      window.ready.then(() => {
+        const target = this.window._backing || this.window;
+        if (!this.picture || this._target !== target) return;
+        const depth = target.depth ?? this.window.depth;
+        if (this._formatFor(depth) !== this.picture.format) {
+          this._bindTarget(true);
+        }
+      });
+    }
     if (typeof window.on === "function") {
       window.on("_backing", () => this._bindTarget());
       // masks are sized to the drawable — recreate them after a resize
@@ -542,9 +584,16 @@ class RenderingContext2d {
     this.lineWidth = 1;
   }
 
-  _bindTarget() {
+  /** The picture format a drawable of this depth is read and written through. */
+  _formatFor(depth) {
+    if (depth === 32) return this.Render.rgba32;
+    if (depth === 8) return this.Render.a8;
+    return this.Render.rgb24;
+  }
+
+  _bindTarget(force = false) {
     const target = this.window._backing || this.window;
-    if (this._target === target) return;
+    if (this._target === target && !force) return;
     this._target = target;
     this._layoutCache = null; // the new target may be a different depth
 
@@ -560,12 +609,7 @@ class RenderingContext2d {
     // result as a mask is how a monochrome drawing gets rendered once and
     // recoloured on every use (see Surface).
     const depth = target.depth ?? this.window.depth;
-    const format =
-      depth === 32
-        ? this.Render.rgba32
-        : depth === 8
-          ? this.Render.a8
-          : this.Render.rgb24;
+    const format = this._formatFor(depth);
     // Does the target have a real alpha channel? Only then is "transparent"
     // a colour it can hold, which is what clearRect turns on.
     this._hasAlpha = depth === 32;

--- a/lib/window.js
+++ b/lib/window.js
@@ -332,6 +332,24 @@ function warnHint(key, message) {
   console.warn(`ntk: ${message} Further occurrences are not reported.`);
 }
 
+/**
+ * A GetGeometry reply in ntk's spelling. node-x11 calls the position `xPos`/
+ * `yPos` and the reply's root window `windowid`, neither of which is what X
+ * calls them; the `root` here is the root of the screen the drawable is on,
+ * not this window's parent.
+ */
+function unpackGeometry(res) {
+  return {
+    x: res.xPos,
+    y: res.yPos,
+    width: res.width,
+    height: res.height,
+    depth: res.depth,
+    borderWidth: res.borderWidth,
+    root: res.windowid
+  };
+}
+
 /** A Window, a Pixmap, or a bare XID — all of these name a server resource. */
 function resourceId(value) {
   return typeof value === 'number' ? value : (value?.id ?? 0);
@@ -404,6 +422,9 @@ export default class Window extends Drawable {
     // the whole property without dropping what an earlier one set
     this._sizeHints = null;
     this._wmHints = null;
+    // `wnd.ready` (see the getter): resolved as soon as this wrapper knows
+    // its geometry — at the end of the constructor for a window ntk created,
+    // when GetGeometry replies for one adopted by id
     this._readyPromiseResolve = null;
     this._readyPromise = new Promise((resolve) => {
       this._readyPromiseResolve = resolve;
@@ -552,20 +573,15 @@ export default class Window extends Drawable {
       this.depth = 0;
       // an adopted window's geometry is not known until GetGeometry replies
       this._deliveredGeom = null;
-      // populate width and height
+      // populate width, height and depth — `wnd.ready` is the public wait
       X.GetGeometry(this.id, (err, res) => {
-        if (!err) {
-          this.width = res.width;
-          this.height = res.height;
-          this.x = res.xPos;
-          this.y = res.yPos;
-          this.depth = res.depth;
-          // nothing was known about this window until now, so until this
-          // reply lands a 'resize' reports both moved and resized (see
-          // _tagResize) rather than guessing
-          this._deliveredGeom ??= { x: this.x, y: this.y, width: this.width, height: this.height };
-        }
-        this._readyPromiseResolve();
+        // A window that was destroyed between the id reaching us and this
+        // request reaching the server answers BadWindow, and there is
+        // nothing to record. `ready` still resolves: adopting a window that
+        // has since gone is ordinary for a window manager, and a wait that
+        // never ends is worse than one that ends with width undefined.
+        if (err) this._readyPromiseResolve(this);
+        else this._applyGeometry(unpackGeometry(res));
       });
     }
 
@@ -717,7 +733,7 @@ export default class Window extends Drawable {
       const child = new Window(app, { id: ev.wid });
       const ntkev = { ...ev, parent: this, window: child, target: child };
       // wait until we know that we track correct x,y,w,h values
-      child._readyPromise.then(() => {
+      child.ready.then(() => {
         this.emit(eventName, ntkev);
       });
     });
@@ -773,8 +789,71 @@ export default class Window extends Drawable {
     });
 
     if (typeof this.width !== 'undefined') {
-      this._readyPromiseResolve();
+      this._readyPromiseResolve(this);
     }
+  }
+
+  /**
+   * Resolves with this window once its geometry is known — immediately for a
+   * window ntk created (it already knows what it asked for), when the
+   * GetGeometry sent by the constructor replies for one adopted by id.
+   *
+   * Adoption is the case that needs it: until the reply lands, `width`,
+   * `height`, `x` and `y` are `undefined` and `depth` is `0`, so anything
+   * that picks a pixel format from the depth — `getContext('2d')`,
+   * `createPattern` — would pick the wrong one. Awaiting is safe
+   * unconditionally, so code that takes windows from either source need not
+   * ask which it has:
+   *
+   *   const wnd = new Window(app, { id: ev.wid });
+   *   await wnd.ready;
+   *   const ctx = wnd.getContext('2d');
+   *
+   * The promise never rejects. A window destroyed before the reply arrives
+   * resolves all the same, with `width` still `undefined` — the request that
+   * hits the gone window is the one that reports it.
+   */
+  get ready() {
+    return this._readyPromise;
+  }
+
+  /**
+   * Ask the server where this window is now — `{ x, y, width, height, depth,
+   * borderWidth, root }`, with `x`/`y` relative to the parent, as X reports
+   * them.
+   *
+   * `wnd.x`/`y`/`width`/`height`/`depth` are kept current from the event
+   * stream and are the cheap answer; this is the round trip for the cases
+   * the events cannot cover — a window nobody selected StructureNotify on, a
+   * window ntk created with the default `depth: 0` (CopyFromParent, whose
+   * real depth only the server knows), or simply the state at a point in
+   * time. The reply is written back to those properties, and resolves
+   * `ready` if it was still pending.
+   */
+  getGeometry() {
+    return new Promise((resolve, reject) => {
+      this.X.GetGeometry(this.id, (err, res) => {
+        if (err) return reject(err);
+        const geometry = unpackGeometry(res);
+        this._applyGeometry(geometry);
+        resolve(geometry);
+      });
+    });
+  }
+
+  /** Record a GetGeometry reply, and let anything waiting on it go. */
+  _applyGeometry({ x, y, width, height, depth }) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+    this.depth = depth;
+    // Only where nothing is known yet: on an adopted window a 'resize'
+    // reports both moved and resized until there is a baseline to compare
+    // against (see _tagResize), and the event stream may already have set
+    // one — that is the delivered geometry, and this reply is not.
+    this._deliveredGeom ??= { x, y, width, height };
+    this._readyPromiseResolve(this);
   }
 
   _forget() {
@@ -3515,7 +3594,7 @@ export default class Window extends Drawable {
       // there can be multiple screens (and roots)
       const root = new Window(app, { id: tree.root });
       const wrappers = [...children, root, ...(parent ? [parent] : [])];
-      Promise.all(wrappers.map((w) => w._readyPromise)).then(() => {
+      Promise.all(wrappers.map((w) => w.ready)).then(() => {
         callback(null, { parent, root, children });
       });
     });

--- a/test/pattern.test.js
+++ b/test/pattern.test.js
@@ -402,6 +402,32 @@ test('a source that is not a drawable names what would have worked', () => {
   }
 });
 
+test('a window whose depth is unknown names a wait that exists (issue #293)', async () => {
+  const ctx = freshCtx();
+  // a window this connection did not make a wrapper for: what a compositor
+  // or a window manager is handed, and what `new Window(app, { id })` adopts
+  const id = app.X.AllocID();
+  app.X.CreateWindow(id, app.display.screen[0].root, 0, 0, 8, 8, 0, 0, 1, 0, {});
+  const wnd = app.createWindow({ id });
+
+  assert.throws(
+    () => ctx.createPattern(wnd, 'repeat'),
+    (err) => {
+      assert.match(err.message, /await wnd\.getGeometry\(\)/, 'the remedy that works on any window');
+      assert.match(err.message, /await wnd\.ready/, 'and the cheaper one for an adopted window');
+      // both are real API, which is the whole point of the issue
+      assert.equal(typeof wnd.getGeometry, 'function');
+      assert.equal(typeof wnd.ready?.then, 'function');
+      return true;
+    }
+  );
+
+  await wnd.ready;
+  assert.equal(wnd.depth, 24, 'the wait is what makes the depth known');
+  assert.ok(ctx.createPattern(wnd, 'repeat') instanceof CanvasPattern);
+  wnd.destroy();
+});
+
 test('setTransform rejects a matrix it cannot use', () => {
   const ctx = freshCtx();
   const tile = checkerTile();

--- a/test/window-ready.test.js
+++ b/test/window-ready.test.js
@@ -1,0 +1,277 @@
+// `wnd.ready` and `wnd.getGeometry()` (sidorares/ntk#293): the public wait
+// for a window adopted by id, whose geometry — and depth — only arrive when
+// the constructor's GetGeometry replies. Before this there was no way to
+// await it from outside ntk, while an error message told you to.
+//
+// Hermetic: node-x11's in-process pure-JS X server, two connections, so the
+// adopted window really belongs to another client the way a compositor's or
+// a window manager's do. The pure-JS server offers only depth 24, so the
+// depth-32 case — the one that silently loses the alpha channel — is driven
+// against a mock client instead.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import Window from '../lib/window.js';
+import { StaticFontSource, createClient } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+const docsDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs');
+
+let server = null;
+let host = null; // the adopter: a compositor, a window manager
+let guest = null; // the client whose windows it adopts
+
+// Adopting a window that has gone is half of what is under test, so the X
+// errors it earns are expected output, not noise to print — take them here
+// instead of letting the default handler warn.
+const xErrors = [];
+
+const connect = async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: (err) => xErrors.push(err)
+  });
+};
+
+beforeEach(async () => {
+  server = createServer({ width: 400, height: 300 });
+  xErrors.length = 0;
+  host = await connect();
+  guest = await connect();
+});
+
+afterEach(() => {
+  host?.X.terminate();
+  guest?.X.terminate();
+  server = host = guest = null;
+});
+
+/** drain the round trips a connection has in flight */
+const settle = (app) => new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+test('a window ntk created is ready without a round trip', async () => {
+  const wnd = host.createWindow({ width: 40, height: 30, x: 5, y: 6 });
+
+  let resolved = null;
+  wnd.ready.then((w) => (resolved = w));
+  await Promise.resolve(); // one microtask: no room for any I/O
+  assert.equal(resolved, wnd, 'resolves with the window, and immediately');
+
+  // which is what makes awaiting it unconditionally safe — code handed a
+  // window from either source need not ask which kind it has
+  assert.equal(await wnd.ready, wnd);
+  wnd.destroy();
+});
+
+test('an adopted window is ready only once GetGeometry answers', async () => {
+  const client = guest.createWindow({ width: 120, height: 80, x: 7, y: 9 });
+  await settle(guest);
+
+  const adopted = host.createWindow({ id: client.id });
+  assert.equal(adopted.width, undefined, 'nothing is known yet');
+  assert.equal(adopted.depth, 0, 'including the depth a picture format comes from');
+
+  let resolved = null;
+  adopted.ready.then((w) => (resolved = w));
+  await Promise.resolve();
+  assert.equal(resolved, null, 'the wait is a real reply, not a formality');
+
+  assert.equal(await adopted.ready, adopted);
+  assert.equal(adopted.width, 120);
+  assert.equal(adopted.height, 80);
+  assert.equal(adopted.x, 7);
+  assert.equal(adopted.y, 9);
+  assert.equal(adopted.depth, 24, 'the depth a 2d context binds its format from');
+
+  client.destroy();
+});
+
+test('adopting a window that has already gone still becomes ready', async () => {
+  const client = guest.createWindow({ width: 20, height: 20 });
+  const id = client.id;
+  client.destroy();
+  await settle(guest);
+
+  // a window manager racing a client that exits is the ordinary case, and a
+  // wait that never ends would be worse than one that ends empty-handed
+  const adopted = host.createWindow({ id });
+  assert.equal(await adopted.ready, adopted);
+  assert.equal(adopted.width, undefined, 'there was nothing to record');
+});
+
+test('getGeometry() asks the server and writes the answer back', async () => {
+  const wnd = host.createWindow({ width: 64, height: 48, x: 3, y: 4 });
+  assert.equal(wnd.depth, 0, 'CopyFromParent: only the server ever resolved this');
+
+  const geometry = await wnd.getGeometry();
+  assert.deepEqual(geometry, {
+    x: 3,
+    y: 4,
+    width: 64,
+    height: 48,
+    depth: 24,
+    borderWidth: 0,
+    root: host.display.screen[0].root
+  });
+  assert.equal(wnd.depth, 24, 'and the window now knows its real depth');
+  assert.equal(wnd.width, 64);
+  wnd.destroy();
+});
+
+test('getGeometry() on an adopted window is the wait as well as the answer', async () => {
+  const client = guest.createWindow({ width: 90, height: 70, x: 11, y: 12 });
+  await settle(guest);
+
+  const adopted = host.createWindow({ id: client.id });
+  const geometry = await adopted.getGeometry();
+  assert.equal(geometry.width, 90);
+  assert.equal(geometry.height, 70);
+  assert.equal(await adopted.ready, adopted, 'the pending wait is settled by this reply too');
+
+  client.destroy();
+});
+
+test('getGeometry() reports a window that is gone rather than hanging', async () => {
+  const client = guest.createWindow({ width: 20, height: 20 });
+  const id = client.id;
+  client.destroy();
+  await settle(guest);
+
+  const adopted = host.createWindow({ id });
+  await assert.rejects(() => adopted.getGeometry(), 'the X error reaches the caller');
+});
+
+test('a late reply does not overwrite a baseline the event stream set', async () => {
+  const client = guest.createWindow({ width: 100, height: 60, x: 1, y: 2 });
+  await settle(guest);
+
+  const adopted = host.createWindow({ id: client.id, frameInterval: 0 });
+  // a ConfigureNotify beats the reply in: that is the delivered geometry, and
+  // the reply is only what the window looked like, so it must not claim to be
+  // the last thing 'resize' handlers saw (see _tagResize)
+  adopted.emit('event', { type: 22, width: 100, height: 60, x: 1, y: 2 });
+  await tick();
+  await adopted.ready;
+  assert.deepEqual(adopted._deliveredGeom, { x: 1, y: 2, width: 100, height: 60 });
+
+  client.destroy();
+});
+
+// ---------------------------------------------------------------------
+// what the wait is for: the picture format a 2d context binds
+// ---------------------------------------------------------------------
+
+let nextId = 0xa000;
+
+/** A mock client, so the adopted window can answer depth 32 on demand. */
+function makeMockApp() {
+  const calls = { pictures: [], freed: [] };
+  const Render = {
+    rgb24: 'rgb24',
+    rgba32: 'rgba32',
+    a8: 'a8',
+    CreatePicture(id, drawable, format) {
+      calls.pictures.push({ id, drawable, format });
+    },
+    FreePicture(id) {
+      calls.freed.push(id);
+    }
+  };
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    GetGeometry(id, cb) {
+      calls.getGeometry = cb;
+    },
+    GetInputFocus() {}
+  };
+  const display = {
+    client: X,
+    Render,
+    screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }]
+  };
+  // the shared solid the default fillStyle asks for, stubbed so that
+  // `calls.pictures` holds only the pictures bound to the target
+  const app = { X, display, solidPicture: () => ({ id: nextId++ }) };
+  return { app, calls };
+}
+
+const geometryReply = (depth) => ({
+  windowid: 1,
+  xPos: 0,
+  yPos: 0,
+  width: 64,
+  height: 64,
+  borderWidth: 0,
+  depth
+});
+
+test('a context on an adopted window rebinds when the depth turns out to be 32', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { id: 0xbeef, frameInterval: 0 });
+  const ctx = wnd.getContext('2d');
+
+  // depth 0 is indistinguishable from depth 24 at this point, so the only
+  // format available is the opaque one — this is where the alpha channel
+  // used to be lost for good
+  assert.deepEqual(
+    calls.pictures.map((p) => p.format),
+    ['rgb24']
+  );
+  assert.equal(ctx._hasAlpha, false);
+
+  calls.getGeometry(null, geometryReply(32));
+  await wnd.ready;
+  await tick();
+
+  assert.deepEqual(
+    calls.pictures.map((p) => p.format),
+    ['rgb24', 'rgba32'],
+    'the reply changes the format, so the picture is rebuilt'
+  );
+  assert.equal(calls.freed.length, 1, 'and the wrong one is freed');
+  assert.equal(ctx._hasAlpha, true, 'clearRect can clear to transparent again');
+  assert.equal(ctx.picture.format, 'rgba32');
+});
+
+test('the section the pattern docs send an adopting caller to exists', () => {
+  // a cross-file anchor is the one kind of doc link nothing else in CI checks
+  const window = readFileSync(join(docsDir, 'window.md'), 'utf8');
+  assert.ok(/^## Adopted windows$/m.test(window), 'docs/window.md#adopted-windows');
+  const context = readFileSync(join(docsDir, 'context-2d.md'), 'utf8');
+  assert.ok(context.includes('window.md#adopted-windows'), 'and createPattern points at it');
+});
+
+test('a depth the reply does not change costs no second picture', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { id: 0xbee0, frameInterval: 0 });
+  wnd.getContext('2d');
+  assert.equal(calls.pictures.length, 1);
+
+  calls.getGeometry(null, geometryReply(24));
+  await wnd.ready;
+  await tick();
+
+  assert.equal(calls.pictures.length, 1, 'rgb24 either way — nothing to redo');
+  assert.equal(calls.freed.length, 0);
+});


### PR DESCRIPTION
Closes #293.

## The gap

`createPattern` on a drawable whose depth ntk did not know yet told the caller
to "await the window's geometry", and nothing public could do that. A `Window`
adopted by id gets its geometry and depth from an async `GetGeometry` that
resolves a private `_readyPromise`; there was no `ready`, no `whenReady`, no
`getGeometry`. The remedies actually available — polling `wnd.width`, or
issuing `X.GetGeometry` yourself — were not the ones the message named.

## What this adds

**`wnd.ready`** — a promise resolving with the window once its geometry is
known. A window ntk created resolves immediately, so awaiting is
unconditionally safe and code handed a window need not ask where it came from.
It never rejects: a window manager racing a client that exits is ordinary, and
a wait that never ends is worse than one that ends with `width` undefined.

```js
const wnd = app.createWindow({ id: ev.wid });
await wnd.ready;
const ctx = wnd.getContext('2d');
```

**`wnd.getGeometry()`** — resolves `{ x, y, width, height, depth, borderWidth,
root }`, written back to `wnd.x`/`y`/`width`/`height`/`depth`, and settles
`ready` if it was still pending. This is the form that also answers for a
window ntk created with `depth: 0` — CopyFromParent, which only the server ever
resolved, and which no pending reply will ever report.

## Past patterns: the alpha channel

A 2d context binds its picture format from the depth when it is created, so one
taken on an adopted depth-32 window before the reply landed bound `rgb24` and
quietly dropped the alpha channel — the ordinary case for a compositor, whose
overlay window and every client window arrive as bare ids. Awaiting `ready`
first is the explicit fix; a context now also re-binds its picture where the
reply turns out to change the format, which is the fix that does not have to be
known about.

## The message

Before:

```
createPattern: the drawable's depth is not known yet — await the window's geometry, or pass a Surface
```

After:

```
createPattern: the tile's depth is not known yet, so there is no picture
format to read it through.

Ask the server for it — the answer is written back to the window:

    await wnd.getGeometry();
    const pattern = ctx.createPattern(wnd, 'repeat');

For a window adopted by id — `new Window(app, { id })`, or `ev.window`
in a window manager — ntk has already sent that request:
`await wnd.ready` waits for the reply it is expecting rather than
asking for another, and resolves immediately on a window ntk created.
A Surface or a Pixmap carries its own depth and needs neither wait.

https://github.com/sidorares/ntk/blob/master/docs/context-2d.md#patterns
```

## Tests

`test/window-ready.test.js` is hermetic on node-x11's in-process pure-JS X
server, with two connections so the adopted window really belongs to another
client: ready-without-a-round-trip on a created window, ready-only-after-the-
reply on an adopted one, a window that was already gone, `getGeometry` written
back, its rejection, and a late reply not overwriting a baseline the event
stream set. That server offers depth 24 only, so the depth-32 re-bind runs
against a mock client and asserts the picture formats: `rgb24` then `rgba32`,
with the first freed, and no second picture where the depth does not change.
`test/pattern.test.js` drives the whole loop — throw, `await wnd.ready`,
pattern.

Docs: a new "Adopted windows" section in `docs/window.md`, `ready`/`depth` in
Properties, `getGeometry` in Methods and in the window-manager reading list,
and the `createPattern` source bullet in `docs/context-2d.md`.

The Pixmap side of the same adoption gap is filed separately and untouched
here.

Full suite: 953 pass, 3 skipped, 1 pre-existing failure on this machine
— `test/glx.test.js` "getContext('opengl') fails with a diagnosis", whose
premise is a server without `+iglx`, and the local XQuartz allows indirect GLX.
It fails identically on `master`.
