### PR TITLE
feat(pixmap): adopt an existing id with real geometry, depth and ownership

### DIFF
--- a/docs/pixmap.md
+++ b/docs/pixmap.md
@@ -16,8 +16,11 @@ wnd.getContext('2d').drawImage(ctx, 0, 0);
   `parent` (a window) determines the screen; defaults to the root window.
 - `wnd.createPixmap(params)` — defaults: `parent` = the window, `width`/`height`
   = window size, `depth` = 32.
-- `new Pixmap(app, { id })` — wrap an existing pixmap id (not owned: it will
-  not be freed by ntk).
+- `await Pixmap.adopt(app, id, options)` — adopt an existing pixmap id: ask
+  the server for its geometry and depth, and own it (see
+  [Adoption](#adoption)).
+- `new Pixmap(app, { id, own, width, height, depth, visual })` — the
+  synchronous form of the same (see [Adoption](#adoption)).
 
 `visual` is the one X itself does not ask for: a pixmap has no visual, only a
 depth, so what its pixels *mean* is decided by whoever put them there. Name
@@ -29,15 +32,64 @@ format is picked from the depth, which is right for the usual 8:8:8 and 8-bit
 coverage layouts and wrong for the rest. A window's own backing pixmap is
 given the window's visual already.
 
+## Adoption
+
+A pixmap id from outside — another client's handover, or
+`XCompositeNameWindowPixmap` naming a window's contents into an id you
+allocated — becomes a `Pixmap` in one of two ways:
+
+```js
+const pixmap = await Pixmap.adopt(app, id);         // GetGeometry, own it
+const pixmap = new Pixmap(app, { id, own: true, width, height, depth });
+```
+
+`Pixmap.adopt(app, id, options)` asks the server for the pixmap's geometry
+and real depth, records them, and returns the pixmap owned: `destroy()`,
+`using` and the GC fallback free it exactly as for a pixmap ntk created.
+It rejects if the pixmap no longer exists — for a compositor, whose named
+pixmap dies with every resize of the window it names, that means: name the
+window again and adopt the fresh id. Options: `own: false` to observe a
+pixmap that stays another client's to free, `visual` (see above), and any
+of `width`/`height`/`depth` already known — with all three declared no
+round trip is made.
+
+`new Pixmap(app, { id })` is the synchronous form. **Nothing is defaulted**:
+`width`, `height` and `depth` are whatever the caller declared, and where
+any is missing the constructor sends a `GetGeometry` whose reply fills them
+in — `await pixmap.ready` is the wait for it, exactly as on an
+[adopted window](window.md#adopted-windows). Until it lands, anything that
+picks a picture format from the depth — `getContext('2d')`,
+`createPattern` — cannot know a depth-32 pixmap from a depth-24 one, which
+is how an ARGB pixmap loses its alpha channel. `own` defaults to `false`
+here.
+
+Ownership frees the pixmap with `FreePixmap` either way; the id itself goes
+back into the connection's allocator only when it came from there (the
+`NameWindowPixmap` case) — a foreign client's id is never recycled into
+ours.
+
 ## Properties
 
-- `pixmap.id`, `pixmap.width`, `pixmap.height`, `pixmap.depth`
+- `pixmap.id`, `pixmap.width`, `pixmap.height`, `pixmap.depth` — on a
+  pixmap adopted by bare id, `width`/`height`/`depth` are `undefined` until
+  the constructor's `GetGeometry` replies
 - `pixmap.visualId` — the visual its pixels are in, or `0` for "go by the
   depth"
+- `pixmap.ready` — resolves with the pixmap once its geometry and depth are
+  known: immediately for a pixmap ntk created or adopted fully declared,
+  when `GetGeometry` replies for one adopted by bare id. Never rejects — a
+  pixmap that was already gone resolves with `width` still `undefined`
+  (`Pixmap.adopt` is the form that rejects instead).
+- `await pixmap.getGeometry()` — ask the server now; resolves with
+  `{ x, y, width, height, depth, borderWidth, root }` (the same shape as
+  [`wnd.getGeometry()`](window.md#adopted-windows); `x`/`y`/`borderWidth`
+  are 0 for a pixmap) and writes the answer back to the properties above.
 
 ## Lifecycle
 
-- `pixmap.destroy()` — free the server-side pixmap and release the id
+- `pixmap.destroy()` — free the server-side pixmap and release the id.
+  A no-op on a pixmap adopted without `own` — that one is someone else's
+  to free.
 - `Symbol.dispose` — same, for `using pixmap = ...`
 - If never destroyed explicitly, the server resource is freed when the
   wrapper is garbage collected (FinalizationRegistry). Don't rely on this

--- a/docs/resource-management.md
+++ b/docs/resource-management.md
@@ -35,7 +35,11 @@ in the meantime. For long-running apps, destroy what you create — or let
 `using` do it.
 
 Objects wrapping ids ntk did not create (`new Window(app, { id })`,
-`new Pixmap(app, { id })`) are not owned and are never freed by ntk.
+`new Pixmap(app, { id })`) are not owned and are never freed by ntk — unless
+adopted with ownership declared: `Pixmap.adopt(app, id)` owns by default,
+`new Pixmap(app, { id, own: true })` on request, and both then free the
+pixmap through `destroy()`, `using` and the GC fallback like any other
+(see [pixmap.md](pixmap.md#adoption)).
 
 Cleanup — explicit or GC-driven — becomes a silent no-op once the connection
 is closing or closed: the X server frees all of a client's resources on

--- a/lib/pixmap.js
+++ b/lib/pixmap.js
@@ -3,12 +3,42 @@ import Drawable from './drawable.js';
 
 // GC fallback: free the server-side pixmap when the wrapper is collected
 // without an explicit destroy()
-const registry = new FinalizationRegistry(({ X, id }) => {
+const registry = new FinalizationRegistry(({ X, id, releaseId }) => {
   safeRelease(X, () => {
     X.FreePixmap(id);
-    X.ReleaseID(id);
+    if (releaseId) X.ReleaseID(id);
   });
 });
+
+/**
+ * A GetGeometry reply in ntk's spelling (window.js has the window-shaped
+ * twin). For a pixmap, `x`, `y` and `borderWidth` are always 0 — X reports
+ * them anyway, and returning the same shape as `wnd.getGeometry()` keeps the
+ * two interchangeable.
+ */
+function unpackGeometry(res) {
+  return {
+    x: res.xPos,
+    y: res.yPos,
+    width: res.width,
+    height: res.height,
+    depth: res.depth,
+    borderWidth: res.borderWidth,
+    root: res.windowid
+  };
+}
+
+/**
+ * Whether this connection's allocator handed out `id`. Owning an adopted
+ * pixmap does not always mean the id was ours: XCompositeNameWindowPixmap
+ * names a pixmap into an id the adopter allocated itself, but a pixmap made
+ * by another client carries an id from that client's range. Only an id of
+ * ours may go back into the pool on destroy — releasing a foreign one would
+ * eventually make AllocID hand out an id the server refuses as not ours.
+ */
+function ownAllocation(display, id) {
+  return ((id & ~display.resource_mask) >>> 0) === (display.resource_base >>> 0);
+}
 
 export default class Pixmap extends Drawable {
   constructor(app, args = {}) {
@@ -18,8 +48,6 @@ export default class Pixmap extends Drawable {
     this.X = X;
     this.display = app.display;
 
-    const parentId = args.parent ? args.parent.id : app.display.screen[0].root;
-    this.depth = args.depth || 24;
     // A pixmap has no visual of its own — X gives it a depth and nothing
     // else. What its pixels mean is decided by whoever put them there, so a
     // pixmap holding a window's content (a backing store, a compositor's
@@ -28,17 +56,126 @@ export default class Pixmap extends Drawable {
     // the format is picked from the depth as before.
     this.visualId = args.visual ?? 0;
 
+    // `pixmap.ready` (see the getter): resolved as soon as this wrapper
+    // knows its geometry — at the end of the constructor for a pixmap ntk
+    // created or one adopted with its geometry declared, when GetGeometry
+    // replies for one adopted by bare id
+    this._readyPromiseResolve = null;
+    this._readyPromise = new Promise((resolve) => {
+      this._readyPromiseResolve = resolve;
+    });
+    this._adoptError = null;
+
     if (!args.id) {
+      const parentId = args.parent ? args.parent.id : app.display.screen[0].root;
+      this.depth = args.depth || 24;
       this.id = X.AllocID();
       X.CreatePixmap(this.id, parentId, this.depth, args.width, args.height);
       this.width = args.width;
       this.height = args.height;
       this._owned = true;
-      registry.register(this, { X, id: this.id }, this);
+      this._releaseId = true;
+      registry.register(this, { X, id: this.id, releaseId: true }, this);
+      this._readyPromiseResolve(this);
     } else {
       this.id = args.id;
-      this._owned = false;
+      // Nothing is defaulted for an adopted pixmap: what the caller declared
+      // is recorded, and what they did not is asked of the server rather
+      // than guessed — a depth invented here would pick the picture format
+      // everything drawing on it reads the pixels through (issue #291).
+      this.width = args.width;
+      this.height = args.height;
+      this.depth = args.depth;
+      this._owned = !!args.own;
+      this._releaseId = this._owned && ownAllocation(this.display, this.id);
+      if (this._owned) {
+        registry.register(this, { X, id: this.id, releaseId: this._releaseId }, this);
+      }
+      if (this.width !== undefined && this.height !== undefined && this.depth !== undefined) {
+        this._readyPromiseResolve(this);
+      } else {
+        X.GetGeometry(this.id, (err, res) => {
+          // A pixmap freed between the id reaching us and this request
+          // reaching the server answers BadDrawable, and there is nothing to
+          // record. `ready` still resolves — a wait that never ends is worse
+          // than one that ends with `width` undefined — and `Pixmap.adopt`
+          // is the form that turns this into a rejection.
+          if (err) this._adoptError = err;
+          else this._applyGeometry(unpackGeometry(res));
+          this._readyPromiseResolve(this);
+        });
+      }
     }
+  }
+
+  /**
+   * Adopt an existing pixmap id: ask the server for its geometry and depth,
+   * and take responsibility for freeing it. This is the compositor's case —
+   * XCompositeNameWindowPixmap hands back a pixmap the adopting client must
+   * FreePixmap, and must re-adopt on every resize of the named window — but
+   * any handover of a pixmap id works the same way.
+   *
+   * Rejects if the pixmap does not exist (already freed — for a compositor,
+   * re-name the window and adopt the fresh id). Pass `own: false` to observe
+   * a pixmap that stays another client's to free, `visual` to name the
+   * visual its pixels are laid out in (see the constructor), and any of
+   * `width`/`height`/`depth` already known — with all three declared no
+   * round trip is made.
+   */
+  static async adopt(app, id, { own = true, ...args } = {}) {
+    const pixmap = new Pixmap(app, { ...args, id, own });
+    await pixmap.ready;
+    if (pixmap._adoptError) {
+      // there is nothing server-side to own, so the GC fallback must not
+      // send a FreePixmap of its own to fail the same way
+      pixmap._owned = false;
+      registry.unregister(pixmap);
+      throw new Error(
+        `Pixmap.adopt: pixmap 0x${id.toString(16)} does not exist — it was freed ` +
+          'between its id being obtained and this request. A compositor sees this ' +
+          'when the named window was resized or destroyed: name it again and adopt ' +
+          'the fresh id.',
+        { cause: pixmap._adoptError }
+      );
+    }
+    return pixmap;
+  }
+
+  /**
+   * Resolves with this pixmap once its geometry and depth are known —
+   * immediately for a pixmap ntk created or one adopted with `width`,
+   * `height` and `depth` all declared, when the GetGeometry sent by the
+   * constructor replies for one adopted by bare id. Never rejects: a pixmap
+   * that was already gone resolves with `width` still `undefined`.
+   */
+  get ready() {
+    return this._readyPromise;
+  }
+
+  /**
+   * Ask the server about this pixmap now — `{ x, y, width, height, depth,
+   * borderWidth, root }`, the same shape `wnd.getGeometry()` resolves with
+   * (`x`, `y` and `borderWidth` are 0 for a pixmap). The reply is written
+   * back to `width`/`height`/`depth`, and resolves `ready` if it was still
+   * pending.
+   */
+  getGeometry() {
+    return new Promise((resolve, reject) => {
+      this.X.GetGeometry(this.id, (err, res) => {
+        if (err) return reject(err);
+        const geometry = unpackGeometry(res);
+        this._applyGeometry(geometry);
+        resolve(geometry);
+      });
+    });
+  }
+
+  /** Record a GetGeometry reply, and let anything waiting on it go. */
+  _applyGeometry({ width, height, depth }) {
+    this.width = width;
+    this.height = height;
+    this.depth = depth;
+    this._readyPromiseResolve(this);
   }
 
   destroy() {
@@ -47,7 +184,7 @@ export default class Pixmap extends Drawable {
     registry.unregister(this);
     safeRelease(this.X, () => {
       this.X.FreePixmap(this.id);
-      this.X.ReleaseID(this.id);
+      if (this._releaseId) this.X.ReleaseID(this.id);
     });
   }
 

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -223,31 +223,33 @@ function needXFixesError() {
 }
 
 /**
- * A window whose depth nothing has established yet, handed to createPattern.
+ * A drawable whose depth nothing has established yet, handed to
+ * createPattern.
  *
- * Two windows are like this, and they want different answers. One adopted by
- * id knows nothing until the requests ntk sent for it reply, and `wnd.ready`
- * is the wait for exactly those — the visual the tile's format really comes
- * from among them. One ntk created with the default `depth: 0` —
- * CopyFromParent — has no reply pending at all, because only the server ever
- * resolved that 0, so its depth has to be asked for. `getGeometry()` covers
- * both, which is why it leads.
+ * Three drawables are like this, and they want different answers. A window
+ * or a pixmap adopted by id knows nothing until the request ntk sent for it
+ * replies, and `ready` is the wait for exactly that — the visual a window
+ * tile's format really comes from among them. A window ntk created with the
+ * default `depth: 0` — CopyFromParent — has no reply pending at all, because
+ * only the server ever resolved that 0, so its depth has to be asked for.
+ * `getGeometry()` covers all of them, which is why it leads.
  */
 function unknownDepthError() {
   return new Error(
     "createPattern: the tile's depth is not known yet, so there is no " +
       "picture\nformat to read it through.\n" +
       "\n" +
-      "Ask the server for it — the answer is written back to the window:\n" +
+      "Ask the server for it — the answer is written back to the tile:\n" +
       "\n" +
-      "    await wnd.getGeometry();\n" +
-      "    const pattern = ctx.createPattern(wnd, 'repeat');\n" +
+      "    await tile.getGeometry();\n" +
+      "    const pattern = ctx.createPattern(tile, 'repeat');\n" +
       "\n" +
-      "For a window adopted by id — `new Window(app, { id })`, or `ev.window`\n" +
-      "in a window manager — ntk has already sent that request:\n" +
-      "`await wnd.ready` waits for the replies it is expecting rather than\n" +
-      "asking again, and resolves immediately on a window ntk created.\n" +
-      "A Surface or a Pixmap carries its own depth and needs neither wait.\n" +
+      "For a window or a pixmap adopted by id — `new Window(app, { id })`,\n" +
+      "`new Pixmap(app, { id })`, or `ev.window` in a window manager — ntk\n" +
+      "has already sent that request: `await tile.ready` waits for the reply\n" +
+      "it is expecting rather than asking again, and resolves immediately on\n" +
+      "one ntk created. `Pixmap.adopt(app, id)` hands the pixmap over with\n" +
+      "this already done. A Surface carries its own depth and needs no wait.\n" +
       `\n${PATTERN_DOCS}`,
   );
 }
@@ -501,13 +503,14 @@ class RenderingContext2d {
     this._gc = null;
     this.picture = null;
     this._bindTarget();
-    // A window adopted by id knows neither its depth nor its visual until the
-    // constructor's two requests reply, and depth 0 binds rgb24 — so a
-    // context taken on a depth-32 window before they land would silently drop
-    // the alpha channel, which is the ordinary case for a compositor taking
-    // the overlay window and its clients as bare ids (issue #293). Awaiting
-    // `wnd.ready` first is the explicit fix; re-binding when the answer
-    // changes the format is the one that does not need to be known about.
+    // A window or pixmap adopted by id knows neither its depth nor its
+    // visual until the requests its constructor sent reply, and an unknown
+    // depth binds rgb24 — so a context taken on a depth-32 drawable before
+    // they land would silently drop the alpha channel, which is the ordinary
+    // case for a compositor taking the overlay window, its clients and their
+    // named pixmaps as bare ids (issues #293, #291). Awaiting `ready` first
+    // is the explicit fix; re-binding when the answer changes the format is
+    // the one that does not need to be known about.
     if (!window.depth && typeof window.ready?.then === "function") {
       window.ready.then(() => this._refreshFormat());
     }

--- a/test/pattern.test.js
+++ b/test/pattern.test.js
@@ -413,8 +413,8 @@ test('a window whose depth is unknown names a wait that exists (issue #293)', as
   assert.throws(
     () => ctx.createPattern(wnd, 'repeat'),
     (err) => {
-      assert.match(err.message, /await wnd\.getGeometry\(\)/, 'the remedy that works on any window');
-      assert.match(err.message, /await wnd\.ready/, 'and the cheaper one for an adopted window');
+      assert.match(err.message, /await tile\.getGeometry\(\)/, 'the remedy that works on any tile');
+      assert.match(err.message, /await tile\.ready/, 'and the cheaper one for an adopted one');
       // both are real API, which is the whole point of the issue
       assert.equal(typeof wnd.getGeometry, 'function');
       assert.equal(typeof wnd.ready?.then, 'function');

--- a/test/pixmap-adopt.test.js
+++ b/test/pixmap-adopt.test.js
@@ -1,0 +1,232 @@
+// Pixmap adoption (sidorares/ntk#291): an id-only pixmap used to report
+// depth 24 whatever it really was, know nothing of its size, and refuse
+// ownership — so a compositor's XCompositeNameWindowPixmap result leaked by
+// construction and tiled with its alpha channel dropped. Now nothing is
+// defaulted, the constructor asks GetGeometry for whatever was not declared,
+// `ready`/`getGeometry()` are the same waits an adopted window has, and
+// `own`/`Pixmap.adopt` make destroy() mean it.
+//
+// Hermetic: node-x11's in-process pure-JS X server, two connections, so the
+// adopted pixmap really belongs to another client the way a handed-over one
+// does. The pure-JS server takes pixmaps at depth 32, so the case that loses
+// the alpha channel runs against a real reply here.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import Pixmap from '../lib/pixmap.js';
+import { StaticFontSource, createClient } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+const docsDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs');
+
+let server = null;
+let host = null; // the adopter: a compositor, a client handed a pixmap
+let guest = null; // the client whose pixmap it adopts
+
+// Adopting a pixmap that has gone is half of what is under test, so the X
+// errors it earns are expected output, not noise to print
+const xErrors = [];
+
+const connect = async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: (err) => xErrors.push(err)
+  });
+};
+
+beforeEach(async () => {
+  server = createServer({ width: 400, height: 300 });
+  xErrors.length = 0;
+  host = await connect();
+  guest = await connect();
+});
+
+afterEach(() => {
+  host?.X.terminate();
+  guest?.X.terminate();
+  server = host = guest = null;
+});
+
+/** drain the round trips a connection has in flight */
+const settle = (app) => new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+/** ask the server directly whether a drawable still answers */
+const geometryOf = (app, id) =>
+  new Promise((resolve, reject) => app.X.GetGeometry(id, (err, res) => (err ? reject(err) : resolve(res))));
+
+test('a pixmap ntk created is ready without a round trip', async () => {
+  const pixmap = host.createPixmap({ width: 16, height: 8, depth: 24 });
+
+  let resolved = null;
+  pixmap.ready.then((p) => (resolved = p));
+  await Promise.resolve(); // one microtask: no room for any I/O
+  assert.equal(resolved, pixmap, 'resolves with the pixmap, and immediately');
+  pixmap.destroy();
+});
+
+test('an adopted pixmap defaults nothing and learns its real depth', async () => {
+  const src = guest.createPixmap({ width: 100, height: 80, depth: 32 });
+  await settle(guest);
+
+  const adopted = new Pixmap(host, { id: src.id });
+  assert.equal(adopted.depth, undefined, 'no invented depth 24 — nothing is known yet');
+  assert.equal(adopted.width, undefined);
+  assert.equal(adopted.height, undefined);
+
+  let resolved = null;
+  adopted.ready.then((p) => (resolved = p));
+  await Promise.resolve();
+  assert.equal(resolved, null, 'the wait is a real reply, not a formality');
+
+  assert.equal(await adopted.ready, adopted);
+  assert.equal(adopted.width, 100);
+  assert.equal(adopted.height, 80);
+  assert.equal(adopted.depth, 32, 'the depth a picture format is picked from');
+
+  src.destroy();
+});
+
+test('declaring the full geometry costs no round trip', async () => {
+  const src = guest.createPixmap({ width: 10, height: 10, depth: 32 });
+  await settle(guest);
+
+  const adopted = new Pixmap(host, { id: src.id, width: 10, height: 10, depth: 32 });
+  let resolved = null;
+  adopted.ready.then((p) => (resolved = p));
+  await Promise.resolve();
+  assert.equal(resolved, adopted, 'the caller already said everything GetGeometry would');
+  assert.equal(adopted.depth, 32);
+
+  src.destroy();
+});
+
+test('getGeometry() asks the server and writes the answer back', async () => {
+  const src = guest.createPixmap({ width: 60, height: 40, depth: 24 });
+  await settle(guest);
+
+  const adopted = new Pixmap(host, { id: src.id });
+  const geometry = await adopted.getGeometry();
+  assert.deepEqual(geometry, {
+    x: 0,
+    y: 0,
+    width: 60,
+    height: 40,
+    depth: 24,
+    borderWidth: 0,
+    root: host.display.screen[0].root
+  });
+  assert.equal(adopted.width, 60);
+  assert.equal(await adopted.ready, adopted, 'the pending wait is settled by this reply too');
+
+  src.destroy();
+});
+
+test('Pixmap.adopt owns: destroy() really frees the server-side pixmap', async () => {
+  const src = guest.createPixmap({ width: 20, height: 20, depth: 24 });
+  await settle(guest);
+
+  const adopted = await Pixmap.adopt(host, src.id);
+  assert.equal(adopted.width, 20);
+  assert.equal(adopted.depth, 24);
+  assert.equal(adopted._owned, true);
+
+  adopted.destroy();
+  await settle(host);
+  await assert.rejects(() => geometryOf(guest, src.id), 'the pixmap is gone server-side');
+});
+
+test('destroy() without ownership stays a no-op', async () => {
+  const src = guest.createPixmap({ width: 20, height: 20, depth: 24 });
+  await settle(guest);
+
+  const adopted = new Pixmap(host, { id: src.id });
+  await adopted.ready;
+  adopted.destroy();
+  await settle(host);
+  await assert.ok(await geometryOf(guest, src.id), 'someone else\'s pixmap was left alone');
+
+  src.destroy();
+});
+
+test('adopting a pixmap that has already gone rejects with the remedy', async () => {
+  const src = guest.createPixmap({ width: 20, height: 20, depth: 24 });
+  const id = src.id;
+  src.destroy();
+  await settle(guest);
+
+  await assert.rejects(
+    () => Pixmap.adopt(host, id),
+    (err) => {
+      assert.match(err.message, /does not exist/);
+      assert.match(err.message, /name it again/, 'the compositor remedy is named');
+      assert.ok(err.cause, 'the X error rides along');
+      return true;
+    }
+  );
+});
+
+test("a foreign id is freed but never recycled into this client's allocator", async () => {
+  const src = guest.createPixmap({ width: 8, height: 8, depth: 24 });
+  await settle(guest);
+
+  const adopted = await Pixmap.adopt(host, src.id);
+  adopted.destroy();
+  assert.ok(
+    !host.X._unusedIds.includes(src.id),
+    "guest's id must not come back out of host's AllocID — the server would refuse it"
+  );
+});
+
+test('an id this client allocated itself goes back into the pool', async () => {
+  // the NameWindowPixmap shape: the adopter allocated the id, another party
+  // (here: a raw request) made the pixmap live behind it
+  const id = host.X.AllocID();
+  host.X.CreatePixmap(id, host.display.screen[0].root, 24, 8, 8);
+
+  const adopted = await Pixmap.adopt(host, id);
+  assert.equal(adopted.width, 8);
+  adopted.destroy();
+  assert.ok(host.X._unusedIds.includes(id), 'the id is ours, so destroy() recycles it');
+});
+
+// ---------------------------------------------------------------------
+// what the wait is for: the picture format a 2d context binds
+// ---------------------------------------------------------------------
+
+test('a context on an adopted pixmap rebinds when the depth turns out to be 32', async () => {
+  const src = guest.createPixmap({ width: 32, height: 32, depth: 32 });
+  await settle(guest);
+
+  const adopted = new Pixmap(host, { id: src.id });
+  const ctx = adopted.getContext('2d');
+  const Render = host.display.Render;
+  // an unknown depth is indistinguishable from 24 at this point, so the only
+  // format available is the opaque one — this is where the alpha channel
+  // used to be lost for good
+  assert.equal(ctx.picture.format, Render.rgb24);
+
+  await adopted.ready;
+  await tick();
+  assert.equal(ctx.picture.format, Render.rgba32, 'the reply changes the format, so the picture is rebuilt');
+  assert.equal(ctx._hasAlpha, true, 'clearRect can clear to transparent again');
+
+  src.destroy();
+});
+
+test('the docs sections the adoption story points at exist', () => {
+  // a cross-file anchor is the one kind of doc link nothing else in CI checks
+  const pixmap = readFileSync(join(docsDir, 'pixmap.md'), 'utf8');
+  assert.ok(/^## Adoption$/m.test(pixmap), 'docs/pixmap.md#adoption');
+  const resources = readFileSync(join(docsDir, 'resource-management.md'), 'utf8');
+  assert.ok(resources.includes('pixmap.md#adoption'), 'and resource-management points at it');
+});


### PR DESCRIPTION
Fixes #291.

`new Pixmap(app, { id })` used to learn nothing about the pixmap it adopted and take no responsibility for it: `depth` silently defaulted to 24 whatever the pixmap really was, `width`/`height` stayed undefined, and `destroy()` was a hard no-op. A wrong depth is not inert — it is what the picture format everything reads the pixels through is picked from, so an adopted ARGB pixmap tiled with its alpha channel dropped. And for a compositor, whose `XCompositeNameWindowPixmap` result the client must free on every resize of the named window, adoption that cannot own was a leak by construction.

Adoption now works the way it does for windows:

- **Nothing is defaulted.** `width`, `height` and `depth` are whatever the caller declared; where any is missing the constructor sends a `GetGeometry` and the reply fills them in. `await pixmap.ready` is the wait for it — the same never-rejecting await an adopted `Window` has — and a 2d context taken before the reply rebinds its picture format when the answer changes it, exactly as on an adopted window.
- **`await pixmap.getGeometry()`** asks the server on demand and writes the answer back, resolving with the same shape as `wnd.getGeometry()`.
- **Ownership is the caller's to declare.** `await Pixmap.adopt(app, id)` fetches the geometry and owns the pixmap — `destroy()`, `using` and the `FinalizationRegistry` fallback free it like any pixmap ntk created — and rejects with the remedy spelled out if the pixmap is already gone. `new Pixmap(app, { id, own: true, width, height, depth })` is the synchronous form; with all three declared no round trip is made. `own` still defaults to false on the bare constructor.
- **The id is only recycled when it was ours.** Owning frees the pixmap with `FreePixmap` either way, but the id goes back into the connection's allocator only when this client allocated it — the `NameWindowPixmap` shape — never when it came from another client's range, where recycling it would make `AllocID` hand out ids the server refuses.

Measured, the issue's repro:

```js
const src = app.createPixmap({ width: 100, height: 100, depth: 32 });
const adopted = new Pixmap(app, { id: src.id });
// before: width undefined  height undefined  depth 24
// now:    width undefined  height undefined  depth undefined
await adopted.ready;
// now:    width 100  height 100  depth 32
```

The `createPattern` unknown-depth error now covers pixmaps alongside windows, docs/pixmap.md gains an Adoption section that resource-management.md links to, and a hermetic two-connection suite pins all of it against node-x11's pure-JS X server, including the depth-32 rebind that used to lose the alpha channel.
