### PR TITLE
feat(window): let an adopted window opt into a backing store and Present

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -149,7 +149,10 @@ const shape = await app.shape();
   own or its children's rendering into an offscreen pixmap and name that
   pixmap (`RedirectWindow`, `RedirectSubwindows`, `NameWindowPixmap`), plus
   the overlay window a compositing manager paints its output into
-  (`GetOverlayWindow` / `ReleaseOverlayWindow`)
+  (`GetOverlayWindow` / `ReleaseOverlayWindow`). The overlay comes back as a
+  bare id; `createWindow({ id, backingStore: true, present: true })` wraps it
+  as a window ntk paints itself, double buffer and all — see
+  [Painting an adopted window](window.md#painting-an-adopted-window)
 - `app.damage() → Promise<ext|null>` — **DAMAGE**: "this drawable changed"
   as an event (`Create`, `Subtract`), so a repaint costs the region a client
   drew into rather than the whole screen

--- a/docs/window.md
+++ b/docs/window.md
@@ -29,7 +29,9 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
   window's geometry, and only inside `hints`/`sizeHints` do they mean the
   `WM_NORMAL_HINTS` fields of the same name
 - `pid: false` — do not declare the process and host (below)
-- `backingStore: false` — opt out of double buffering (below)
+- `backingStore: false` — opt out of double buffering (below); `backingStore:
+  true` opts an *adopted* window back **in** (see
+  [Painting an adopted window](#painting-an-adopted-window))
 - X window attributes, forwarded into the `CreateWindow` value list under
   their node-x11 names: `backgroundPixmap`, `backgroundPixel`,
   `borderPixmap`, `borderPixel`, `bitGravity`, `winGravity`,
@@ -61,7 +63,10 @@ Creation options beyond geometry/`title`/`parent`/`onXxx` handlers:
   fence, and no waiting for the display either
 - `present: false` — blit with `CopyArea` instead of the Present extension,
   and keep the frame clock off the display
-  (see [Blitting with Present](#blitting-with-present))
+  (see [Blitting with Present](#blitting-with-present)). `present: true` sets
+  Present up before the first paint, and on an *adopted* window it is also an
+  ownership claim (see
+  [Painting an adopted window](#painting-an-adopted-window))
 - `frameClock: 'fence'` — keep the round-trip clock on a window that presents
   (see [What ends a frame](#what-ends-a-frame))
 - `frameInterval: ms` — minimum time between paced frames, and the minimum
@@ -137,6 +142,57 @@ visual, so `wnd.visualId` is right from the start.
 - `wnd.getAttributes()` also writes the visual back to `visualId`, so a
   window manager that asks for `mapState` has paid for it already.
 
+### Painting an adopted window
+
+By default ntk touches an adopted window's pixels as little as it can: no
+[backing store](#double-buffering-backing-store), no
+[Present](#blitting-with-present), and `setBackgroundPixel` changes only what
+a backing store would clear to, not the window attribute. That is the safe
+reading of `{ id }` — the window belongs to another client, which is painting
+it.
+
+It is not always true. **Adopting a window is not the same as another client
+owning its pixels**, and two cases are ours completely:
+
+- the **Composite overlay window**, which `GetOverlayWindow` hands back as a
+  bare id (see [Extensions](app.md#extensions)). The compositor draws the
+  whole screen into it and is the only client that ever will — it is exactly
+  the window that most wants an unflickering double buffer and a
+  vblank-paced blit
+- a window handed over by an **embedding host** — XEmbed's plug side
+  ([xembed.md](xembed.md)), or an `--wid` style handoff — where the client is
+  the sole painter
+
+Say so, and such a window behaves like any other window ntk owns:
+
+```js
+const composite = await app.composite();
+const root = app.display.screen[0].root;
+const overlayId = await new Promise((resolve, reject) => {
+  composite.GetOverlayWindow(root, (err, wid) => (err ? reject(err) : resolve(wid)));
+});
+
+const overlay = app.createWindow({ id: overlayId, backingStore: true, present: true });
+await overlay.ready;                     // its geometry, depth and visual
+const ctx = overlay.getContext('2d');    // draws into the backing pixmap
+```
+
+- `backingStore: true` and `present: true` are each an ownership claim on
+  their own, and either one enables both halves — presenting needs a pixmap
+  to present from. `present: false` still opts out of Present alone, and
+  `backingStore: false` still opts out of everything.
+- **The buffer waits for `ready`.** A backing pixmap needs a width, a height,
+  a depth and a visual, and an adopted window knows none of them until its
+  constructor's replies land — so the allocation is scheduled at
+  construction and happens when they do. A 2d context taken in the meantime
+  draws straight to the window and re-binds itself to the pixmap when it
+  appears, the same way it does across a resize; `await wnd.ready` before the
+  first drawing is what keeps a frame out of the gap. A window destroyed
+  before the replies arrive gets no pixmap at all.
+- `setBackgroundPixel` now writes the window attribute too, so the colour the
+  server paints into exposed area and the colour the backing store clears to
+  agree — see [Double buffering](#double-buffering-backing-store).
+
 ## Transparent windows
 
 `app.findArgbVisual([screen])` looks for a 32-bit TrueColor visual and
@@ -206,8 +262,10 @@ automatically (opt out with `createWindow({ backingStore: false })`):
 - Windows are created with NorthWest `bit-gravity`, so the server keeps old
   content anchored during a resize instead of clearing to background.
 
-Foreign windows (`{ id }`) and windows drawing via the `'opengl'` or
-`'x11'` contexts are not double-buffered.
+Windows drawing via the `'opengl'` or `'x11'` contexts are not
+double-buffered, and neither is a window adopted by id — until it says the
+pixels are its own, with `createWindow({ id, backingStore: true })`. See
+[Painting an adopted window](#painting-an-adopted-window).
 
 ### Blitting with Present
 
@@ -231,6 +289,9 @@ await wnd.enablePresent();
 
 // to stay on CopyArea:
 const plain = app.createWindow({ width: 800, height: 600, present: false });
+
+// an adopted window presents once it says the pixels are its own:
+const overlay = app.createWindow({ id: overlayId, present: true });
 ```
 
 Two things follow. A frame is a fixed two requests however fragmented the

--- a/lib/window.js
+++ b/lib/window.js
@@ -437,8 +437,22 @@ export default class Window extends Drawable {
     // double buffering (see docs/window.md): windows we created get a
     // backing pixmap when a 2d context is requested, unless opted out
     this._foreign = !!args.id;
+    // Adopting a window is not the same as "another client paints these
+    // pixels", though it is the safe default reading of one. The Composite
+    // overlay window and a window handed over by an embedding host (XEmbed's
+    // plug side, an `--wid` handoff) are ours completely — they are foreign
+    // only in the sense that `createWindow` did not make them, and they are
+    // exactly the windows that most want an unflickering double buffer and a
+    // vblank-paced blit. Saying so is `{ id, backingStore: true }` or
+    // `{ id, present: true }`; from there such a window behaves like any
+    // other window ntk owns (issue #294).
+    this._ownsPixels = !this._foreign || args.backingStore === true || args.present === true;
     this._backingOptOut = args.backingStore === false;
     this._backing = null;
+    // an adopted window has no geometry, depth or visual to build a backing
+    // pixmap from until its constructor's questions reply — see
+    // _enableBackingStoreWhenReady
+    this._backingScheduled = false;
     // What the backing store clears to, and the window attribute it mirrors.
     // Undefined means "nothing was asked for" — see _clearColour.
     this._clearPixel = args.backgroundPixel;
@@ -671,10 +685,20 @@ export default class Window extends Drawable {
     // region and an event selection it never uses. `present: true` is still
     // honoured eagerly, for a caller who wants it up before the first paint.
     this._presentOptOut = args.present === false;
-    if (args.present && !args.id) {
+    if (args.present === true) {
       // fire and forget: until the extensions answer, blits use CopyArea,
-      // which is what they would have done anyway
+      // which is what they would have done anyway. Present needs nothing of
+      // the window but its id, so an adopted one can have it up before its
+      // geometry has even replied.
       this.enablePresent().catch((err) => this.app.options?.onXError?.(err));
+    }
+    // A window adopted with ownership declared starts its backing store now
+    // rather than waiting for the first getContext('2d'): the allocation
+    // needs the constructor's replies anyway, so starting it here means it
+    // is normally already there by the time the caller's `await wnd.ready`
+    // returns and it draws.
+    if (this._foreign && this._ownsPixels && !this._backingOptOut) {
+      this._enableBackingStoreWhenReady();
     }
 
     X.event_consumers[this.id] = this;
@@ -903,12 +927,41 @@ export default class Window extends Drawable {
    * an 'expose' (and 'draw') event is emitted only when a real redraw is
    * needed (first paint, resize). Opt out with
    * `createWindow({ backingStore: false })`.
+   *
+   * A window adopted by id is left alone by default — another client's
+   * pixels are not ntk's to buffer — and opts in with
+   * `createWindow({ id, backingStore: true })` (see `_ownsPixels`).
    */
   getContext(name, ...args) {
-    if (name === '2d' && !this._backing && !this._backingOptOut && !this._foreign) {
-      this._enableBackingStore();
+    if (name === '2d' && !this._backing && !this._backingOptOut && this._ownsPixels) {
+      if (this._foreign) this._enableBackingStoreWhenReady();
+      else this._enableBackingStore();
     }
     return super.getContext(name, ...args);
+  }
+
+  /**
+   * The backing store for an adopted window, once there is something to build
+   * it out of.
+   *
+   * A pixmap needs a width, a height, a depth and a visual, and an adopted
+   * window knows none of them until `GetGeometry` and `GetWindowAttributes`
+   * reply — so the allocation waits on `ready`. A 2d context taken in the
+   * meantime draws straight to the window and re-binds itself to the pixmap
+   * when it appears (the `_backing` event), which is the same path a resize
+   * reallocation takes.
+   */
+  _enableBackingStoreWhenReady() {
+    if (this._backingScheduled) return;
+    this._backingScheduled = true;
+    this.ready.then(() => {
+      // A window destroyed before the replies arrived still settles `ready`,
+      // with its geometry never filled in — there is no pixmap to make for
+      // one, and CreatePixmap with an undefined size is not the way to find
+      // that out.
+      if (this._destroyed || this._backing || !this.width || !this.height) return;
+      this._enableBackingStore();
+    });
   }
 
   _enableBackingStore() {
@@ -918,7 +971,7 @@ export default class Window extends Drawable {
     // Now there is a pixmap to present. Inert where the extensions are
     // missing, so this costs a window on such a server two extension queries
     // that node-x11 answers from its cache after the first.
-    if (!this._presentOptOut && !this._foreign) {
+    if (!this._presentOptOut && this._ownsPixels) {
       this.enablePresent().catch((err) => this.app.options?.onXError?.(err));
     }
 
@@ -977,7 +1030,9 @@ export default class Window extends Drawable {
     this._clearPixel = pixel;
     if (this._destroyed) return this;
     if (this._clearGc) this.X.ChangeGC(this._clearGc, { foreground: pixel });
-    if (!this._foreign) {
+    // The window attribute half is only ours to write on a window whose
+    // pixels are ours — an adopted one has to have said so (see _ownsPixels).
+    if (this._ownsPixels) {
       // no callback: it would only buy node-x11's void-sync round trip, see setCursor
       this.X.ChangeWindowAttributes(this.id, { backgroundPixel: pixel });
     }

--- a/test/adopted-backing.test.js
+++ b/test/adopted-backing.test.js
@@ -1,0 +1,318 @@
+// An adopted window opting into a backing store and Present
+// (sidorares/ntk#294). `{ id }` alone still means "another client paints
+// these pixels" — but the Composite overlay window and a window handed over
+// by an embedding host are ours completely, and saying so is what turns
+// double buffering and the vblank-paced blit back on for them.
+//
+// Hermetic: node-x11's in-process pure-JS X server with two connections, so
+// the adopted window really belongs to another client, plus a mock client
+// for the Present half (the pure-JS server has no Present extension).
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import Window from '../lib/window.js';
+import { StaticFontSource, createClient } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+const docsDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs');
+
+let server = null;
+let host = null; // the adopter: a compositor, an embedding host
+let guest = null; // the client whose window it adopts
+
+const xErrors = [];
+
+const connect = async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: (err) => xErrors.push(err)
+  });
+};
+
+beforeEach(async () => {
+  server = createServer({ width: 400, height: 300 });
+  xErrors.length = 0;
+  host = await connect();
+  guest = await connect();
+});
+
+afterEach(() => {
+  host?.X.terminate();
+  guest?.X.terminate();
+  server = host = guest = null;
+});
+
+/** drain the round trips a connection has in flight */
+const settle = (app) => new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+/** a window belonging to the other client, ready to be adopted by `host` */
+const foreignWindow = async (opts = {}) => {
+  const client = guest.createWindow({ width: 120, height: 80, ...opts });
+  await settle(guest);
+  return client;
+};
+
+test('an adopted window is still not double-buffered by default', async () => {
+  const client = await foreignWindow();
+  const adopted = host.createWindow({ id: client.id });
+  const ctx = adopted.getContext('2d');
+  await adopted.ready;
+  await tick();
+
+  assert.equal(adopted._backing, null, 'someone else paints these pixels');
+  assert.equal(ctx._target, adopted, 'so the context draws straight to the window');
+  client.destroy();
+});
+
+test('backingStore: true gives an adopted window a backing pixmap', async () => {
+  const client = await foreignWindow();
+  const adopted = host.createWindow({ id: client.id, backingStore: true });
+
+  // the allocation needs the geometry, the depth and the visual the
+  // constructor asked for, so it cannot have happened yet
+  assert.equal(adopted._backing, null, 'nothing is known about the window yet');
+
+  await adopted.ready;
+  await tick();
+
+  assert.ok(adopted._backing, 'the pixmap lands once the replies do');
+  assert.ok(adopted._backing.width >= 120 && adopted._backing.height >= 80, 'big enough');
+  assert.equal(adopted._backing.depth, 24, "the window's own depth");
+  assert.equal(adopted._backing.visualId, adopted.visualId, "and its visual (#295)");
+  client.destroy();
+});
+
+test('a 2d context taken before the replies re-binds to the pixmap', async () => {
+  const client = await foreignWindow();
+  const adopted = host.createWindow({ id: client.id, backingStore: true });
+  const ctx = adopted.getContext('2d');
+  assert.equal(ctx._target, adopted, 'the window itself, until there is a pixmap');
+
+  await adopted.ready;
+  await tick();
+  assert.equal(ctx._target, adopted._backing, 'the "_backing" event re-binds it');
+
+  // and drawing goes to the pixmap, not the window: nothing is on screen
+  // until the frame is blitted
+  ctx.fillStyle = 'rgb(10, 200, 30)';
+  ctx.fillRect(0, 0, 20, 20);
+  assert.equal(adopted._dirty, true, 'a frame is pending');
+  client.destroy();
+});
+
+test('opting in after the fact works too: getContext is the other entry point', async () => {
+  const client = await foreignWindow();
+  // `present: true` alone also declares ownership — presenting needs a pixmap
+  const adopted = host.createWindow({ id: client.id, present: true });
+  await adopted.ready;
+  adopted.getContext('2d');
+  await tick();
+
+  assert.ok(adopted._backing, 'the context asks for the buffer Present blits from');
+  client.destroy();
+});
+
+test('backingStore: false still wins over an ownership claim', async () => {
+  const client = await foreignWindow();
+  const adopted = host.createWindow({ id: client.id, present: true, backingStore: false });
+  adopted.getContext('2d');
+  await adopted.ready;
+  await tick();
+
+  assert.equal(adopted._backing, null);
+  client.destroy();
+});
+
+test('an adopted window that has gone gets no pixmap, and does not throw', async () => {
+  const client = await foreignWindow();
+  const id = client.id;
+  client.destroy();
+  await settle(guest);
+
+  const adopted = host.createWindow({ id, backingStore: true });
+  await adopted.ready;
+  await tick();
+
+  // `ready` settles either way, with the geometry never filled in — a
+  // CreatePixmap of undefined by undefined is not the way to discover that
+  assert.equal(adopted.width, undefined);
+  assert.equal(adopted._backing, null);
+  await settle(host);
+});
+
+test('setBackgroundPixel writes the window attribute only where we own it', async () => {
+  const client = await foreignWindow();
+  const attrs = [];
+  const patch = (app) => {
+    const real = app.X.ChangeWindowAttributes.bind(app.X);
+    app.X.ChangeWindowAttributes = (id, values, cb) => {
+      if (values.backgroundPixel !== undefined) attrs.push({ id, values });
+      return real(id, values, cb);
+    };
+  };
+
+  const plain = host.createWindow({ id: client.id });
+  patch(host);
+  plain.setBackgroundPixel(0x1e2228);
+  assert.deepEqual(attrs, [], "another client's attributes are not ours to change");
+
+  const owned = host.createWindow({ id: client.id, backingStore: true });
+  assert.equal(owned, plain, 'the same wrapper — adoption is cached by id');
+  // so drive the owned case on a wrapper of its own
+  const second = await foreignWindow({ width: 40, height: 40 });
+  const mine = host.createWindow({ id: second.id, backingStore: true });
+  mine.setBackgroundPixel(0x1e2228);
+  assert.equal(attrs.length, 1, 'declared ours, so the attribute is written');
+  assert.equal(attrs[0].id, second.id);
+
+  client.destroy();
+  second.destroy();
+});
+
+test('the docs section describing the opt-in exists', () => {
+  const window = readFileSync(join(docsDir, 'window.md'), 'utf8');
+  assert.ok(/^## Adopted windows$/m.test(window), 'docs/window.md#adopted-windows');
+  assert.ok(
+    window.includes('createWindow({ id, backingStore: true })'),
+    'and it spells the opt-in out'
+  );
+});
+
+// ---------------------------------------------------------------------
+// the Present half, against a mock client
+// ---------------------------------------------------------------------
+
+let nextId = 0xd000;
+
+function makeMockApp() {
+  const calls = { selects: [], presents: [] };
+  const Present = {
+    majorOpcode: 145,
+    Option: { None: 0, Async: 1, Copy: 2 },
+    EventMask: { NoEvent: 0, ConfigureNotify: 1, CompleteNotify: 2, IdleNotify: 4 },
+    Pixmap(window, pixmap, opts) {
+      calls.presents.push({ window, pixmap, opts });
+    },
+    SelectInput(eid, window, eventMask) {
+      calls.selects.push({ eid, window, eventMask });
+    }
+  };
+  const Fixes = {
+    CreateRegion() {},
+    SetRegion() {},
+    DestroyRegion() {}
+  };
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea() {},
+    GetGeometry(id, cb) {
+      calls.getGeometry = cb;
+    },
+    GetWindowAttributes(id, cb) {
+      calls.getAttributes = cb;
+    },
+    GetInputFocus() {},
+    require(name, cb) {
+      if (name === 'present') return cb(null, Present);
+      if (name === 'fixes') return cb(null, Fixes);
+      cb(new Error(`no ${name}`));
+    }
+  };
+  const display = {
+    client: X,
+    Render: { rgb24: 'rgb24', rgba32: 'rgba32', a8: 'a8', CreatePicture() {}, FreePicture() {} },
+    screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }]
+  };
+  return { app: { X, display, options: {}, solidPicture: () => ({ id: nextId++ }) }, calls };
+}
+
+const geometryReply = () => ({
+  windowid: 1,
+  xPos: 0,
+  yPos: 0,
+  width: 64,
+  height: 48,
+  borderWidth: 0,
+  depth: 24
+});
+
+test('present: true is honoured eagerly on an adopted window', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { id: 0xf001, present: true, frameInterval: 0 });
+  await wnd._presentPromise;
+
+  assert.ok(wnd._presentExt, 'Present needs nothing of the window but its id');
+  assert.equal(calls.selects.length, 1, 'and the completion events the clock runs on');
+  assert.equal(calls.selects[0].window, wnd.id);
+});
+
+test('an adopted window opted into a backing store presents from it', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { id: 0xf002, backingStore: true, frameInterval: 0 });
+  wnd.getContext('2d');
+  calls.getGeometry(null, geometryReply());
+  calls.getAttributes(null, { visual: 34 });
+  await wnd.ready;
+  await tick();
+  await wnd._presentPromise;
+
+  assert.ok(wnd._backing, 'double buffered');
+  wnd._markDirty({ x: 0, y: 0, w: 10, h: 10 });
+  await tick();
+  assert.equal(calls.presents.length, 1, 'and blitted with Present, not CopyArea');
+  assert.equal(calls.presents[0].pixmap, wnd._backing.id);
+});
+
+test('present: false keeps an owned adopted window on CopyArea', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, {
+    id: 0xf003,
+    backingStore: true,
+    present: false,
+    frameInterval: 0
+  });
+  wnd.getContext('2d');
+  calls.getGeometry(null, geometryReply());
+  calls.getAttributes(null, { visual: 34 });
+  await wnd.ready;
+  await tick();
+
+  assert.ok(wnd._backing, 'still double buffered');
+  assert.equal(wnd._presentExt, null, 'the opt-out is independent of the ownership claim');
+});
+
+test('a plain adopted window asks for neither', async () => {
+  const { app, calls } = makeMockApp();
+  const wnd = new Window(app, { id: 0xf004, frameInterval: 0 });
+  wnd.getContext('2d');
+  calls.getGeometry(null, geometryReply());
+  calls.getAttributes(null, { visual: 34 });
+  await wnd.ready;
+  await tick();
+
+  assert.equal(wnd._backing, null);
+  assert.equal(wnd._presentExt, null);
+  assert.deepEqual(calls.selects, []);
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -314,6 +314,43 @@ test('backing store: opt out keeps drawing direct', async (t) => {
   wnd.destroy();
 });
 
+test('backing store: an adopted window opts in and is drawn into (#294)', async (t) => {
+  if (skip) return t.skip(skip);
+  assertConnected();
+  // a second connection, so the window really belongs to another client the
+  // way the Composite overlay and an embedding host's handoff do
+  let other = null;
+  try {
+    other = await withTimeout(createClient(), 5000, 'second connection');
+  } catch (err) {
+    return t.skip(`cannot open a second connection: ${err.message}`);
+  }
+  try {
+    const theirs = other.createWindow({ width: 64, height: 64 });
+    // let CreateWindow reach the server before we ask about it from here
+    await withTimeout(theirs.getGeometry(), 5000, 'CreateWindow round trip');
+
+    const adopted = app.createWindow({ id: theirs.id, backingStore: true, present: true });
+    await withTimeout(adopted.ready, 5000, 'adopted geometry');
+    const ctx = adopted.getContext('2d');
+
+    assert.ok(adopted._backing, 'the ownership claim gets it a backing pixmap');
+    assert.equal(ctx._target, adopted._backing, 'and the context draws into it');
+    assert.equal(adopted._backing.depth, adopted.depth, "the window's own depth");
+
+    ctx.fillStyle = 'rgb(0, 128, 255)';
+    ctx.fillRect(0, 0, 64, 64);
+    const image = await ctx.getImageData(0, 0, 64, 64);
+    assert.deepEqual([image.data[0], image.data[1], image.data[2]], [0, 128, 255]);
+
+    // destroying the wrapper frees the backing pixmap and the window itself;
+    // `theirs` is the same X window, so it must not be destroyed twice
+    adopted.destroy();
+  } finally {
+    await other.close();
+  }
+});
+
 test('vector text: sizes above vectorFrom render via trapezoids', async (t) => {
   if (skip) return t.skip(skip);
   assertConnected();

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -317,38 +317,32 @@ test('backing store: opt out keeps drawing direct', async (t) => {
 test('backing store: an adopted window opts in and is drawn into (#294)', async (t) => {
   if (skip) return t.skip(skip);
   assertConnected();
-  // a second connection, so the window really belongs to another client the
-  // way the Composite overlay and an embedding host's handoff do
-  let other = null;
-  try {
-    other = await withTimeout(createClient(), 5000, 'second connection');
-  } catch (err) {
-    return t.skip(`cannot open a second connection: ${err.message}`);
-  }
-  try {
-    const theirs = other.createWindow({ width: 64, height: 64 });
-    // let CreateWindow reach the server before we ask about it from here
-    await withTimeout(theirs.getGeometry(), 5000, 'CreateWindow round trip');
+  // A bare id and nothing else, which is what GetOverlayWindow and an
+  // embedding host's handoff give you: dropping the wrapper leaves the X
+  // window standing and takes this connection back to knowing only its id,
+  // so adopting it runs the real path — GetGeometry, GetWindowAttributes,
+  // and a backing pixmap that cannot be built until they answer.
+  const created = app.createWindow({ width: 64, height: 64 });
+  const id = created.id;
+  created._forget();
 
-    const adopted = app.createWindow({ id: theirs.id, backingStore: true, present: true });
-    await withTimeout(adopted.ready, 5000, 'adopted geometry');
-    const ctx = adopted.getContext('2d');
+  const adopted = app.createWindow({ id, backingStore: true, present: true });
+  assert.notEqual(adopted, created, 'a fresh wrapper, adopted rather than created');
+  assert.equal(adopted._backing, null, 'nothing to build a pixmap from yet');
 
-    assert.ok(adopted._backing, 'the ownership claim gets it a backing pixmap');
-    assert.equal(ctx._target, adopted._backing, 'and the context draws into it');
-    assert.equal(adopted._backing.depth, adopted.depth, "the window's own depth");
+  await withTimeout(adopted.ready, 5000, 'adopted geometry');
+  const ctx = adopted.getContext('2d');
 
-    ctx.fillStyle = 'rgb(0, 128, 255)';
-    ctx.fillRect(0, 0, 64, 64);
-    const image = await ctx.getImageData(0, 0, 64, 64);
-    assert.deepEqual([image.data[0], image.data[1], image.data[2]], [0, 128, 255]);
+  assert.ok(adopted._backing, 'the ownership claim gets it a backing pixmap');
+  assert.equal(ctx._target, adopted._backing, 'and the context draws into it');
+  assert.equal(adopted._backing.depth, adopted.depth, "at the window's own depth");
 
-    // destroying the wrapper frees the backing pixmap and the window itself;
-    // `theirs` is the same X window, so it must not be destroyed twice
-    adopted.destroy();
-  } finally {
-    await other.close();
-  }
+  ctx.fillStyle = 'rgb(0, 128, 255)';
+  ctx.fillRect(0, 0, 64, 64);
+  const image = await ctx.getImageData(0, 0, 64, 64);
+  assert.deepEqual([image.data[0], image.data[1], image.data[2]], [0, 128, 255]);
+
+  adopted.destroy();
 });
 
 test('vector text: sizes above vectorFrom render via trapezoids', async (t) => {


### PR DESCRIPTION
Closes #294.

## The problem

A window adopted by id was excluded from double buffering and Present
outright:

```js
if (name === '2d' && !this._backing && !this._backingOptOut && !this._foreign)
```

So `getContext('2d')` on one drew straight to the window — every drawing
visible as it happened, no pixmap to serve `expose` from, nothing for
`scrollRegion` to scroll, and the frame clock stuck on the fence round trip
because no Present completion ever arrived.

That reading of `{ id }` is right by default and wrong in the two cases that
want double buffering most. `XCompositeGetOverlayWindow` returns a bare id
and the compositor is the only client that will ever paint it; the same goes
for a window handed over by an embedding host. Both had to hand-roll a back
pixmap plus `CopyArea`, reimplementing `_allocBacking` / `_blitList` / the
Present path `lib/window.js` already has.

## What changed

`backingStore: true` or `present: true` on an adopted window is now an
ownership claim, and from there the window behaves like any other window ntk
owns:

```js
const overlay = app.createWindow({ id: overlayId, backingStore: true, present: true });
await overlay.ready;
const ctx = overlay.getContext('2d');
```

- Either flag alone enables both halves — presenting needs a pixmap to
  present from. `present: false` still opts out of Present alone,
  `backingStore: false` still opts out of everything, and a plain `{ id }` is
  unchanged.
- `setBackgroundPixel` writes the window attribute on such a window too, so
  the colour the server paints into exposed area and the colour the backing
  store clears to agree.
- Present is set up eagerly on the id, which is all it needs.

## The prerequisite from the issue

The pixmap needs a width, a height, a depth and a visual, and an adopted
window knows none of them until `GetGeometry` and `GetWindowAttributes`
reply. So the allocation waits on `ready`, and is scheduled at construction
rather than at the first `getContext` — by the time the caller's own await
returns, the buffer is normally already there. A 2d context taken in the
meantime draws straight to the window and rebinds on the `_backing` event,
the same path a resize reallocation takes. A window destroyed before the
replies land gets no pixmap, rather than a `CreatePixmap` of undefined by
undefined.

## Tests

`test/adopted-backing.test.js`, 12 cases: the hermetic pure-JS X server with
two connections, so the adopted window really belongs to another client, plus
a mock client for the Present half the pure-JS server has no extension for.
Covers the unchanged default, both opt-in spellings, the opt-outs, the
late rebind, the destroyed-window path and the `setBackgroundPixel` split.

`test/smoke.test.js` gains a real-server case: a window is created, its
wrapper forgotten so only the id is left, and the id adopted with both flags
— the pixels drawn then read back through `getImageData` at the depth the
window actually has. Verified against Xvfb as well as XQuartz, since only
Xvfb has Present and so actually exercises the blit.
