### PR TITLE
perf(window): drop no-op callbacks on void requests, memo the cursor

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -1196,6 +1196,13 @@ constant) is accepted too. Unknown names throw synchronously, listing the
 valid names. Created cursors are server-side resources, cached per
 connection on `app.cursors` and freed on `app.close()`.
 
+`setCursor` remembers what it last set (and what `createWindow({ cursor })`
+started the window with), so setting the cursor the window already has sends
+nothing — a hover handler that calls `setCursor` on every motion event costs
+one request per boundary crossing, not one per frame. Aliases resolve first,
+so `'pointer'` after `'hand'` is the same cursor and is free too. The name is
+still validated on every call.
+
 **`'none'` and `null` are not the same thing**, and the difference is the
 one people get wrong. `setCursor('none')` hides the pointer.
 `setCursor(null)` sets X cursor `None`, which means *inherit the parent's

--- a/lib/window.js
+++ b/lib/window.js
@@ -551,6 +551,9 @@ export default class Window extends Drawable {
       for (const name of forwardedXAttributes) {
         if (args[name] !== undefined) values[name] = args[name];
       }
+      // what setCursor compares against, so setting the cursor a window was
+      // created with is free rather than a redundant round trip
+      this._currentCursor = values.cursor;
       // a window on a non-default visual (GLX, ARGB) also needs its own
       // colormap and an explicit border pixel: inheriting either from a
       // parent of a different depth is a BadMatch (X11 CreateWindow)
@@ -927,7 +930,8 @@ export default class Window extends Drawable {
     // server sends them even if user code only listens to 'draw'
     if (!(this.eventMask & x11.eventMask.Exposure)) {
       this.eventMask |= x11.eventMask.Exposure;
-      this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask }, () => {});
+      // no callback: it would only buy node-x11's void-sync round trip, see setCursor
+      this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask });
     }
 
     // a pure move is a ConfigureNotify too, and reallocating a backing
@@ -974,7 +978,8 @@ export default class Window extends Drawable {
     if (this._destroyed) return this;
     if (this._clearGc) this.X.ChangeGC(this._clearGc, { foreground: pixel });
     if (!this._foreign) {
-      this.X.ChangeWindowAttributes(this.id, { backgroundPixel: pixel }, () => {});
+      // no callback: it would only buy node-x11's void-sync round trip, see setCursor
+      this.X.ChangeWindowAttributes(this.id, { backgroundPixel: pixel });
     }
     const backing = this._backing;
     if (backing && this._clearGc) {
@@ -3110,9 +3115,19 @@ export default class Window extends Drawable {
    *                      pointer stays visible
    */
   setCursor(nameOrShape) {
+    // resolved first: an unknown name has to throw whether or not the memo
+    // below short-circuits the request
     const cursor = nameOrShape == null ? 0 : this.app.cursors.get(nameOrShape);
+    if (cursor === this._currentCursor) return this;
+    this._currentCursor = cursor;
     safeRelease(this.X, () => {
-      this.X.ChangeWindowAttributes(this.id, { cursor }, () => {});
+      // no callback, deliberately: node-x11 guarantees a callback on a *void*
+      // request eventually fires, and buys that by injecting a GetInputFocus
+      // round trip when nothing else in the tick expects a reply (node-x11
+      // issue #85). A callback that ignores its argument costs that round trip
+      // per cursor change and buys nothing — an X error reaches
+      // `client.emit('error')`, and so app's onXError hook, either way.
+      this.X.ChangeWindowAttributes(this.id, { cursor });
     });
     return this;
   }
@@ -3125,7 +3140,8 @@ export default class Window extends Drawable {
     } else {
       return this;
     }
-    this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask }, () => {});
+    // no callback: it would only buy node-x11's void-sync round trip, see setCursor
+    this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask });
     return this;
   }
 

--- a/lib/xembed.js
+++ b/lib/xembed.js
@@ -559,7 +559,9 @@ export class XEmbedSocket extends EventEmitter {
     // reparent, so its ReparentNotify does not come back to us
     safeRelease(this.X, () => {
       client.eventMask = 0;
-      this.X.ChangeWindowAttributes(client.id, { eventMask: 0 }, () => {});
+      // no callback: it would only buy node-x11's void-sync round trip, see
+      // Window#setCursor
+      this.X.ChangeWindowAttributes(client.id, { eventMask: 0 });
     });
     client.reparentTo(this.app.rootWindow(), x, y);
     client.removeFromSaveSet();

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -163,3 +163,93 @@ test('app.close() frees the cached cursors and the cursor font', async () => {
   assert.equal(server.resources.get(fontId), undefined, 'font closed');
   await app2.close();
 });
+
+// The cost of a callback on a *void* request: node-x11 guarantees it fires
+// (node-x11 issue #85), and where nothing else in the tick expects a reply it
+// keeps that promise by injecting a GetInputFocus round trip. A callback that
+// ignores its argument therefore buys a round trip per cursor change and
+// nothing else — an X error reaches client.emit('error') either way (#309).
+const countInjectedSyncs = async (fn) => {
+  const original = app.X.GetInputFocus;
+  let injected = 0;
+  app.X.GetInputFocus = function (...args) {
+    injected++;
+    return original.apply(this, args);
+  };
+  try {
+    fn();
+    // node-x11 schedules the void sync on setImmediate; give it two turns
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    app.X.GetInputFocus = original;
+  }
+  return injected;
+};
+
+test('setCursor does not inject a void-sync round trip', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  const cid = app.cursors.get('wait'); // create it now, outside the measurement
+  await roundtrip(app);
+
+  const injected = await countInjectedSyncs(() => wnd.setCursor('wait'));
+  assert.equal(injected, 0, 'no GetInputFocus rides along with the attribute change');
+
+  await roundtrip(app);
+  assert.equal(server.resources.get(wnd.id).cursor, cid, 'and the cursor still got set');
+  wnd.destroy();
+});
+
+test('setting the cursor a window already has sends nothing', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.setCursor('pointer');
+  await roundtrip(app);
+
+  const before = app.X.seq_num;
+  wnd.setCursor('pointer');
+  wnd.setCursor('hand'); // an alias: the same cursor id
+  assert.equal(app.X.seq_num, before, 'no requests for a cursor that is already current');
+
+  wnd.setCursor(null);
+  assert.equal(app.X.seq_num, before + 1, 'a different cursor still goes out');
+  await roundtrip(app);
+  assert.equal(server.resources.get(wnd.id).cursor, 0);
+  wnd.destroy();
+});
+
+test('a window created with a cursor knows it, and re-setting it is free', async () => {
+  const cid = app.cursors.get('crosshair');
+  await roundtrip(app);
+  const wnd = app.createWindow({ width: 40, height: 30, cursor: cid });
+  await roundtrip(app);
+  assert.equal(server.resources.get(wnd.id).cursor, cid, 'set at creation time');
+
+  const before = app.X.seq_num;
+  wnd.setCursor('crosshair');
+  assert.equal(app.X.seq_num, before, 'the creation attribute seeded the memo');
+  wnd.destroy();
+});
+
+test('an X error from the callback-less request still reaches onXError', async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  const errors = [];
+  const app2 = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: (err) => errors.push(err)
+  });
+  const wnd = app2.createWindow({ width: 40, height: 30 });
+  await roundtrip(app2);
+
+  // the window is gone, so the ChangeWindowAttributes that follows is a
+  // BadWindow — with no callback to route it, node-x11 emits it on the client
+  // and App's listener hands it to onXError
+  wnd.destroy();
+  wnd.setCursor('text');
+  await roundtrip(app2);
+
+  assert.equal(errors.length, 1, 'exactly one error surfaced');
+  assert.equal(errors[0].error, 3, 'BadWindow');
+  await app2.close();
+});


### PR DESCRIPTION
Fixes #309.

## What was happening

node-x11 guarantees that a callback passed to a **void** request eventually fires, and buys that guarantee by injecting a `GetInputFocus` round trip on a `setImmediate` when nothing else in the same tick expects a reply. Four call sites here passed a callback that ignores its argument, so each of them paid that round trip for nothing. `setCursor` is the one that shows: a hover boundary crossing shipped a 16 B `ChangeWindowAttributes`, an injected 4 B request and its 32 B reply. In a react-x11 pointer trace those injected round trips look like the frame fence - they are not, and the issue writes up how to tell them apart.

## What changed

- The callback is gone at the four `ChangeWindowAttributes` sites in `lib/window.js` - the cursor write, the two event-mask writes and the background-pixel write - plus the matching one-shot in `lib/xembed.js`'s detach path. Nothing else moves: an X error still reaches `client.emit` with `'error'` and so `App`'s `onXError` hook, and request ordering is unchanged because ntk buffers requests and node-x11 flushes the batch before the event loop polls.
- `setCursor` now memoizes the cursor id it last sent, seeded from the `createWindow` cursor attribute, so re-setting the current cursor sends nothing. That is the part of #309 that hardens every caller rather than one - react-x11 dedupes in two places today. The name is still resolved on each call, so unknown names throw exactly as before, and aliases resolve first so `'hand'` after `'pointer'` is free too.

## Measured

100 alternating cursor transitions, each set twice as a per-motion caller would, against the hermetic JS X server:

| | requests sent | injected round trips | bytes written |
|---|---|---|---|
| before | 300 | 100 | 3628 |
| after | 100 | 0 | 1628 |

The 32 B reply per injected round trip is server to client and not counted above.

## Tests

Four new cases in `test/cursor.test.js`, all hermetic:

- a `setCursor` injects no `GetInputFocus`, and the cursor still lands on the window server-side
- setting the cursor a window already has sends no request, while a different one still does
- `createWindow` with a cursor attribute seeds the memo
- with no callback on the request, a `BadWindow` from it still arrives at `onXError` - exactly one error, error code 3

`npm test` is green locally against XQuartz: 1029 pass, 0 fail, 3 skipped.
