### PR TITLE
perf(2d): bound the composite-mask fallback to the drawing's own box

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -65,7 +65,10 @@ a box, as `fillRect` and `drawImage` are — the same rectangle intersected
 into that box, which costs no requests and no pixels at all. That is what
 makes a renderer's `save()`/`clip(damage)`/…/`restore()` frame cheap.
 Non-rectangular clips build an a8 mask, and an XFIXES region is a third kind
-the server applies itself — see [Region clips](#region-clips).
+the server applies itself — see [Region clips](#region-clips). Where a mask
+is genuinely needed, the work it costs is bounded to the box the drawing
+composites, not the surface: a translucent fill inside a rounded-corner clip
+pays for its own rectangle.
 
 The exception is the composite ops that paint where the clip is *not*:
 `copy`, `source-in`, `destination-in`, `source-out` and `destination-atop`

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -2744,6 +2744,28 @@ class RenderingContext2d {
     return this.createSolidPicture(0, 0, 0, this.globalAlpha).id;
   }
 
+  /**
+   * The composite's own box, as somewhere to put pixels: `box` grown to
+   * whole pixels and clamped to the surface, or the whole surface when the
+   * caller has no box to give.
+   *
+   * Growing outward rather than rounding is the safe direction — the mask
+   * has to cover every pixel the composite samples, and a pixel of slack
+   * outside it is never read.
+   */
+  _maskBox(box) {
+    // no box, or one the caller never normalized: the whole surface, which
+    // is what this always used to be
+    if (!box || !(box.w > 0) || !(box.h > 0))
+      return { x: 0, y: 0, w: this.width, h: this.height };
+    const x = Math.max(0, Math.floor(box.x));
+    const y = Math.max(0, Math.floor(box.y));
+    const right = Math.min(this.width, Math.ceil(box.x + box.w));
+    const bottom = Math.min(this.height, Math.ceil(box.y + box.h));
+    if (right <= x || bottom <= y) return { x: 0, y: 0, w: 0, h: 0 };
+    return { x, y, w: right - x, h: bottom - y };
+  }
+
   // combined clip ∩ globalAlpha mask for direct composites (rect/image
   // fast paths); returns a picture id or 0. Reuses the fill scratch mask.
   //
@@ -2751,16 +2773,27 @@ class RenderingContext2d {
   // rect-only clip stack without materializing anything, and every caller
   // here asks it first. A **region** clip needs nothing either — the picture
   // carries it, and the mask must not try to hold it.
-  _compositeMask() {
+  //
+  // `box` is the destination box of the composite the mask is for, in device
+  // coordinates. The composite samples the mask over that box and nowhere
+  // else, so both writes here take it instead of the whole surface (issue
+  // #313): a translucent fill inside a rounded-corner clip used to stamp the
+  // alpha across the full surface and intersect the clip across it again,
+  // per fill, for pixels nothing reads. Stale content outside the box is
+  // fine — every caller re-stamps the scratch unconditionally, so there is
+  // no reuse to preserve.
+  _compositeMask(box) {
     const clipMask =
       this._hasPolyClip || this._clipRect() ? this._requireClipMask() : null;
     if (this.globalAlpha >= 1) return clipMask ? clipMask.id : 0;
     this._ensureFillMask();
+    const b = this._maskBox(box);
+    if (b.w === 0 || b.h === 0) return this.fillMask.id; // nothing is sampled
     this.Render.FillRectangles(
       this.Render.PictOp.Src,
       this.fillMask.id,
       [0, 0, 0, this.globalAlpha],
-      [0, 0, this.width, this.height],
+      [b.x, b.y, b.w, b.h],
     );
     if (clipMask) {
       this.Render.Composite(
@@ -2768,14 +2801,14 @@ class RenderingContext2d {
         clipMask.id,
         0,
         this.fillMask.id,
+        b.x,
+        b.y,
         0,
         0,
-        0,
-        0,
-        0,
-        0,
-        this.width,
-        this.height,
+        b.x,
+        b.y,
+        b.w,
+        b.h,
       );
     }
     return this.fillMask.id;
@@ -2844,7 +2877,7 @@ class RenderingContext2d {
       this.Render.Composite(
         op,
         this._backgroundPicture.id,
-        direct ? direct.mask : this._compositeMask(),
+        direct ? direct.mask : this._compositeMask(box),
         this.picture.id,
         box.x,
         box.y,
@@ -4222,13 +4255,15 @@ class RenderingContext2d {
    * Uniform alpha needs no surface-sized mask either: a 1x1 repeating
    * picture is the same thing to the server, with no pixel work at all.
    */
-  _beginDirectComposite() {
+  _beginDirectComposite(box) {
     const rect = this._clipRect();
     if (!rect) {
       // a poly clip is the only thing left that needs a mask; without one
-      // there is nothing to apply here but the alpha
+      // there is nothing to apply here but the alpha. The mask it does need
+      // is bounded to `box`, the destination box of the composite it is for
+      // — the only pixels of it the server samples (issue #313).
       const mask = this._hasPolyClip
-        ? this._compositeMask()
+        ? this._compositeMask(box)
         : this._alphaMask();
       return { mask, clipped: false, empty: false };
     }
@@ -4443,7 +4478,7 @@ class RenderingContext2d {
         return;
       }
 
-      const state = this._beginDirectComposite();
+      const state = this._beginDirectComposite({ x: dx, y: dy, w: dw, h: dh });
       if (state.empty) return;
       const mask = state.mask;
       const scaled = dw !== sw || dh !== sh;
@@ -4522,7 +4557,7 @@ class RenderingContext2d {
       this.Render.Composite(
         this.Render.PictOp.Over,
         image.picture.id,
-        direct ? direct.mask : this._compositeMask(),
+        direct ? direct.mask : this._compositeMask(box),
         this.picture.id,
         box.x,
         box.y,
@@ -4586,7 +4621,7 @@ class RenderingContext2d {
         this.Render.Composite(
           this.Render.PictOp.Over,
           picture.id,
-          direct ? direct.mask : this._compositeMask(),
+          direct ? direct.mask : this._compositeMask(box),
           this.picture.id,
           box.x,
           box.y,
@@ -4659,7 +4694,7 @@ class RenderingContext2d {
     this.Render.Composite(
       op,
       picture.id,
-      direct ? direct.mask : this._compositeMask(),
+      direct ? direct.mask : this._compositeMask(box),
       this.picture.id,
       box.x,
       box.y,

--- a/test/composite-mask-box.test.js
+++ b/test/composite-mask-box.test.js
@@ -1,0 +1,305 @@
+// The `_compositeMask` fallback writes only the composite's own box (issue
+// #313). With a non-rectangular clip in the stack there is a real a8 mask to
+// build, but the drawing that follows composites one box and samples the
+// mask nowhere else — so stamping `globalAlpha` across the whole surface and
+// intersecting the clip mask across it again is pixel work nothing reads. A
+// translucent fill inside a rounded-corner clip used to pay two full
+// surfaces per fill on top of the poly-clip mask it legitimately needs.
+//
+// What is asserted here: the two writes take the box, and the pixels are the
+// ones the full-surface route drew — checked against that route itself,
+// reinstated by making `_maskBox` answer with the whole surface again.
+//
+// Hermetic: node-x11's in-process pure-JS X server, no $DISPLAY needed.
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import xserver from "x11/lib/xserver/index.js";
+
+import { createClient, StaticFontSource, Surface } from "../lib/index.js";
+
+let app = null;
+const W = 120;
+const H = 120;
+
+before(async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+  });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+function freshCtx() {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext("2d");
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+/** The route this replaces: both writes at full surface size. */
+function fullSurfaceCtx() {
+  const ctx = freshCtx();
+  ctx._maskBox = () => ({ x: 0, y: 0, w: W, h: H });
+  return ctx;
+}
+
+const read = (ctx) => ctx.getImageData(0, 0, W, H);
+
+/** Byte-for-byte comparison of two getImageData results. */
+function assertSamePixels(a, b, what) {
+  let worst = 0;
+  let where = -1;
+  for (let i = 0; i < a.data.length; i++) {
+    const d = Math.abs(a.data[i] - b.data[i]);
+    if (d > worst) {
+      worst = d;
+      where = i;
+    }
+  }
+  assert.equal(
+    worst,
+    0,
+    `${what}: differs by ${worst} at byte ${where} (pixel ${Math.floor(
+      (where / 4) % W,
+    )},${Math.floor(where / 4 / W)})`,
+  );
+}
+
+/**
+ * Every write the drawing aims at the scratch fill mask, as boxes: the alpha
+ * stamp (a FillRectangles) and the clip intersection (a Composite whose
+ * destination it is).
+ */
+function maskWrites(ctx, fn) {
+  const R = ctx.Render;
+  const fills = R.FillRectangles;
+  const composites = R.Composite;
+  const calls = [];
+  // the scratch is created lazily, and the temp pictures the clip mask
+  // rasterizes through are freed before it exists — so "is this the scratch"
+  // has to be asked at call time, before a recycled id can answer for it
+  const isScratch = (dst) => ctx.fillMask != null && dst === ctx.fillMask.id;
+  R.FillRectangles = function (op, dst, color, rects) {
+    if (isScratch(dst)) calls.push({ kind: "fill", box: rectOf(rects) });
+    return fills.apply(this, arguments);
+  };
+  R.Composite = function (op, src, mask, dst, sx, sy, mx, my, dx, dy, w, h) {
+    if (isScratch(dst))
+      calls.push({ kind: "composite", box: { x: dx, y: dy, w, h } });
+    return composites.apply(this, arguments);
+  };
+  try {
+    fn();
+  } finally {
+    R.FillRectangles = fills;
+    R.Composite = composites;
+  }
+  return calls;
+}
+
+function rectOf(rects) {
+  assert.equal(rects.length, 4, "one rectangle per stamp");
+  const [x, y, w, h] = rects;
+  return { x, y, w, h };
+}
+
+test("a translucent fill under a poly clip stamps only its own box", async () => {
+  const draw = (ctx) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(20, 20, 80, 80, 20);
+    ctx.clip();
+    ctx.globalAlpha = 0.5;
+    ctx.fillStyle = "red";
+    ctx.fillRect(30, 40, 25, 20);
+    ctx.restore();
+  };
+
+  const ctx = freshCtx();
+  const writes = maskWrites(ctx, () => draw(ctx));
+  assert.deepEqual(
+    writes,
+    [
+      { kind: "fill", box: { x: 30, y: 40, w: 25, h: 20 } },
+      { kind: "composite", box: { x: 30, y: 40, w: 25, h: 20 } },
+    ],
+    "alpha stamp and clip intersection both take the fill box",
+  );
+
+  const ref = fullSurfaceCtx();
+  draw(ref);
+  assertSamePixels(
+    await read(ctx),
+    await read(ref),
+    "translucent clipped fill",
+  );
+});
+
+test("the box is the fill's, not the clip's, and the clip still bites", async () => {
+  // a fill overlapping the rounded corner: the corner has to come out of the
+  // mask, which is the half of the work that is not the alpha stamp
+  const draw = (ctx) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(20, 20, 80, 80, 20);
+    ctx.clip();
+    ctx.globalAlpha = 0.5;
+    ctx.fillStyle = "blue";
+    ctx.fillRect(0, 0, 60, 60);
+    ctx.restore();
+  };
+
+  const ctx = freshCtx();
+  const writes = maskWrites(ctx, () => draw(ctx));
+  assert.deepEqual(
+    writes.map((w) => w.box),
+    [
+      { x: 0, y: 0, w: 60, h: 60 },
+      { x: 0, y: 0, w: 60, h: 60 },
+    ],
+    "the fill box, clamped to the surface",
+  );
+
+  const ref = fullSurfaceCtx();
+  draw(ref);
+  assertSamePixels(await read(ctx), await read(ref), "fill over the corner");
+});
+
+test("a fractional fill box grows to whole pixels rather than rounding", async () => {
+  const draw = (ctx) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(20, 20, 80, 80, 20);
+    ctx.clip();
+    ctx.globalAlpha = 0.4;
+    ctx.fillStyle = "red";
+    ctx.fillRect(30.5, 40.25, 20.5, 10.5);
+    ctx.restore();
+  };
+
+  const ctx = freshCtx();
+  const writes = maskWrites(ctx, () => draw(ctx));
+  assert.deepEqual(
+    writes.map((w) => w.box),
+    [
+      { x: 30, y: 40, w: 21, h: 11 },
+      { x: 30, y: 40, w: 21, h: 11 },
+    ],
+    "outward: the mask covers every pixel the composite samples",
+  );
+
+  const ref = fullSurfaceCtx();
+  draw(ref);
+  assertSamePixels(await read(ctx), await read(ref), "fractional fill");
+});
+
+test("an unbounded op under a rect clip bounds the mask to its box too", async () => {
+  // `copy` keeps the mask (issue #307's guard: it writes where the mask is
+  // zero), so a rect clip lands here rather than on the boxed route — and
+  // the box it clears is still just the fill's
+  const draw = (ctx) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(20, 20, 60, 60);
+    ctx.clip();
+    ctx.globalAlpha = 0.5;
+    ctx.globalCompositeOperation = "copy";
+    ctx.fillStyle = "red";
+    ctx.fillRect(10, 10, 50, 50);
+    ctx.restore();
+  };
+
+  const ctx = freshCtx();
+  const writes = maskWrites(ctx, () => draw(ctx));
+  assert.deepEqual(
+    writes.map((w) => w.box),
+    [
+      { x: 10, y: 10, w: 50, h: 50 },
+      { x: 10, y: 10, w: 50, h: 50 },
+    ],
+    "the composite box, not the surface",
+  );
+
+  const ref = fullSurfaceCtx();
+  draw(ref);
+  assertSamePixels(await read(ctx), await read(ref), "copy under a rect clip");
+});
+
+test("drawImage under a poly clip masks only the destination box", async () => {
+  const surface = new Surface(app, { width: 40, height: 40 });
+  const paint = surface.getContext("2d");
+  paint.fillStyle = "#4c6ef5";
+  paint.fillRect(0, 0, 40, 40);
+  paint.fillStyle = "#f76707";
+  paint.fillRect(0, 0, 20, 20);
+
+  const draw = (ctx) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(20, 20, 80, 80, 20);
+    ctx.clip();
+    ctx.globalAlpha = 0.6;
+    ctx.drawImage(surface, 25, 35);
+    ctx.restore();
+  };
+
+  const ctx = freshCtx();
+  const writes = maskWrites(ctx, () => draw(ctx));
+  assert.deepEqual(
+    writes.map((w) => w.box),
+    [
+      { x: 25, y: 35, w: 40, h: 40 },
+      { x: 25, y: 35, w: 40, h: 40 },
+    ],
+    "the image's destination box",
+  );
+
+  const ref = fullSurfaceCtx();
+  draw(ref);
+  assertSamePixels(await read(ctx), await read(ref), "clipped drawImage");
+  surface.destroy();
+});
+
+test("a transformed drawImage under a poly clip masks its bounding box", async () => {
+  const surface = new Surface(app, { width: 40, height: 40 });
+  const paint = surface.getContext("2d");
+  paint.fillStyle = "#4c6ef5";
+  paint.fillRect(0, 0, 40, 40);
+  paint.fillStyle = "#f76707";
+  paint.fillRect(0, 0, 20, 20);
+
+  const draw = (ctx) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(20, 20, 80, 80, 20);
+    ctx.clip();
+    ctx.globalAlpha = 0.5;
+    ctx.translate(60, 60);
+    ctx.rotate(Math.PI / 5);
+    ctx.drawImage(surface, -20, -20);
+    ctx.restore();
+  };
+
+  const ctx = freshCtx();
+  const writes = maskWrites(ctx, () => draw(ctx));
+  assert.equal(writes.length, 2, "one alpha stamp, one clip intersection");
+  for (const { box } of writes) {
+    assert.ok(
+      box.w < W && box.h < H,
+      `smaller than the surface: ${box.w}x${box.h}`,
+    );
+  }
+
+  const ref = fullSurfaceCtx();
+  draw(ref);
+  assertSamePixels(await read(ctx), await read(ref), "transformed drawImage");
+  surface.destroy();
+});


### PR DESCRIPTION
Closes #313.

## The fallback

#312 took `globalAlpha` off the mask path for every **direct** composite, so
a rect-only clip stack no longer materializes anything. What was left is the
leg it declines: with a **non-rectangular** clip there is a real a8 mask to
build, and `_compositeMask` built it at full surface size, per drawing —

- `globalAlpha < 1` stamped the alpha across the whole scratch fillMask:
  `FillRectangles Src [0,0,0,α] [0, 0, width, height]`;
- the clip-mask intersection was a full-surface `Composite In`.

The drawing that follows composites only its own box and samples the mask
nowhere else, so every pixel of both writes outside that box was work nothing
reads. A translucent fill inside a rounded-corner clip — a scrim fading in
over a card — paid two full surfaces of server pixel work per fill per frame,
on top of the poly-clip mask it legitimately needs.

## What changed

Both writes take the composite rectangle. Callers pass the box they are about
to composite: `_fillRect` its own rectangle, the `drawImage` legs their
destination box, `_drawImageTransformed` the transformed bounding box, and
`_beginDirectComposite` forwards the one its caller already computed.

`_maskBox` grows the box outward to whole pixels and clamps it to the
surface, so the mask covers every pixel the composite can sample; growing
outward rather than rounding is the safe direction, and pixels outside the
box are never sampled. That makes this identical by construction — no
quantization question, unlike the a8-vs-solid switch #312 settled for the
direct legs. A box the caller never normalized still gets the whole surface,
so nothing changes for a degenerate rectangle.

Stale scratch content outside the box is fine: every `_compositeMask` call
re-stamps unconditionally, so there was no reuse to preserve.

## Numbers

300 translucent 200x60 fills inside a rounded clip on a 900x600 surface,
against XQuartz:

| | mask pixels stamped | wall clock |
| --- | --- | --- |
| full-surface | 162 Mpx | 14 ms |
| boxed | 3.6 Mpx | 6 ms |

## Tests

New `test/composite-mask-box.test.js`, hermetic against node-x11's in-process
X server. It records every write aimed at the scratch mask and asserts the
box each one takes — the fill's rectangle, an image's destination box, a
transformed bounding box, a fractional rectangle grown to whole pixels, and
an unbounded op under a rect clip, which lands here rather than on the boxed
route. Each case also checks the pixels byte for byte against the
full-surface route itself, reinstated by making `_maskBox` answer with the
whole surface again.

`docs/context-2d.md` gains a sentence on what a mask now costs.

Full suite green locally, apart from `test/xi2-live.test.js`, which fails on
this machine over pointer warping under XQuartz and touches none of this.
