### PR TITLE
feat(events): deliver extension events to the window or pixmap they name

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -191,20 +191,46 @@ app that only wanted a region or a shape degrades to doing without.
 
 ### Extension events
 
-Extension events do not currently reach the `Window` or `Pixmap` they name.
-They arrive parsed on the node-x11 client, where a compositor's repaint
-trigger reads them:
+The events these extensions add are not core events and not generic events
+either: their type codes are assigned by the server at QueryExtension time,
+and each one names its target under the field its own protocol calls it —
+`DamageNotify` a `drawable`, the others a `window` — so the core dispatch
+tables cannot see them. Requiring an extension through the accessors above
+is what teaches the connection its events; from then on each one is
+delivered to the `Window` — or `Pixmap`, since a DAMAGE object can watch
+one — that it names, under an ntk name, through the same delivery path as
+core events:
+
+| event | X event | payload |
+|---|---|---|
+| `damage` | DAMAGE DamageNotify | the drawable's content changed. Coalesced per paced frame exactly like `expose`: bounding box in `ev.x/y/width/height`, every reported rectangle in `ev.rects`; plus `ev.damage` (the DAMAGE object id, what `Subtract` takes), `ev.geometry`, `ev.level`, `ev.more` (the wire's "more follow" flag — coalescing already batches, so it is informational), `ev.time` |
+| `shape` | SHAPE ShapeNotify | the window's shape changed: `ev.kind` (`'bounding'`, `'clip'` or `'input'`), the new extents in `ev.x/y/width/height`, `ev.shaped` (false when the shape was removed), `ev.time` |
+| `selection_owner` | XFIXES SelectionNotify | a selection's ownership changed (`selection` here means what it does in [clipboard](clipboard.md), not the core conversion event `'selection'` reports): `ev.selection` (atom), `ev.owner` (window id, 0 when nobody), `ev.reason` (`'new-owner'`, `'destroyed'` or `'closed'`), `ev.timestamp`, `ev.selectionTimestamp`. [`app.clipboard.watch()`](clipboard.md) is the wrapped spelling |
+| `cursor` | XFIXES CursorNotify | the displayed cursor image changed — what a compositor redraws its cursor from: `ev.cursorSerial`, `ev.cursorName` (atom, 0 when unnamed), `ev.time` |
+
+Selecting for them still goes through the extension — `damage.Create(...)`,
+`shape.SelectInput(...)`, `fixes.SelectSelectionInput(...)`,
+`fixes.SelectCursorInput(...)` — because that is a request each protocol
+shapes differently. Delivery is ntk's: a compositor's repaint loop is one
+listener, with the same per-frame coalescing a window's own `expose` gets:
 
 ```js
-app.X.on('event', (ev) => {
-  if (ev.name === 'DamageNotify') repaint(ev.drawable, ev.area);
-  if (ev.name === 'ShapeNotify') reshape(ev.window);
+const damage = await app.damage();
+if (!damage) throw new Error('no DAMAGE on this server');
+
+const wnd = app.createWindow({ id: clientWid }); // adopt the composited window
+damage.Create(app.X.AllocID(), wnd.id, damage.ReportLevel.NonEmpty);
+wnd.on('damage', (ev) => {
+  // once per paced frame, however many rectangles the burst reported
+  for (const r of ev.rects) repaint(wnd, r);
 });
 ```
 
-Selecting for them still goes through the extension (`damage.Create(...)`,
-`shape.SelectInput(...)`), and there is no `wnd.on('damage')` — so a repaint
-driven this way sits outside ntk's own event and frame machinery.
+Events about drawables nothing wraps — an id never made into a `Window` or
+`Pixmap` — still arrive parsed on the node-x11 client, as every event does:
+`app.X.on('event', (ev) => ...)`, matching `ev.name`. A `Pixmap` joins the
+routed path the moment it gets a listener for one of these names, and
+leaves it in `destroy()`.
 
 ## Picture formats
 

--- a/docs/pixmap.md
+++ b/docs/pixmap.md
@@ -35,6 +35,24 @@ given the window's visual already.
 - `pixmap.visualId` — the visual its pixels are in, or `0` for "go by the
   depth"
 
+## Events
+
+A pixmap is an `EventEmitter` for one reason: extension events name a
+*drawable*, and a DAMAGE object can watch a pixmap as readily as a window.
+Create one on the pixmap's id and its `damage` events are delivered here —
+see [Extension events](app.md#extension-events):
+
+```js
+const damage = await app.damage();
+damage.Create(app.X.AllocID(), pixmap.id, damage.ReportLevel.NonEmpty);
+pixmap.on('damage', (ev) => { /* ev.x/y/width/height changed */ });
+```
+
+Unlike a window, a pixmap has no frame clock, so nothing is coalesced: every
+event is delivered as it arrives. Note that a pixmap with such a listener is
+referenced by the connection and stays alive until `destroy()` — the GC
+fallback below cannot collect it.
+
 ## Lifecycle
 
 - `pixmap.destroy()` — free the server-side pixmap and release the id

--- a/docs/window.md
+++ b/docs/window.md
@@ -1254,6 +1254,8 @@ constructor arg) automatically extends the window's X event mask.
 | `statechange` | PropertyNotify | derived, not an X event: the window manager changed `_NET_WM_STATE`. The handler gets the state names, not an event object — see [Window states](#window-states--setwmstatenames-action) |
 | `close` | ClientMessage | the window manager asking this window to close. `ev.preventDefault()` declines; see [Closing](#closing--onclose-ev--evpreventdefault) |
 | `property`, `reparent`, `message`, `selection*` | | |
+| `damage` | DAMAGE DamageNotify | coalesced per frame like `expose` (bounding box in `ev.x/y/width/height`, rect list in `ev.rects`); needs a DAMAGE object created on the window first — see [Extension events](app.md#extension-events) |
+| `shape`, `selection_owner`, `cursor` | SHAPE / XFIXES notifies | selected through the extension, delivered here — see [Extension events](app.md#extension-events) |
 
 Every event object gets `ev.window` and `ev.target` set to the `Window`.
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -12,6 +12,7 @@ import { sharedGlyphsFor } from './sharedglyphs.js';
 import { ShmUploader } from './shm-upload.js';
 import FontManager from './text/fontmanager.js';
 import Window from './window.js';
+import * as xevents from './events_map.js';
 
 /**
  * The highest predefined atom id in the core protocol, `XA_WM_TRANSIENT_FOR`.
@@ -135,6 +136,11 @@ export default class App {
     this._rasterizer = undefined;
     this._shm = undefined;
     this._extensionPromises = new Map();
+    // extension event routing (see _routeExtensionEvents): server-assigned
+    // event type code -> events_map.extension entry. Null until the first
+    // extension with events is required, which is also when the client-level
+    // listener that consults it is attached.
+    this._extEvents = null;
     this._devicesPromise = null;
     // XFIXES, once something has asked for it (regions, `app.fixes()`). The
     // promise lives in _extensionPromises with the other extensions; the
@@ -377,11 +383,66 @@ export default class App {
     let pending = this._extensionPromises.get(name);
     if (!pending) {
       pending = new Promise((resolve) => {
-        this.X.require(name, (err, ext) => resolve(err ? null : ext));
+        this.X.require(name, (err, ext) => {
+          if (!err && ext) this._routeExtensionEvents(name, ext);
+          resolve(err ? null : ext);
+        });
       });
       this._extensionPromises.set(name, pending);
     }
     return pending;
+  }
+
+  /**
+   * Give this extension's events names, and a route to the object they name.
+   *
+   * A non-generic extension event carries a server-assigned type code
+   * (`firstEvent` + a fixed offset) and names its target under the field its
+   * own protocol calls it — DamageNotify a `drawable`, ShapeNotify and the
+   * XFIXES notifies a `window` — never under the `wid` node-x11 dispatches
+   * per-window consumers by. So without this they reach the client's raw
+   * `'event'` stream and nothing else (issue #290).
+   *
+   * Registered here, when the extension is first required through the
+   * accessors above, because the type codes exist only once the server has
+   * answered. From then on the listener below hands each one to the Window
+   * or Pixmap it names — through `_deliverEvent`, so a window's coalescing
+   * and frame pacing apply: `damage` unions its rectangles per paced frame
+   * exactly as `expose` does. The lookup goes through `X.event_consumers`,
+   * where every Window already sits for core dispatch and a Pixmap enrols
+   * itself when given a listener (see lib/pixmap.js).
+   */
+  _routeExtensionEvents(module, ext) {
+    const events = xevents.extension[module];
+    if (!events || !ext.firstEvent || !ext.events) return;
+    if (!this._extEvents) {
+      this._extEvents = new Map();
+      this.X.on('event', (ev) => {
+        // by the server-assigned type code, with the parser's event name
+        // standing in where the parsed event does not carry one — node-x11's
+        // DamageNotify parser is the one extension parser that sets `name`
+        // but not `type` (x11 <= 3.9). Only names this table registered can
+        // match, and core events always carry their type.
+        const route = this._extEvents.get(ev.type ?? ev.name);
+        if (!route) return;
+        const target = this.X.event_consumers[ev[route.target]];
+        // a consumer that is not an ntk drawable (a caller's own) keeps
+        // reading the raw client stream it always read
+        if (typeof target?._deliverEvent !== 'function') return;
+        const ntkev = route.translate(ev);
+        ntkev.target = target;
+        if (target instanceof Window) ntkev.window = target;
+        target._deliverEvent(route.name, ntkev);
+      });
+    }
+    for (const [key, spec] of Object.entries(events)) {
+      const offset = ext.events[key];
+      if (offset === undefined) continue;
+      this._extEvents.set(ext.firstEvent + offset, spec);
+      // the wire name doubles as a key, for parsed events missing `type` —
+      // number and string keys cannot collide in the one map
+      this._extEvents.set(key, spec);
+    }
   }
 
   /**

--- a/lib/drawable.js
+++ b/lib/drawable.js
@@ -11,6 +11,16 @@ export default class Drawable extends EventEmitter {
     if (!factory) throw new Error(`Unknown rendering context: ${name}`);
     return factory(this, ...args);
   }
+
+  /**
+   * Deliver one named event to this drawable's listeners. Window overrides
+   * this with per-frame coalescing and pacing; the base emits directly,
+   * for drawables with no frame clock — a Pixmap a DAMAGE object watches
+   * (see App#_routeExtensionEvents).
+   */
+  _deliverEvent(name, ev) {
+    this.emit(name, ev);
+  }
 }
 
 // populated by the renderingcontext_* modules on import

--- a/lib/events_map.js
+++ b/lib/events_map.js
@@ -86,12 +86,111 @@ export const coalesce = {
   mousemove: 'last',
   resize: 'last',
   expose: 'union',
+  // DamageNotify is the expose case again — a burst of rectangles whose
+  // union is what a repaint wants — reported about a drawable's content
+  // instead of a window's visibility
+  damage: 'union',
   // 'accumulate' — scroll distance adds up. Keeping the last delta instead
   // would throw away everything but the final step of a fast scroll, and a
   // frame's worth of a touchpad's sub-notch deltas is exactly the case the
   // smooth-scroll path exists for.
   wheel: 'accumulate'
 };
+
+// XFixes SelectionNotify subtype -> why the ownership changed, the same
+// vocabulary clipboard.watch already answers in. The codes are fixed by
+// xfixesproto (SelectionEvent), not assigned by the server.
+const selectionReason = ['new-owner', 'destroyed', 'closed'];
+
+// ShapeNotify kind -> which of the window's three shapes changed
+// (shapeproto ShapeKind)
+const shapeKind = ['bounding', 'clip', 'input'];
+
+/**
+ * The non-generic extension events, and how to deliver them.
+ *
+ * Unlike core events their type codes are assigned by the server at
+ * QueryExtension time (`ext.firstEvent` + a fixed offset), and the drawable
+ * each one names arrives under the field its own protocol calls it —
+ * DamageNotify a `drawable`, the others a `window` — never under the `wid`
+ * node-x11 dispatches per-window consumers by. So they need both halves of
+ * this table: a name, and which field to route by. App reads it when an
+ * extension is required through its accessors (`app.damage()` and friends)
+ * and hands each event to the Window or Pixmap it names — see
+ * App#_routeExtensionEvents and docs/app.md "Extension events".
+ *
+ * Keyed by node-x11's module name, then by the event's key in `ext.events`.
+ * `translate` shapes the raw node-x11 event into the one delivered.
+ */
+export const extension = {
+  damage: {
+    DamageNotify: {
+      name: 'damage',
+      target: 'drawable',
+      // expose-shaped, because it is the same news: the box in
+      // x/y/width/height so 'union' coalescing applies to it unchanged.
+      // Bit 7 of the level byte is the wire's own "more follow" flag —
+      // split out, since the report level it rides on is 0..3.
+      translate: (ev) => ({
+        x: ev.area.x,
+        y: ev.area.y,
+        width: ev.area.w,
+        height: ev.area.h,
+        geometry: ev.geometry,
+        damage: ev.damage,
+        level: ev.level & 0x7f,
+        more: !!(ev.level & 0x80),
+        time: ev.time
+      })
+    }
+  },
+  fixes: {
+    // 'selection' is taken — it is core SelectionNotify, a conversion
+    // answered — and this event is about who owns the selection, hence the
+    // qualified name
+    SelectionNotify: {
+      name: 'selection_owner',
+      target: 'window',
+      translate: (ev) => ({
+        selection: ev.selection,
+        owner: ev.owner,
+        reason: selectionReason[ev.subtype] ?? ev.subtype,
+        timestamp: ev.timestamp,
+        selectionTimestamp: ev.selectionTimestamp
+      })
+    },
+    CursorNotify: {
+      name: 'cursor',
+      target: 'window',
+      translate: (ev) => ({
+        cursorSerial: ev.cursorSerial,
+        cursorName: ev.cursorName,
+        time: ev.timestamp
+      })
+    }
+  },
+  shape: {
+    ShapeNotify: {
+      name: 'shape',
+      target: 'window',
+      translate: (ev) => ({
+        kind: shapeKind[ev.kind] ?? ev.kind,
+        x: ev.x,
+        y: ev.y,
+        width: ev.width,
+        height: ev.height,
+        shaped: !!ev.shaped,
+        time: ev.time
+      })
+    }
+  }
+};
+
+// every routed extension event name — what a Pixmap watches `newListener`
+// for to enrol itself in the routing table (see lib/pixmap.js)
+export const extensionEventNames = new Set(
+  Object.values(extension).flatMap((events) => Object.values(events).map((spec) => spec.name))
+);
 
 export const toSnake = {
   onMouseMove: 'mousemove',
@@ -124,4 +223,4 @@ export const maskCamelCase = Object.fromEntries(
   Object.entries(toSnake).map(([camel, snake]) => [camel, mask[snake]])
 );
 
-export default { eventName, mask, maskCamelCase, toSnake, coalesce };
+export default { eventName, mask, maskCamelCase, toSnake, coalesce, extension, extensionEventNames };

--- a/lib/pixmap.js
+++ b/lib/pixmap.js
@@ -1,5 +1,6 @@
 import { safeRelease } from './cleanup.js';
 import Drawable from './drawable.js';
+import { extensionEventNames } from './events_map.js';
 
 // GC fallback: free the server-side pixmap when the wrapper is collected
 // without an explicit destroy()
@@ -39,9 +40,23 @@ export default class Pixmap extends Drawable {
       this.id = args.id;
       this._owned = false;
     }
+
+    // Extension events name their drawable, and a DAMAGE object can watch a
+    // pixmap, so routing (see App#_routeExtensionEvents) looks the target up
+    // in `X.event_consumers` — where windows already live. A pixmap enrols
+    // only when someone listens, because the entry is a strong reference:
+    // enrolling every pixmap would pin them all past the GC fallback above.
+    // A listening pixmap therefore stays until destroy(), which is also what
+    // removes it from the table.
+    this.on('newListener', (name) => {
+      if (extensionEventNames.has(name) && X.event_consumers) {
+        X.event_consumers[this.id] = this;
+      }
+    });
   }
 
   destroy() {
+    if (this.X.event_consumers?.[this.id] === this) delete this.X.event_consumers[this.id];
     if (!this._owned) return;
     this._owned = false;
     registry.unregister(this);

--- a/test/events-map.test.js
+++ b/test/events-map.test.js
@@ -1,7 +1,14 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { coalesce, eventName, mask, maskCamelCase, toSnake } from '../lib/events_map.js';
+import {
+  coalesce,
+  eventName,
+  extensionEventNames,
+  mask,
+  maskCamelCase,
+  toSnake
+} from '../lib/events_map.js';
 
 test('every camelCase handler name maps to a snake event with a mask entry', () => {
   for (const [camel, snake] of Object.entries(toSnake)) {
@@ -32,12 +39,16 @@ test('every maskable event name is emitted by some X event type, or derived from
 test('coalescible events are known event names with known strategies', () => {
   const emitted = new Set(eventName.filter(Boolean));
   for (const [name, strategy] of Object.entries(coalesce)) {
-    assert.ok(emitted.has(name) || DERIVED.has(name), `${name} never emitted`);
+    assert.ok(
+      emitted.has(name) || DERIVED.has(name) || extensionEventNames.has(name),
+      `${name} never emitted`
+    );
     assert.ok(['last', 'union', 'accumulate'].includes(strategy), `unknown strategy ${strategy}`);
   }
   assert.equal(coalesce.mousemove, 'last');
   assert.equal(coalesce.resize, 'last');
   assert.equal(coalesce.expose, 'union');
+  assert.equal(coalesce.damage, 'union');
   assert.equal(coalesce.wheel, 'accumulate');
 });
 

--- a/test/extension-events-live.test.js
+++ b/test/extension-events-live.test.js
@@ -1,0 +1,146 @@
+// Extension events against a real X server: DamageNotify, ShapeNotify and
+// XFixes SelectionNotify delivered to the ntk object they name (issue #290).
+//
+// This is the half the hermetic test cannot check — that the type codes the
+// server really assigned are the ones the routing learnt, and that delivery
+// rides the window's own frame machinery (a damage burst arrives coalesced,
+// with its rectangles). Skipped where there is no DISPLAY, and per-extension
+// where the server lacks the extension.
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { after, before, test } from 'node:test';
+
+import { createClient } from '../lib/index.js';
+import { withTimeout } from './helpers/async.js';
+
+let app = null;
+let skip = false;
+
+before(async () => {
+  if (!process.env.DISPLAY) {
+    skip = 'no DISPLAY set';
+    return;
+  }
+  try {
+    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+  } catch (err) {
+    skip = `cannot connect to X server: ${err.message}`;
+  }
+});
+
+after(async () => {
+  await app?.close();
+});
+
+const nextEvent = (emitter, name) =>
+  withTimeout(new Promise((resolve) => emitter.once(name, resolve)), 5000, `a '${name}' event`);
+
+test('drawing on a window delivers coalesced damage to its wrapper', async (t) => {
+  if (skip) return t.skip(skip);
+  const damage = await app.damage();
+  if (!damage) return t.skip('server has no DAMAGE');
+
+  const wnd = app.createWindow({ width: 120, height: 90 });
+  const ctx = wnd.getContext('2d');
+  wnd.map();
+  await withTimeout(once(wnd, 'map'), 5000, 'the window to map');
+
+  // RawRectangles: every damaged rectangle is its own event, which is the
+  // report level that makes coalescing observable — and the one a compositor
+  // that wants ev.rects would pick
+  const damageId = app.X.AllocID();
+  damage.Create(damageId, wnd.id, damage.ReportLevel.RawRectangles);
+
+  const delivered = nextEvent(wnd, 'damage');
+  ctx.fillStyle = 'red';
+  ctx.fillRect(10, 10, 50, 40);
+  const ev = await delivered;
+
+  assert.equal(ev.window, wnd, 'the event carries its Window');
+  assert.equal(ev.target, wnd);
+  assert.equal(ev.damage, damageId, 'the DAMAGE object id, for Subtract');
+  assert.ok(Array.isArray(ev.rects) && ev.rects.length >= 1, 'rect list, like expose');
+  assert.ok(ev.width > 0 && ev.height > 0, 'a non-empty bounding box');
+  // the blit that damaged the window covers what was drawn, so the reported
+  // box must touch it
+  assert.ok(ev.x < 60 && ev.x + ev.width > 10, `box [${ev.x}, ${ev.x + ev.width}) misses x 10..60`);
+  assert.ok(ev.y < 50 && ev.y + ev.height > 10, `box [${ev.y}, ${ev.y + ev.height}) misses y 10..50`);
+
+  damage.Destroy(damageId);
+  wnd.destroy();
+});
+
+test('drawing on a pixmap delivers damage to the pixmap itself', async (t) => {
+  if (skip) return t.skip(skip);
+  const damage = await app.damage();
+  if (!damage) return t.skip('server has no DAMAGE');
+
+  const pixmap = app.createPixmap({
+    width: 40,
+    height: 30,
+    depth: app.display.screen[0].root_depth
+  });
+  const damageId = app.X.AllocID();
+  damage.Create(damageId, pixmap.id, damage.ReportLevel.NonEmpty);
+
+  const delivered = nextEvent(pixmap, 'damage');
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'blue';
+  ctx.fillRect(0, 0, 40, 30);
+  const ev = await delivered;
+
+  assert.equal(ev.target, pixmap, 'a damage created on a pixmap routes to the Pixmap');
+  assert.equal(ev.window, undefined, 'no window field on a pixmap event');
+  assert.equal(ev.damage, damageId);
+  assert.ok(ev.width > 0 && ev.height > 0);
+
+  damage.Destroy(damageId);
+  pixmap.destroy();
+});
+
+test('reshaping a window delivers a shape event', async (t) => {
+  if (skip) return t.skip(skip);
+  const shape = await app.shape();
+  if (!shape) return t.skip('server has no SHAPE');
+
+  const wnd = app.createWindow({ width: 60, height: 60 });
+  shape.SelectInput(wnd.id, true);
+
+  const delivered = nextEvent(wnd, 'shape');
+  shape.Rectangles(shape.Op.Set, shape.Kind.Bounding, wnd.id, 0, 0, [[0, 0, 30, 30]]);
+  const ev = await delivered;
+
+  assert.equal(ev.window, wnd);
+  assert.equal(ev.kind, 'bounding');
+  assert.equal(ev.shaped, true);
+  assert.ok(ev.width > 0 && ev.height > 0);
+
+  wnd.destroy();
+});
+
+test('a selection changing owners delivers selection_owner to the watcher', async (t) => {
+  if (skip) return t.skip(skip);
+  const fixes = await app.xfixes();
+  if (!fixes) return t.skip('server has no XFIXES');
+
+  const watcher = app.createWindow({ width: 10, height: 10 });
+  const owner = app.createWindow({ width: 10, height: 10 });
+  const atom = await new Promise((resolve, reject) =>
+    app.X.InternAtom(false, `NTK_TEST_SELECTION_${process.pid}`, (err, a) =>
+      err ? reject(err) : resolve(a)
+    )
+  );
+  fixes.SelectSelectionInput(watcher.id, atom, fixes.SelectionEventMask.SetSelectionOwner);
+
+  const delivered = nextEvent(watcher, 'selection_owner');
+  app.X.SetSelectionOwner(owner.id, atom);
+  const ev = await delivered;
+
+  assert.equal(ev.window, watcher, 'delivered to the window that selected the input');
+  assert.equal(ev.selection, atom);
+  assert.equal(ev.owner, owner.id);
+  assert.equal(ev.reason, 'new-owner');
+
+  watcher.destroy();
+  owner.destroy();
+});

--- a/test/extension-events.test.js
+++ b/test/extension-events.test.js
@@ -1,0 +1,219 @@
+// Extension event routing (issue #290): DamageNotify, ShapeNotify and the
+// XFIXES notifies carry a server-assigned type code and name their target
+// under `drawable`/`window` rather than `wid`, so node-x11's per-window
+// dispatch never routes them. App learns their codes when an extension is
+// required through its accessors and hands each one to the drawable it
+// names, under an ntk name.
+//
+// Hermetic — the extension objects and the event stream are stubs, because
+// what is under test is the registration, the lookup and the translation.
+// The full path against a real server (frame-coalesced delivery included) is
+// extension-events-live.test.js.
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+
+import App from '../lib/app.js';
+import Pixmap from '../lib/pixmap.js';
+import * as xevents from '../lib/events_map.js';
+
+// firstEvent values as a real server might assign them — arbitrary, distinct
+const EXTS = {
+  damage: { majorOpcode: 143, firstEvent: 91, events: { DamageNotify: 0 } },
+  fixes: { majorOpcode: 138, firstEvent: 87, events: { SelectionNotify: 0, CursorNotify: 1 } },
+  shape: { majorOpcode: 129, firstEvent: 64, events: { ShapeNotify: 0 } }
+};
+
+/** An App on a stub client that "has" every extension in EXTS. */
+function makeApp() {
+  const X = new EventEmitter();
+  X.atoms = {};
+  X.event_consumers = {};
+  X.require = (name, cb) => {
+    const ext = EXTS[name];
+    setImmediate(() => (ext ? cb(null, ext) : cb(new Error('extension not available'))));
+  };
+  const app = new App({ client: X, screen: [{ root: 1 }] }, {});
+  return { app, X };
+}
+
+/** An ntk-drawable-shaped consumer that records what reaches it. */
+function consumer() {
+  const delivered = [];
+  return { delivered, _deliverEvent: (name, ev) => delivered.push({ name, ev }) };
+}
+
+test('DamageNotify reaches the drawable it names, expose-shaped', async () => {
+  const { app, X } = makeApp();
+  const wnd = consumer();
+  X.event_consumers[5001] = wnd;
+
+  await app.damage();
+  X.emit('event', {
+    type: EXTS.damage.firstEvent,
+    name: 'DamageNotify',
+    level: 1 | 0x80,
+    drawable: 5001,
+    damage: 777,
+    time: 12345,
+    area: { x: 10, y: 20, w: 30, h: 40 },
+    geometry: { x: 0, y: 0, w: 200, h: 200 }
+  });
+
+  assert.equal(wnd.delivered.length, 1);
+  const { name, ev } = wnd.delivered[0];
+  assert.equal(name, 'damage');
+  assert.deepEqual(
+    { x: ev.x, y: ev.y, width: ev.width, height: ev.height },
+    { x: 10, y: 20, width: 30, height: 40 },
+    'the damaged box lands where expose puts it, so union coalescing applies'
+  );
+  assert.equal(ev.damage, 777, 'the DAMAGE object id, for Subtract');
+  assert.equal(ev.level, 1, 'report level without the wire flag bit');
+  assert.equal(ev.more, true, 'the flag bit, split out');
+  assert.deepEqual(ev.geometry, { x: 0, y: 0, w: 200, h: 200 });
+  assert.equal(ev.target, wnd, 'events carry their target object');
+});
+
+test('ShapeNotify and the XFIXES notifies route by their window field', async () => {
+  const { app, X } = makeApp();
+  const wnd = consumer();
+  X.event_consumers[42] = wnd;
+
+  await Promise.all([app.shape(), app.xfixes()]);
+
+  X.emit('event', {
+    type: EXTS.shape.firstEvent,
+    name: 'ShapeNotify',
+    kind: 0,
+    window: 42,
+    x: 1,
+    y: 2,
+    width: 3,
+    height: 4,
+    time: 9,
+    shaped: 1
+  });
+  X.emit('event', {
+    type: EXTS.fixes.firstEvent + EXTS.fixes.events.SelectionNotify,
+    name: 'SelectionNotify',
+    subtype: 0,
+    window: 42,
+    owner: 600,
+    selection: 31,
+    timestamp: 100,
+    selectionTimestamp: 99
+  });
+  X.emit('event', {
+    type: EXTS.fixes.firstEvent + EXTS.fixes.events.CursorNotify,
+    name: 'CursorNotify',
+    subtype: 0,
+    window: 42,
+    cursorSerial: 8,
+    timestamp: 101,
+    cursorName: 0
+  });
+
+  assert.deepEqual(
+    wnd.delivered.map((d) => d.name),
+    ['shape', 'selection_owner', 'cursor']
+  );
+  const [shape, owner, cursor] = wnd.delivered.map((d) => d.ev);
+  assert.equal(shape.kind, 'bounding', 'ShapeKind by name');
+  assert.equal(shape.shaped, true);
+  assert.deepEqual(
+    { x: shape.x, y: shape.y, width: shape.width, height: shape.height },
+    { x: 1, y: 2, width: 3, height: 4 }
+  );
+  assert.equal(owner.reason, 'new-owner', 'the vocabulary clipboard.watch answers in');
+  assert.equal(owner.owner, 600);
+  assert.equal(owner.selection, 31);
+  assert.equal(cursor.cursorSerial, 8);
+  assert.equal(cursor.time, 101, "the timestamp under the name ntk's other events use");
+});
+
+test('a parsed event with a name but no type still routes', async () => {
+  // node-x11's DamageNotify parser (x11 <= 3.9) sets `name` but not `type`,
+  // unlike every other extension parser — the wire name is the key then
+  const { app, X } = makeApp();
+  const wnd = consumer();
+  X.event_consumers[5001] = wnd;
+
+  await app.damage();
+  X.emit('event', {
+    name: 'DamageNotify',
+    level: 0,
+    drawable: 5001,
+    damage: 1,
+    time: 0,
+    area: { x: 1, y: 1, w: 2, h: 2 },
+    geometry: { x: 0, y: 0, w: 9, h: 9 }
+  });
+  assert.equal(wnd.delivered.length, 1);
+  assert.equal(wnd.delivered[0].name, 'damage');
+});
+
+test('nothing routes before the extension has been required', async () => {
+  const { app, X } = makeApp();
+  const wnd = consumer();
+  X.event_consumers[5001] = wnd;
+
+  X.emit('event', { type: EXTS.damage.firstEvent, drawable: 5001, area: {}, geometry: {} });
+  assert.equal(wnd.delivered.length, 0, 'the type code means nothing yet');
+  assert.equal(X.listenerCount('event'), 0, 'and no listener sits on an unused connection');
+
+  await app.damage();
+  X.emit('event', {
+    type: EXTS.damage.firstEvent,
+    drawable: 5001,
+    level: 0,
+    area: { x: 0, y: 0, w: 1, h: 1 },
+    geometry: { x: 0, y: 0, w: 1, h: 1 }
+  });
+  assert.equal(wnd.delivered.length, 1, 'requiring the extension is what arms the route');
+});
+
+test('an event naming nothing we wrap, or a consumer that is not ours, is left alone', async () => {
+  const { app, X } = makeApp();
+  const plain = new EventEmitter(); // a caller's own event_consumers entry
+  let raw = 0;
+  plain.on('event', () => raw++);
+  X.event_consumers[7] = plain;
+
+  await app.damage();
+  // no entry for this drawable at all — must not throw
+  X.emit('event', { type: EXTS.damage.firstEvent, drawable: 999, area: {}, geometry: {} });
+  // an entry that is not an ntk drawable — must be left to its raw stream
+  X.emit('event', { type: EXTS.damage.firstEvent, drawable: 7, area: {}, geometry: {} });
+  assert.equal(raw, 0, 'ntk does not double-deliver into foreign consumers');
+});
+
+test('extension event names collide with nothing the core tables hand out', () => {
+  for (const name of xevents.extensionEventNames) {
+    assert.ok(!Object.values(xevents.eventName).includes(name), `'${name}' vs core event names`);
+    assert.ok(!(name in xevents.mask), `'${name}' vs the mask table`);
+  }
+  assert.equal(xevents.coalesce.damage, 'union', 'damage coalesces the way expose does');
+});
+
+test('a pixmap enrols for routing when listened to, and leaves on destroy', () => {
+  let ids = 9000;
+  const X = {
+    atoms: {},
+    on() {},
+    event_consumers: {},
+    AllocID: () => ++ids,
+    CreatePixmap() {}
+  };
+  const app = { X, display: { screen: [{ root: 1 }] } };
+
+  const pixmap = new Pixmap(app, { width: 4, height: 4 });
+  pixmap.on('newListener', () => {}); // any non-extension name changes nothing
+  assert.equal(X.event_consumers[pixmap.id], undefined, 'no listener, no entry, no pinning');
+
+  pixmap.on('damage', () => {});
+  assert.equal(X.event_consumers[pixmap.id], pixmap, 'a damage listener enrols it');
+
+  pixmap.destroy();
+  assert.equal(X.event_consumers[pixmap.id], undefined, 'destroy removes the entry');
+});


### PR DESCRIPTION
DamageNotify, ShapeNotify and the XFIXES notifies never reached the ntk object they name: node-x11 dispatches per-window consumers by `ev.wid`, and these events carry their target under the field their own protocol calls it — `drawable` for DamageNotify, `window` for the rest — with a type code the server assigns at QueryExtension time. So a compositor's repaint loop had to sit on `app.X.on('event', ...)` with its own drawable map, outside ntk's delivery, coalescing and frame pacing.

## What this does

Requiring an extension through the accessors from #301 — `app.damage()`, `app.xfixes()` / `app.fixes()`, `app.shape()` — now also registers its events with the connection. A client-level listener looks each one up by the server-assigned type code and hands it to the `Window` or `Pixmap` it names, through `_deliverEvent`, so the window's own machinery applies:

```js
const damage = await app.damage();
const damageId = app.X.AllocID();
damage.Create(damageId, wnd.id, damage.ReportLevel.RawRectangles);
// delivered once per paced frame: bounding box in ev.x/y/width/height,
// every reported rectangle in ev.rects
wnd.on('damage', repaint);
```

| event | X event | route field |
|---|---|---|
| `damage` | DAMAGE DamageNotify | `drawable` |
| `shape` | SHAPE ShapeNotify | `window` |
| `selection_owner` | XFIXES SelectionNotify | `window` |
| `cursor` | XFIXES CursorNotify | `window` |

- **`damage` coalesces with `union`**, exactly as `expose` does — damage rectangles are the expose case, which is the issue's main point. The delivered event is expose-shaped so the existing union path applies unchanged; `ev.damage` carries the DAMAGE object id for `Subtract`, and the wire's more-follows bit is split out of the level byte as `ev.more`.
- **`Drawable` is the registration point**, as the issue asked: a damage can be created on a pixmap, and a `Pixmap` now enrols itself in `X.event_consumers` when given a listener for one of these names — lazily, because an entry pins the wrapper past the GC fallback — and leaves on `destroy()`. Windows already sit there for core dispatch. Base `Drawable#_deliverEvent` emits directly; `Window` keeps its coalescing override.
- **Names are protocol-derived**: strip Notify — except XFIXES SelectionNotify, where `selection` is taken by the core conversion event, hence `selection_owner`; its `ev.reason` speaks the same vocabulary `clipboard.watch` already answers in.
- Non-ntk `event_consumers` entries are left alone, and events naming drawables nothing wraps still arrive on the raw client stream as before.

## A node-x11 wrinkle

node-x11's DamageNotify parser is the one extension parser that sets `event.name` but not `event.type` — x11 <= 3.9, `lib/ext/damage.js` — so the routing map is keyed by both the computed type code and the wire name, and the name is consulted only when `type` is absent. Worth a small upstream fix; the issue's other upstream idea, parsers also setting `wid`, would still not remove the need for the name table and the coalescing here.

## Testing

- `test/extension-events.test.js` — hermetic: registration arms only after an accessor resolves, routing and translation per event, the missing-`type` fallback, foreign consumers untouched, pixmap enrol/leave.
- `test/extension-events-live.test.js` — against a real server, per-extension skips: a window's 2d drawing delivers coalesced `damage` with `rects` to the wrapper; a damage created on a pixmap routes to the `Pixmap`; `shape` and `selection_owner` fire end to end. Verified on XQuartz; the issue's own reproduction now reports the event on the wrapper.
- Full suite: 1012 tests, 0 failures.

Docs updated: `docs/app.md` Extension events, `docs/window.md` event table, `docs/pixmap.md` Events.

Fixes #290