### PR TITLE
perf(2d): the picture clip is context state, not a stamp per drawing

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -70,6 +70,13 @@ is genuinely needed, the work it costs is bounded to the box the drawing
 composites, not the surface: a translucent fill inside a rounded-corner clip
 pays for its own rectangle.
 
+Where the rectangle does go to the server it is **context state, not a
+per-drawing stamp**: a second drawing under a clip the picture already carries
+sends no clip request at all, and neither does a repaint of the same damage
+rectangle on the next frame. A rounded box under a damage clip — a fill and a
+border, each of them corner glyphs plus strips — costs one clip request rather
+than four.
+
 The exception is the composite ops that paint where the clip is *not*:
 `copy`, `source-in`, `destination-in`, `source-out` and `destination-atop`
 clear the rest of the drawing's box rather than leaving it alone. Under a
@@ -337,6 +344,10 @@ the picture to a rectangle around the drawing and put it back afterwards. Any
 region in that slot is overwritten, silently, and which drawings do it depends
 on which internal route they take (issue
 [#292](https://github.com/sidorares/ntk/issues/292)).
+
+Reading `ctx.picture` does settle the slot first, so a region you install
+right after one is not fighting a rectangle left over from the last drawing —
+but the next drawing takes the slot back.
 
 `clipRegion()` is the same region as a clip ntk knows about: it is part of the
 `save()`/`restore()` state, the fast paths intersect *with* it and restore *to*

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -506,7 +506,7 @@ class RenderingContext2d {
     // buffering); re-bind when the backing pixmap is reallocated on resize
     this._target = null;
     this._gc = null;
-    this.picture = null;
+    this._picture = null;
     this._bindTarget();
     // A window or pixmap adopted by id knows neither its depth nor its
     // visual until the requests its constructor sent reply, and an unknown
@@ -537,9 +537,9 @@ class RenderingContext2d {
       window.on("resize", () => this._dropMasks());
       // window-backed pictures are freed server-side with the window
       window.on("_destroyed", () => {
-        if (this.picture && this._target === this.window) {
-          this.picture.forget();
-          this.picture = null;
+        if (this._picture && this._target === this.window) {
+          this._picture.forget();
+          this._picture = null;
         }
       });
     }
@@ -579,6 +579,11 @@ class RenderingContext2d {
     // drawing that only meant to narrow to a box (issue #292).
     this._fixes = null;
     this._pictureClipped = false;
+    // the rectangle the slot holds, when it is a plain one (no region in it),
+    // so a second drawing under the same clip can skip re-stamping it; and
+    // whether a reset is owed but not yet sent (issue #308)
+    this._pictureClipRect = null;
+    this._clipStale = false;
     this._regionScratch = null; // region entries intersected, when >1
     this._regionBox = null; // that ∩ the rectangular clip
     this._gco = "source-over";
@@ -635,9 +640,9 @@ class RenderingContext2d {
    */
   _refreshFormat() {
     const target = this.window._backing || this.window;
-    if (!this.picture || this._target !== target) return;
+    if (!this._picture || this._target !== target) return;
     const { depth, visual } = this._targetPixels();
-    if (this._formatFor(depth, visual) !== this.picture.format) this._bindTarget(true);
+    if (this._formatFor(depth, visual) !== this._picture.format) this._bindTarget(true);
   }
 
   _bindTarget(force = false) {
@@ -653,7 +658,7 @@ class RenderingContext2d {
       this._gcs.push(this._gc);
       this.X.CreateGC(this._gc, target.id);
     }
-    if (this.picture) this.picture.destroy();
+    if (this._picture) this._picture.destroy();
     // a8 targets are coverage, not colour: drawing into one and using the
     // result as a mask is how a monochrome drawing gets rendered once and
     // recoloured on every use (see Surface).
@@ -662,7 +667,7 @@ class RenderingContext2d {
     // Does the target have a real alpha channel? Only then is "transparent"
     // a colour it can hold, which is what clearRect turns on.
     this._hasAlpha = depth === 32;
-    this.picture = new Picture(this.window.app, {
+    this._picture = new Picture(this.window.app, {
       drawable: target,
       format,
       polyEdge: 1,
@@ -671,7 +676,8 @@ class RenderingContext2d {
     // a new picture carries no clip; a region one is context state and has to
     // be re-installed on it (this runs on every backing-pixmap reallocation)
     this._pictureClipped = false;
-    if (this._hasRegionClip) this._resetPictureClip();
+    this._pictureClipRect = null;
+    this._invalidatePictureClip();
     this._dropMasks();
   }
 
@@ -689,60 +695,135 @@ class RenderingContext2d {
   // one: it overwrote whatever else was in the slot. Now the slot's contents
   // are state the context tracks, so a region clip survives a fill or a glyph
   // run that only meant to narrow to a box.
+  //
+  // Tracking the contents also makes the stamping *lazy* (issue #308). Every
+  // rect-clipped fast path brackets its own drawing — set, draw, reset — so
+  // two drawings under one clip used to emit a reset immediately followed by
+  // an identical set, with nothing in between that reads the slot. Instead
+  // the reset is only recorded as owed, `_dst()` flushes it before any
+  // drawing that does *not* set its own clip, and a set whose rectangle is
+  // already in the slot supersedes it and sends nothing. A rounded box under
+  // a damage clip goes from four stamps to one, and a repaint of the same
+  // rectangle next frame to none.
 
   /** Narrow the picture to `rect`, intersected with any region clip. */
   _setPictureClip(rect) {
     const region = this._effectiveRegion();
     if (region === null) {
-      this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [
+      const held = this._pictureClipRect;
+      // The owed reset (if any) is superseded either way: what follows draws
+      // under exactly this rectangle, which is what the slot is about to hold.
+      this._clipStale = false;
+      if (
+        held &&
+        held.x === rect.x &&
+        held.y === rect.y &&
+        held.w === rect.w &&
+        held.h === rect.h
+      ) {
+        return; // already stamped, and nothing since has read the slot
+      }
+      this.Render.SetPictureClipRectangles(this._picture.id, 0, 0, [
         rect.x,
         rect.y,
         rect.w,
         rect.h,
       ]);
       this._pictureClipped = true;
+      // a copy: the caller owns `rect` and _clipRect() hands out fresh ones,
+      // but nothing here should depend on that
+      this._pictureClipRect = { x: rect.x, y: rect.y, w: rect.w, h: rect.h };
       return;
     }
     // region ∩ rectangle, computed by the server: three requests and no round
-    // trip, against a full-surface a8 mask for the same answer
+    // trip, against a full-surface a8 mask for the same answer.
+    //
+    // Always re-emitted, never skipped: the region is the caller's and they
+    // may have edited it — server-side, invisibly to us — since the last
+    // drawing, for the same reason _effectiveRegion() is recomputed.
     const box = this._scratchRegion("_regionBox");
     this._fixes.SetRegion(box, [
       { x: rect.x, y: rect.y, width: rect.w, height: rect.h },
     ]);
     this._fixes.IntersectRegion(region, box, box);
-    this._fixes.SetPictureClipRegion(this.picture.id, box, 0, 0);
+    this._fixes.SetPictureClipRegion(this._picture.id, box, 0, 0);
     this._pictureClipped = true;
+    this._pictureClipRect = null; // a region is in there, not a plain rect
+    this._clipStale = false;
+  }
+
+  /**
+   * Note that the picture's clip no longer matches what the clip stack says,
+   * without sending anything: the next drawing either sets its own clip
+   * (which supersedes this) or goes through `_dst()`, which flushes it first.
+   *
+   * This is what every rect-clipped fast path calls after its drawing, and
+   * also what installs a region in the first place — `clipRegion()` and a
+   * `restore()` that changes the stack both come through here, so the region
+   * is on the picture for every route, including the ones that composite an
+   * a8 mask and never touch a clip rectangle.
+   */
+  _invalidatePictureClip() {
+    this._clipStale = true;
   }
 
   /**
    * Put the picture's clip back to what the clip stack says it is between
-   * drawings: the region clip if there is one, nothing otherwise.
-   *
-   * Also what installs a region in the first place — `clipRegion()` and a
-   * `restore()` that changes the stack both come through here — so the region
-   * is on the picture for every route, including the ones that composite an
-   * a8 mask and never touch a clip rectangle.
+   * drawings: the region clip if there is one, nothing otherwise. Sends
+   * nothing when the slot already says that.
    */
-  _resetPictureClip() {
+  _flushPictureClip() {
+    if (!this._clipStale) return;
+    this._clipStale = false;
+    if (!this._picture) return; // destroyed, or a window that went away
     const region = this._effectiveRegion();
     if (region !== null) {
-      this._fixes.SetPictureClipRegion(this.picture.id, region, 0, 0);
+      this._fixes.SetPictureClipRegion(this._picture.id, region, 0, 0);
       this._pictureClipped = true;
+      this._pictureClipRect = null;
       return;
     }
     if (!this._pictureClipped) return; // nothing of ours is in the slot
     if (this._fixes) {
       // None is the real "no clip"; a rectangle would only be a wider one
-      this._fixes.SetPictureClipRegion(this.picture.id, 0, 0, 0);
+      this._fixes.SetPictureClipRegion(this._picture.id, 0, 0, 0);
     } else {
       // Without XFIXES the widest rectangle is all there is, and it has to
       // outlive window growth: the backing pixmap has headroom past the
       // window and growing into it does not rebind the picture, so a reset at
       // today's window size would keep clipping tomorrow's pixels.
       // Coordinates are INT16 — one rect at their maximum covers any drawable.
-      this.Render.SetPictureClipRectangles(this.picture.id, 0, 0, [0, 0, 0x7fff, 0x7fff]);
+      this.Render.SetPictureClipRectangles(this._picture.id, 0, 0, [0, 0, 0x7fff, 0x7fff]);
     }
     this._pictureClipped = false;
+    this._pictureClipRect = null;
+  }
+
+  /**
+   * The destination picture id for a drawing request, with any owed clip
+   * reset flushed first.
+   *
+   * Everything that draws into this context's own picture goes through here
+   * — including the composites that bypass the set/reset bracket entirely
+   * (`_fillRect`, the `clearRect` fast path, the a8-mask routes) — because
+   * that is what keeps a lazily-owed reset from leaking a narrower clip into
+   * a drawing that never asked for one.
+   */
+  _dst() {
+    this._flushPictureClip();
+    return this._picture.id;
+  }
+
+  /**
+   * The RENDER Picture this context draws through — a real server-side
+   * picture a caller can composite from, or hang a clip region on
+   * (docs/context-2d.md). Reading it settles the clip slot first, so what an
+   * outside request sees is what the clip stack says, not whatever the last
+   * fast path left behind.
+   */
+  get picture() {
+    this._flushPictureClip();
+    return this._picture;
   }
 
   /**
@@ -826,15 +907,15 @@ class RenderingContext2d {
 
     this._backgroundPicture = this._glyphSource = null;
 
-    if (this.picture) {
+    if (this._picture) {
       // a picture on a *window* is freed by the server with the window;
       // asking again would raise BadPicture. Same rule as `_destroyed`.
       if (this._target === this.window && !(this.window instanceof Pixmap)) {
-        this.picture.forget();
+        this._picture.forget();
       } else {
-        this.picture.destroy();
+        this._picture.destroy();
       }
-      this.picture = null;
+      this._picture = null;
     }
   }
 
@@ -1020,7 +1101,7 @@ class RenderingContext2d {
       this._rebuildClipMask();
       // a region clip going out of scope (or coming back into it) is a change
       // to the picture's clip, and nothing else will notice it
-      if (hadRegion || this._hasRegionClip) this._resetPictureClip();
+      if (hadRegion || this._hasRegionClip) this._invalidatePictureClip();
     }
   }
 
@@ -1942,7 +2023,7 @@ class RenderingContext2d {
       op,
       src.id,
       this.fillMask.id,
-      this.picture.id,
+      this._dst(),
       out.x,
       out.y,
       out.x,
@@ -2361,7 +2442,7 @@ class RenderingContext2d {
           src.id,
           Math.floor(batch[0]),
           Math.floor(batch[1]),
-          this.picture.id,
+          this._dst(),
           this.Render.a8,
           batch,
         );
@@ -2568,8 +2649,8 @@ class RenderingContext2d {
         if (rect.w === 0 || rect.h === 0) return;
         this._setPictureClip(rect);
       }
-      drawGlyphRuns(app, op, src.id, this.picture.id, positioned);
-      if (rect) this._resetPictureClip();
+      drawGlyphRuns(app, op, src.id, this._dst(), positioned);
+      if (rect) this._invalidatePictureClip();
       this._markDirty();
       return;
     }
@@ -2608,7 +2689,7 @@ class RenderingContext2d {
       op,
       src.id,
       this.fillMask.id,
-      this.picture.id,
+      this._dst(),
       0,
       0,
       0,
@@ -2637,8 +2718,8 @@ class RenderingContext2d {
         if (rect.w === 0 || rect.h === 0) return;
         this._setPictureClip(rect);
       }
-      compositeTraps(app, op, src.id, this.picture.id, traps);
-      if (rect) this._resetPictureClip();
+      compositeTraps(app, op, src.id, this._dst(), traps);
+      if (rect) this._invalidatePictureClip();
       this._markDirty();
       return;
     }
@@ -2676,7 +2757,7 @@ class RenderingContext2d {
       op,
       src.id,
       this.fillMask.id,
-      this.picture.id,
+      this._dst(),
       0,
       0,
       0,
@@ -2828,7 +2909,7 @@ class RenderingContext2d {
     if (matIsIdentity(this._m) && !this._hasPolyClip && !this._clipRect()) {
       this.Render.FillRectangles(
         this.Render.PictOp.Src,
-        this.picture.id,
+        this._dst(),
         alpha ? [0, 0, 0, 0] : [1, 1, 1, 1],
         [x, y, w, h],
       );
@@ -2878,7 +2959,7 @@ class RenderingContext2d {
         op,
         this._backgroundPicture.id,
         direct ? direct.mask : this._compositeMask(box),
-        this.picture.id,
+        this._dst(),
         box.x,
         box.y,
         box.x,
@@ -2965,12 +3046,12 @@ class RenderingContext2d {
     for (let i = 0; i < flat.length; i += chunk) {
       R.FillRectangles(
         this._op(),
-        this.picture.id,
+        this._dst(),
         color,
         i === 0 && flat.length <= chunk ? flat : flat.slice(i, i + chunk),
       );
     }
-    if (clip) this._resetPictureClip();
+    if (clip) this._invalidatePictureClip();
     this._markDirty();
   }
 
@@ -3342,7 +3423,7 @@ class RenderingContext2d {
         encoded.bits,
         R.PictOp.Over,
         src.id,
-        this.picture.id,
+        this._dst(),
         0,
         encoded.gsid,
         items[0].x,
@@ -3352,9 +3433,9 @@ class RenderingContext2d {
       trimShapeGlyphs(app);
     }
     if (rects.length) {
-      R.FillRectangles(R.PictOp.Over, this.picture.id, color, rects);
+      R.FillRectangles(R.PictOp.Over, this._dst(), color, rects);
     }
-    if (clip) this._resetPictureClip();
+    if (clip) this._invalidatePictureClip();
     this._markDirty();
   }
 
@@ -3500,7 +3581,7 @@ class RenderingContext2d {
     if (!fixes) throw needXFixesError();
     this._fixes = fixes;
     this._setClips(this._clips.concat([{ region: id }]));
-    this._resetPictureClip();
+    this._invalidatePictureClip();
   }
 
   /**
@@ -4275,7 +4356,7 @@ class RenderingContext2d {
 
   _endDirectComposite(state) {
     if (!state.clipped) return;
-    this._resetPictureClip();
+    this._invalidatePictureClip();
   }
 
   /** The source colour for a coverage composite, with `globalAlpha` folded
@@ -4402,7 +4483,7 @@ class RenderingContext2d {
         op,
         this._backgroundPicture.id,
         this.fillMask.id,
-        this.picture.id,
+        this._dst(),
         dx,
         dy,
         dx,
@@ -4412,7 +4493,7 @@ class RenderingContext2d {
         dw,
         dh,
       );
-      if (rect) this._resetPictureClip();
+      if (rect) this._invalidatePictureClip();
     } else if (!rect || (rect.w > 0 && rect.h > 0)) {
       if (rect) this._setPictureClip(rect);
       // the source is a 1x1 repeating solid (offset irrelevant) or the fill
@@ -4422,7 +4503,7 @@ class RenderingContext2d {
         op,
         this._coverageSource().id,
         picture.id,
-        this.picture.id,
+        this._dst(),
         dx,
         dy,
         mx,
@@ -4432,7 +4513,7 @@ class RenderingContext2d {
         dw,
         dh,
       );
-      if (rect) this._resetPictureClip();
+      if (rect) this._invalidatePictureClip();
     }
 
     if (scaled) {
@@ -4501,7 +4582,7 @@ class RenderingContext2d {
           op,
           picture.id,
           mask,
-          this.picture.id,
+          this._dst(),
           0,
           0,
           dx,
@@ -4522,7 +4603,7 @@ class RenderingContext2d {
           op,
           picture.id,
           mask,
-          this.picture.id,
+          this._dst(),
           sx,
           sy,
           dx,
@@ -4558,7 +4639,7 @@ class RenderingContext2d {
         this.Render.PictOp.Over,
         image.picture.id,
         direct ? direct.mask : this._compositeMask(box),
-        this.picture.id,
+        this._dst(),
         box.x,
         box.y,
         box.x,
@@ -4622,7 +4703,7 @@ class RenderingContext2d {
           this.Render.PictOp.Over,
           picture.id,
           direct ? direct.mask : this._compositeMask(box),
-          this.picture.id,
+          this._dst(),
           box.x,
           box.y,
           box.x,
@@ -4695,7 +4776,7 @@ class RenderingContext2d {
       op,
       picture.id,
       direct ? direct.mask : this._compositeMask(box),
-      this.picture.id,
+      this._dst(),
       box.x,
       box.y,
       box.x,

--- a/test/clip-region.test.js
+++ b/test/clip-region.test.js
@@ -182,6 +182,38 @@ test('the other clip-rectangle fast paths leave the region alone', async (t) => 
   pixmap.destroy();
 });
 
+// Issue #308 made the picture clip lazy: a rectangle already in the slot is
+// not re-stamped. A region is never treated that way, because it is the
+// caller's and they may have edited it — server-side, invisibly to us —
+// between two drawings under the same rectangle.
+test('a region edited between two identically clipped drawings is honored', async (t) => {
+  if (skip) return t.skip(skip);
+  const { pixmap, ctx } = freshCtx();
+  const region = await app.createRegion([{ x: 0, y: 0, width: W, height: 100 }]);
+  ctx.clipRegion(region);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, 0, 100, H); // one rectangular clip for both drawings
+  ctx.clip();
+
+  ctx.fillStyle = 'red';
+  ctx.fillRects([[0, 0, W, H]]); // region: the top half
+
+  region.set([{ x: 0, y: 100, width: W, height: 100 }]);
+  ctx.fillStyle = 'blue';
+  ctx.fillRects([[0, 0, W, H]]); // region: the bottom half now
+  ctx.restore();
+
+  const image = await ctx.getImageData(0, 0, W, H);
+  assert.deepEqual(at(image, 50, 50), RED, 'the first drawing, top half');
+  assert.deepEqual(at(image, 50, 150), BLUE, 'the second saw the edited region');
+  assert.deepEqual(at(image, 150, 50), WHITE, 'the rectangle still applies');
+  assert.deepEqual(at(image, 150, 150), WHITE, 'to both of them');
+  region.destroy();
+  pixmap.destroy();
+});
+
 test('a region and a rectangular clip intersect, in either order', async (t) => {
   if (skip) return t.skip(skip);
   const region = await app.createRegion([{ x: 0, y: 0, width: 100, height: 100 }]);

--- a/test/clip-stamps.test.js
+++ b/test/clip-stamps.test.js
@@ -1,0 +1,238 @@
+// The picture clip is context state, not something stamped per drawing
+// (issue #308).
+//
+// Every rect-clipped fast path brackets its own drawing — set the clip, draw,
+// put it back — so two drawings under one clip used to emit a reset
+// immediately followed by an identical set, with nothing in between that
+// reads the slot. A rounded box is exactly that shape: the fill's corner
+// glyphs and strips, then the border's. Four stamps where one does.
+//
+// What this pins: the stamps that disappear, and the flush points that keep
+// them from mattering — anything drawing into the picture without setting its
+// own clip must not inherit the one the last fast path left there.
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import xserver from "x11/lib/xserver/index.js";
+
+import { createClient, StaticFontSource } from "../lib/index.js";
+
+let app = null;
+const W = 120;
+const H = 120;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+  });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext("2d");
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+const read = (ctx) => ctx.getImageData(0, 0, W, H);
+const at = (img, x, y) => {
+  const i = (y * W + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2]];
+};
+const RED = [255, 0, 0];
+const BLUE = [0, 0, 255];
+const WHITE = [255, 255, 255];
+
+/** The clip rectangles stamped on `ctx`'s own picture while `fn` runs. */
+function stamps(ctx, fn) {
+  const R = ctx.Render;
+  const original = R.SetPictureClipRectangles;
+  // the internal field: reading `ctx.picture` would settle the slot, which
+  // is one of the things under test here
+  const id = ctx._picture.id;
+  const seen = [];
+  R.SetPictureClipRectangles = function (pid, ...rest) {
+    if (pid === id) seen.push(rest[2]);
+    return original.call(this, pid, ...rest);
+  };
+  try {
+    fn();
+  } finally {
+    R.SetPictureClipRectangles = original;
+  }
+  return seen;
+}
+
+/** Clip to a box the way a renderer clips to a damage rectangle. */
+function clipTo(ctx, x, y, w, h) {
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x, y, w, h);
+  ctx.clip();
+}
+
+test("two drawings under one clip stamp it once", () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 10, 10, 60, 60);
+  ctx.fillStyle = "red";
+  const seen = stamps(ctx, () => {
+    ctx.fillRects([[0, 0, 100, 20]]);
+    ctx.fillRects([[0, 40, 100, 20]]);
+  });
+  ctx.restore();
+
+  assert.deepEqual(
+    seen,
+    [[10, 10, 60, 60]],
+    "one stamp: the second drawing found the slot already holding it",
+  );
+});
+
+test("a rounded box costs one stamp, not four", () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 8, 8, 100, 100);
+  const seen = stamps(ctx, () => {
+    // the fill's corner glyphs + strips, then the border's — the two
+    // drawings the issue was traced on
+    ctx.fillStyle = "red";
+    ctx.beginPath();
+    ctx.roundRect(20, 20, 60, 40, 8);
+    ctx.fill();
+    ctx.strokeStyle = "blue";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.roundRect(20, 20, 60, 40, 8);
+    ctx.stroke();
+  });
+  ctx.restore();
+
+  assert.equal(ctx.shapeStats.hits, 2, "both took the rounded-box fast path");
+  assert.deepEqual(seen, [[8, 8, 100, 100]], "one stamp for the pair");
+});
+
+test("repainting the same rectangle next frame stamps nothing", () => {
+  const ctx = freshCtx();
+  const frame = () => {
+    clipTo(ctx, 10, 10, 60, 60);
+    ctx.fillStyle = "red";
+    ctx.fillRects([[0, 0, 100, 100]]);
+    ctx.restore();
+  };
+  frame();
+  const seen = stamps(ctx, frame);
+  assert.deepEqual(seen, [], "the slot already holds the damage rectangle");
+});
+
+test("a different rectangle is stamped, and only once", () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 10, 10, 60, 60);
+  ctx.fillStyle = "red";
+  ctx.fillRects([[0, 0, 100, 100]]);
+  ctx.restore();
+
+  clipTo(ctx, 20, 20, 30, 30);
+  const seen = stamps(ctx, () => {
+    ctx.fillRects([[0, 0, 100, 100]]);
+  });
+  ctx.restore();
+  assert.deepEqual(seen, [[20, 20, 30, 30]], "narrowed, in one request");
+});
+
+// ------------------------------------------------------------------
+// the flush points: a clip that outlives its drawing must not reach the
+// next one
+
+test("an unclipped fillRect after a clipped one is not clipped", async () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 0, 0, 20, 20);
+  ctx.fillStyle = "red";
+  ctx.fillRects([[0, 0, W, H]]);
+  ctx.restore();
+
+  // no clip stack now, and this route composites straight to the picture
+  // without stamping anything of its own
+  ctx.fillStyle = "blue";
+  ctx.fillRect(40, 40, 40, 40);
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 10, 10), RED, "the clipped fill stayed inside");
+  assert.deepEqual(at(img, 60, 60), BLUE, "the unclipped one was not narrowed");
+  assert.deepEqual(at(img, 100, 10), WHITE, "and painted only its own box");
+});
+
+test("an unclipped fillRects batch after a clipped one is not clipped", async () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 0, 0, 20, 20);
+  ctx.fillStyle = "red";
+  ctx.fillRects([[0, 0, W, H]]);
+  ctx.restore();
+
+  ctx.fillStyle = "blue";
+  ctx.fillRects([[40, 40, 40, 40]]);
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 60, 60), BLUE, "the no-clip branch flushed first");
+});
+
+test("an unclipped clearRect after a clipped drawing clears everything", async () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 0, 0, 20, 20);
+  ctx.fillStyle = "red";
+  ctx.fillRects([[0, 0, W, H]]);
+  ctx.restore();
+
+  // the clearRect fast path is another composite that sets no clip of its own
+  ctx.clearRect(0, 0, W, H);
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 10, 10), WHITE, "cleared inside the old clip");
+  assert.deepEqual(at(img, 60, 60), WHITE, "and outside it");
+});
+
+test("a masked fill after a clipped drawing is not clipped", async () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 0, 0, 20, 20);
+  ctx.fillStyle = "red";
+  ctx.fillRects([[0, 0, W, H]]);
+  ctx.restore();
+
+  // a transform forces the coverage-mask route, which composites onto the
+  // picture without a clip rectangle anywhere
+  ctx.save();
+  ctx.translate(40, 40);
+  ctx.fillStyle = "blue";
+  ctx.fillRect(0, 0, 40, 40);
+  ctx.restore();
+
+  const img = await read(ctx);
+  assert.deepEqual(at(img, 60, 60), BLUE, "the mask route flushed first");
+});
+
+test("reading ctx.picture settles the slot", () => {
+  const ctx = freshCtx();
+  clipTo(ctx, 10, 10, 20, 20);
+  ctx.fillStyle = "red";
+  ctx.fillRects([[0, 0, W, H]]);
+  ctx.restore();
+
+  // an outside caller compositing onto (or from) the picture must not
+  // inherit a rectangle from whatever ntk drew last
+  const seen = stamps(ctx, () => {
+    void ctx.picture;
+  });
+  assert.deepEqual(
+    seen,
+    [[0, 0, 0x7fff, 0x7fff]],
+    "the owed reset went out on the read",
+  );
+});

--- a/test/fill-rects.test.js
+++ b/test/fill-rects.test.js
@@ -106,8 +106,10 @@ test('a rectangular clip is honored, still without a mask', async () => {
   const at = await pixels(ctx);
   assert.deepEqual(at(12, 11), RED, 'inside the clip');
   assert.deepEqual(at(20, 11), WHITE, 'outside the clip is untouched');
-  // SetPictureClipRectangles + FillRectangles + the clip reset
-  assert.equal(emitted, 3, 'server-side clip, no a8 mask');
+  // SetPictureClipRectangles + FillRectangles. The reset is owed, not sent:
+  // it is only stamped when something that does not set its own clip draws
+  // next, and a second batch under the same clip skips the set too (#308).
+  assert.equal(emitted, 2, 'server-side clip, no a8 mask');
 });
 
 test('globalAlpha folds into the colour', async () => {

--- a/test/surface.test.js
+++ b/test/surface.test.js
@@ -219,7 +219,9 @@ describe('clipping a surface composite', () => {
     });
     ctx.restore();
 
-    assert.equal(counts.SetPictureClipRectangles, 2, 'set and reset around the composite');
+    // the reset is owed rather than stamped, and nothing has read the slot
+    // since (#308)
+    assert.equal(counts.SetPictureClipRectangles, 1, 'one stamp for the composite');
     assert.equal(counts.Composite, 1, 'one composite, with no mask to intersect first');
 
     const px = await readPixels(ctx);


### PR DESCRIPTION
Closes #308.

## The problem

Every rect-clipped fast path brackets its own drawing: `_setPictureClip(rect)`
before, `_resetPictureClip()` after — `drawGlyphs`, `_emitShapeGlyphs`,
`drawTraps`, `fillRects`, `_beginDirectComposite`, `_drawCoverage`.
`_setPictureClip` always emitted, and `_resetPictureClip` eagerly stamped the
full plane back, so two drawings under one damage clip emitted a reset
immediately followed by an identical set with nothing in between that read the
slot. A rounded box is exactly that: the fill's corner glyphs and strips, then
the border's.

## The fix

The slot's contents become context state, following the sketch in the issue:

1. `_setPictureClip` records the rectangle it stamped, and **skips** a set
   whose rectangle is already in the slot.
2. `_resetPictureClip` becomes `_invalidatePictureClip` — it records "reset
   owed" and sends nothing. `_flushPictureClip` does the work, and a later
   `_setPictureClip` supersedes it.

The care is entirely in the flush point, so every drawing that targets the
context's own picture now goes through one accessor, `_dst()` — including the
composites that bypass the bracket (`_paintThroughMask`, `_fillRect`, the
`clearRect` fast path, `fillRects`' no-clip branch, the mask-path composites).
`ctx.picture` became a getter over `_picture` that settles the slot too, so the
documented "hang your own region on it" escape hatch does not inherit a
rectangle ntk left behind either.

**A region clip is never skipped, only a rectangle.** The region belongs to the
caller and they may have edited it server-side between two drawings under the
same rectangle — the same reason `_effectiveRegion()` is recomputed rather than
cached. Pinned by a new test in `clip-region.test.js`.

## Measured

A react-x11-style checkbox-well repaint — damage clip, rounded fill, rounded
border — on the hermetic JS X server, steady state (the clip rectangle is
already in the slot from the previous frame):

| | RENDER requests | |
|---|---|---|
| before | 8 | `SetPictureClipRectangles` x4, `CompositeGlyphs` x2, `FillRectangles` x2 |
| after | 4 | `CompositeGlyphs` x2, `FillRectangles` x2 |

`getImageData` over the result hashes identically before and after
(`75e33322c312cd23…`) — pixels are unchanged by construction, since every
drawing still executes under exactly the effective clip it did before and only
slot states nothing samples disappear.

## Tests

New `test/clip-stamps.test.js` (hermetic) pins both halves:

- two drawings under one clip stamp it once; a rounded box costs one stamp, not
  four; a repaint of the same rectangle next frame stamps nothing; a different
  rectangle is stamped once
- the flush points: an unclipped `fillRect` / `fillRects` / `clearRect` / masked
  fill after a clipped drawing is not narrowed, and reading `ctx.picture` sends
  the owed reset

Two existing request-count assertions move to the new numbers
(`fill-rects.test.js` 3 -> 2, `surface.test.js` 2 -> 1) — they were counting
exactly the stamps this removes. Full suite: 1038 tests, 0 failures, against
XQuartz; `website` demos green and pixel-verified.
