### PR TITLE
fix(test): dispose of the connection a timed-out wait still receives

### DIFF
--- a/test/async-helper.test.js
+++ b/test/async-helper.test.js
@@ -1,0 +1,65 @@
+// The test suite's own timeout helper (test/helpers/async.js).
+//
+// The interesting behaviour is what happens *after* the deadline. A promise
+// cannot be cancelled, so the work keeps going and eventually hands back
+// whatever it was making — a live X connection, in nearly every caller here.
+// Nobody is awaiting it by then, so unless it is disposed of its socket refs
+// the event loop forever: every test in the file skips, the file reports, and
+// `node --test` never exits (issue #254; a matrix leg on #316 sat there for
+// 20 minutes on its way to the six-hour job limit).
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { withTimeout } from './helpers/async.js';
+
+test('resolves through when the promise wins', async () => {
+  let disposed = 0;
+  const value = await withTimeout(Promise.resolve('quick'), 1000, 'the quick thing', () => disposed++);
+  assert.equal(value, 'quick');
+  await sleep(10);
+  assert.equal(disposed, 0, 'nothing arrived late, so nothing to dispose of');
+});
+
+test('the timeout error names what it was waiting for', async () => {
+  await assert.rejects(withTimeout(sleep(1000), 5, 'the slow thing'), /timeout after 5ms: the slow thing/);
+});
+
+test('a value that arrives after the deadline is handed to dispose', async () => {
+  const resource = { closed: false, close() { this.closed = true; } };
+  const late = sleep(20).then(() => resource);
+  await assert.rejects(
+    withTimeout(late, 5, 'a resource', (arrived) => arrived.close()),
+    /timeout after 5ms/
+  );
+  assert.equal(resource.closed, false, 'not closed before it exists');
+  await late;
+  await sleep(5);
+  assert.equal(resource.closed, true, 'the late arrival was closed for us');
+});
+
+test('a promise that rejects on its own disposes of nothing', async () => {
+  let disposed = 0;
+  const boom = sleep(20).then(() => Promise.reject(new Error('boom')));
+  await assert.rejects(withTimeout(boom, 5, 'a failure', () => disposed++), /timeout after 5ms/);
+  await sleep(20);
+  assert.equal(disposed, 0, 'there is no resource behind a rejection');
+});
+
+test('a dispose that throws does not become an unhandled rejection', async () => {
+  const unhandled = [];
+  const watch = (err) => unhandled.push(err);
+  process.on('unhandledRejection', watch);
+  try {
+    await assert.rejects(
+      withTimeout(sleep(10).then(() => 'late'), 1, 'a resource', () => {
+        throw new Error('close failed');
+      }),
+      /timeout after 1ms/
+    );
+    await sleep(30);
+  } finally {
+    process.off('unhandledRejection', watch);
+  }
+  assert.deepEqual(unhandled, [], 'by then nobody is listening, so it must be swallowed');
+});

--- a/test/clip-region.test.js
+++ b/test/clip-region.test.js
@@ -37,7 +37,12 @@ before(async () => {
   source.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), { family: 'Test Main' });
   source.alias('sans-serif', 'Test Main');
   try {
-    app = await withTimeout(createClient({ fontSource: source }), 5000, 'connecting to X server');
+    app = await withTimeout(
+      createClient({ fontSource: source }),
+      5000,
+      'connecting to X server',
+      (late) => late.close()
+    );
   } catch (err) {
     skip = `cannot connect to X server: ${err.message}`;
     return;
@@ -367,7 +372,8 @@ test('clipRegion before XFIXES is loaded says what to do about it', async (t) =>
   const other = await withTimeout(
     createClient({ fontSource: new StaticFontSource() }),
     5000,
-    'second connection'
+    'second connection',
+    (late) => late.close()
   );
   try {
     const pixmap = other.createPixmap({ width: 32, height: 32, depth: 24 });

--- a/test/extension-events-live.test.js
+++ b/test/extension-events-live.test.js
@@ -22,7 +22,7 @@ before(async () => {
     return;
   }
   try {
-    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+    app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
   } catch (err) {
     skip = `cannot connect to X server: ${err.message}`;
   }

--- a/test/extensions-live.test.js
+++ b/test/extensions-live.test.js
@@ -36,7 +36,7 @@ before(async () => {
     return;
   }
   try {
-    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+    app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
   } catch (err) {
     skip = `cannot connect to X server: ${err.message}`;
   }

--- a/test/gl-direct-live.test.js
+++ b/test/gl-direct-live.test.js
@@ -85,7 +85,12 @@ before(async () => {
   }
   keepalive = setInterval(() => {}, 1000);
   try {
-    app = await withTimeout(createClient({ glPolicy: 'auto' }), 5000, 'connecting to X server');
+    app = await withTimeout(
+      createClient({ glPolicy: 'auto' }),
+      5000,
+      'connecting to X server',
+      (late) => late.close()
+    );
   } catch (err) {
     skip = `cannot connect to X server: ${err.message}`;
     return;

--- a/test/glyph-positions.test.js
+++ b/test/glyph-positions.test.js
@@ -32,7 +32,7 @@ before(async () => {
     return;
   }
   try {
-    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+    app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
     app.fonts.match('sans-serif');
   } catch (err) {
     skip = `cannot connect / no fonts: ${err.message}`;

--- a/test/helpers/async.js
+++ b/test/helpers/async.js
@@ -22,11 +22,28 @@
  *
  * Holding the loop costs nothing here because the timer is cleared as soon as
  * the promise settles, which is what `unref` was reaching for.
+ *
+ * A timeout ends *this* wait, never the work behind it: a promise cannot be
+ * cancelled, so whatever it was making still arrives, unowned and unwatched.
+ * Where that is a live X connection the socket refs the event loop forever —
+ * every test skips, the file reports, and then `node --test` simply never
+ * exits (seen on #316: a 20-minute stall on two matrix legs, on its way to
+ * the six-hour job limit). Pass `dispose` for anything holding a resource and
+ * the late arrival is handed to it instead of being dropped on the floor:
+ *
+ *     withTimeout(createClient(), 5000, 'connecting', (app) => app.close())
+ *
+ * `dispose` runs at most once, only on the timeout path — a promise that
+ * rejects on its own left nothing to dispose of — and anything it throws is
+ * swallowed, since by then nobody is waiting to hear it.
  */
-export function withTimeout(promise, ms, what) {
+export function withTimeout(promise, ms, what, dispose) {
   let timer;
   const limit = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`timeout after ${ms}ms: ${what}`)), ms);
+    timer = setTimeout(() => {
+      if (dispose) Promise.resolve(promise).then(dispose).catch(() => {});
+      reject(new Error(`timeout after ${ms}ms: ${what}`));
+    }, ms);
   });
   return Promise.race([promise, limit]).finally(() => clearTimeout(timer));
 }

--- a/test/shared-glyphs-assumptions.test.js
+++ b/test/shared-glyphs-assumptions.test.js
@@ -34,12 +34,23 @@ function connect(opts) {
       const X = display.client;
       const errors = [];
       X.on('error', (e) => errors.push(e));
+      // the connection is already up by the time these can fail; rejecting
+      // hands the caller an error but no handle, so drop the socket here or
+      // it refs the event loop for the rest of the process
+      const failed = (cause) => {
+        try {
+          X.terminate();
+        } catch {
+          // already gone
+        }
+        reject(cause);
+      };
       X.require('render', (rerr, Render) => {
-        if (rerr) return reject(rerr);
+        if (rerr) return failed(rerr);
         // QueryVersion also flushes the ext's QueryPictFormat, so a8/rgb24
         // are populated once this roundtrip completes
         Render.QueryVersion(0, 11, (verr) => {
-          if (verr) return reject(verr);
+          if (verr) return failed(verr);
           resolve({ display, X, Render, errors });
         });
       });
@@ -146,11 +157,20 @@ async function waitClosedown(c, canvas, deadGsid, what) {
 
 /** the whole scenario, over any pair-of-connections factory */
 async function runScenarios(t, makeConn) {
-  const A = await makeConn();
-  const B = await makeConn();
-  const C = await makeConn();
-  const open = [A, B, C];
+  // every connection joins `open` the moment it exists: a factory that fails
+  // (or times out) on the second or third call would otherwise strand the
+  // ones already made, and a live X socket refs the event loop for as long as
+  // the process lives — `node --test` reports and then never exits
+  const open = [];
+  const conn = async () => {
+    const c = await makeConn();
+    open.push(c);
+    return c;
+  };
   try {
+    const A = await conn();
+    const B = await conn();
+    const C = await conn();
     // A creates the set and uploads two glyphs
     const gsA = A.X.AllocID();
     A.Render.CreateGlyphSet(gsA, A.Render.a8);
@@ -221,7 +241,12 @@ test('shared glyphsets across connections (pure-JS server)', async (t) => {
   await runScenarios(t, () => {
     const [serverEnd, clientEnd] = xserver.createStreamPair();
     server.addClientStream(serverEnd);
-    return withTimeout(connect({ stream: clientEnd }), 5000, 'connecting to js server');
+    return withTimeout(
+      connect({ stream: clientEnd }),
+      5000,
+      'connecting to js server',
+      (late) => late.X.terminate()
+    );
   });
 });
 
@@ -232,7 +257,7 @@ test('shared glyphsets across connections (real X server)', async (t) => {
   }
   let first;
   try {
-    first = await withTimeout(connect({}), 5000, 'connecting to X server');
+    first = await withTimeout(connect({}), 5000, 'connecting to X server', (late) => late.X.terminate());
   } catch (err) {
     t.skip(`cannot connect to X server: ${err.message}`);
     return;
@@ -243,6 +268,6 @@ test('shared glyphsets across connections (real X server)', async (t) => {
       used = true;
       return first;
     }
-    return withTimeout(connect({}), 5000, 'connecting to X server');
+    return withTimeout(connect({}), 5000, 'connecting to X server', (late) => late.X.terminate());
   });
 });

--- a/test/shared-glyphs.test.js
+++ b/test/shared-glyphs.test.js
@@ -109,7 +109,8 @@ function makeWorld() {
           ...options
         }),
         5000,
-        'connecting an app to the js server'
+        'connecting an app to the js server',
+        (late) => late.close()
       );
       app._testErrors = errors;
       this.apps.push(app);
@@ -427,7 +428,12 @@ test('two real-server apps share glyphs (smoke)', async (t) => {
   }
   let app1;
   try {
-    app1 = await withTimeout(createClient({ fontSource: makeFontSource() }), 5000, 'connecting to X server');
+    app1 = await withTimeout(
+      createClient({ fontSource: makeFontSource() }),
+      5000,
+      'connecting to X server',
+      (late) => late.close()
+    );
   } catch (err) {
     t.skip(`cannot connect to X server: ${err.message}`);
     return;
@@ -439,7 +445,12 @@ test('two real-server apps share glyphs (smoke)', async (t) => {
     const img1 = await drawText(app1, 'Hello shared');
     assert.ok(inkOf(img1) > 40, 'first app inked');
 
-    const app2 = await withTimeout(createClient({ fontSource: makeFontSource() }), 5000, 'connecting to X server');
+    const app2 = await withTimeout(
+      createClient({ fontSource: makeFontSource() }),
+      5000,
+      'connecting to X server',
+      (late) => late.close()
+    );
     apps.push(app2);
     const font2 = app2.fonts.match('sans-serif');
     const uploads = spyRender(app2, 'AddGlyphs');

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -16,7 +16,7 @@ before(async () => {
     return;
   }
   try {
-    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+    app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
   } catch (err) {
     skip = `cannot connect to X server: ${err.message}`;
   }

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -27,7 +27,7 @@ before(async () => {
   // alive long enough for whatever went wrong to be reported as itself.
   keepalive = setInterval(() => {}, 1000);
   try {
-    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+    app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
   } catch (err) {
     skip = `cannot connect to X server: ${err.message}`;
     return;

--- a/test/variable-fonts-canvas.test.js
+++ b/test/variable-fonts-canvas.test.js
@@ -31,7 +31,12 @@ before(async () => {
     const fontSource = new StaticFontSource();
     fontSource.add(readFileSync(VF), { family: 'Test VF' });
     fontSource.alias('sans-serif', 'test vf');
-    app = await withTimeout(createClient({ fontSource }), 5000, 'connecting to X server');
+    app = await withTimeout(
+      createClient({ fontSource }),
+      5000,
+      'connecting to X server',
+      (late) => late.close()
+    );
     win = app.createWindow({ width: 400, height: 120 });
     ctx = win.getContext('2d');
   } catch (err) {

--- a/test/xi2-live.test.js
+++ b/test/xi2-live.test.js
@@ -26,7 +26,7 @@ before(async () => {
   }
   keepalive = setInterval(() => {}, 1000);
   try {
-    app = await withTimeout(createClient(), 5000, 'connecting to X server');
+    app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
   } catch (err) {
     skip = `cannot connect to X server: ${err.message}`;
     return;


### PR DESCRIPTION
## The hang

Every X-dependent test file opens its connection the same way:

```js
app = await withTimeout(createClient(), 5000, 'connecting to X server');
```

and sets `skip` when that rejects. But a timeout ends *this wait*, not the work behind it — a promise cannot be cancelled, so `createClient()` keeps going and eventually hands back a live connection that nobody owns. Its socket refs the event loop for the rest of the process: every test in the file skips, the file reports its results, and then `node --test` simply never exits.

That is a fully green run that hangs until the six-hour GitHub Actions limit. It is not theoretical — a second call of this shape stalled the 18.19 and 22 matrix legs of #316 for 20+ minutes before it was removed. The same hazard was still sitting in ten `before()` hooks.

## The fix

`withTimeout` grows an optional fourth argument rather than every caller hand-rolling the same `.then(late => late.close())`:

```js
app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
```

The disposer runs only on the timeout path (a promise that rejects on its own left nothing to dispose of), at most once, and anything it throws is swallowed — by then nobody is waiting to hear it.

Applied at every `createClient()`/`connect()` wait in the suite: smoke, smoke-canvas, clip-region (both sites), extension-events-live, extensions-live, glyph-positions, xi2-live, gl-direct-live, variable-fonts-canvas, shared-glyphs (all three), shared-glyphs-assumptions (three raw node-x11 connections, disposed with `X.terminate()`).

## Two adjacent leaks of the same shape

Both in `shared-glyphs-assumptions.test.js`:

- `connect()` rejected from inside the `X.require`/`QueryVersion` callbacks. By that point the connection is already up, so the caller got an error and no handle — the socket stayed refed. It now terminates before rejecting.
- `runScenarios()` built `open = [A, B, C]` only after all three connections existed, so a failure on B or C stranded the ones already made. Each connection now joins the cleanup list the moment it exists.

## Verification

Against a real X server (XQuartz), with the smoke `before()` timeout lowered to 1ms:

- **without** the disposer: 18 tests skip, the file reports, process still running after 20s — the reported hang, reproduced;
- **with** it: same skips, process exits in 0.3s.

Full suite: 1063 tests, 1060 pass, 0 fail, 3 skipped (no DRI3 on this box), clean exit.

`test/async-helper.test.js` is new and hermetic — five tests fencing the helper itself: pass-through on the happy path, the error naming what it waited for, a late value reaching `dispose`, a self-rejecting promise disposing nothing, and a throwing `dispose` not surfacing as an unhandled rejection. That is the guard against the argument quietly going missing again.

No library code changed; test infrastructure only.