### PR TITLE
chore(deps): bump x11 to ^3.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "linebreak": "^1.1.0",
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
-        "x11": "^3.9.0"
+        "x11": "^3.9.2"
       },
       "devDependencies": {
         "@conventional-commits/parser": "^0.4.1",
@@ -464,9 +464,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.9.0.tgz",
-      "integrity": "sha512-OecExjhkArWOEJssYD4JjfGS63EhqX8/oY6dCTPLDu0NxNgbrfLMzT8585LfW4RHoAtFiye3GM9ZIbubuvUSNA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.9.2.tgz",
+      "integrity": "sha512-IHIE2iKcJtPOtrTRW+sGkJ1l21F0Jiwl/tSlpZOZ9zN6qrAUvp4u5ITjKws/SoOtE7Oo8ifP3fc//AqLgwtV7g==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "linebreak": "^1.1.0",
     "parse-color": "^1.0.0",
     "pngjs": "^7.0.0",
-    "x11": "^3.9.0"
+    "x11": "^3.9.2"
   },
   "optionalDependencies": {
     "x11-dri": ">=0.2.0 <1"


### PR DESCRIPTION
Bumps the `x11` dependency from `^3.9.0` to `^3.9.2`.

Full test suite passes against a real X server: 998 pass, 0 fail, 3 skipped.