### PR TITLE
feat(deps): x11 4.0.1, and the visual to format table it decodes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -148,10 +148,10 @@ export default class App {
     // installed synchronously, in request order with the drawing around it —
     // see RenderingContext2d#clipRegion.
     this._fixes = null;
-    // QueryPictFormats, once — the visual -> picture format table and the
-    // formats list it was built from. Kept resolved alongside the promise so
-    // that binding a picture, which happens synchronously, can consult it
-    // without waiting (see pictFormats).
+    // The visual -> picture format table and the formats list it was built
+    // from, read once out of node-x11's cached QueryPictFormats reply. Kept
+    // resolved alongside the promise so that binding a picture, which happens
+    // synchronously, can consult it without waiting (see pictFormats).
     this._pictFormats = null;
     this._pictFormatsPromise = null;
     // node-x11 emits X errors it cannot route to a request callback as
@@ -660,35 +660,29 @@ export default class App {
    * The RENDER picture formats this server publishes, and which one belongs
    * to each visual: `{ formats, byVisual }`.
    *
-   * One `QueryPictFormats` per connection, cached — ntk sends it while the
-   * connection is still being set up, so by the time anything draws the
-   * answer is usually already here. `formats` is the list as objects
-   * (`{ id, type, depth, redShift, redMask, ... }`); `byVisual` is a
-   * `Map` from visual id to format id.
+   * No round trip of ntk's own: node-x11 sends `QueryPictFormats` itself
+   * while requiring RENDER — that is where its `rgb24`/`rgba32`/`a8` come
+   * from — and since 4.0.0 it keeps the reply as `Render.pictFormats`. So
+   * the answer is already here before anything can draw. `formats` is the
+   * list as objects (`{ id, type, depth, redShift, redMask, ... }`);
+   * `byVisual` is a `Map` from visual id to format id.
    *
    * @returns {Promise<{formats: Array<object>, byVisual: Map<number, number>}>}
    */
   pictFormats() {
     if (this._pictFormatsPromise) return this._pictFormatsPromise;
     this._pictFormatsPromise = new Promise((resolve, reject) => {
-      const Render = this.display.Render;
-      if (!Render?.QueryPictFormats) {
+      const reply = this.display.Render?.pictFormats;
+      if (!reply) {
         reject(new Error('ntk: this connection has no RENDER extension, so it has no picture formats'));
         return;
       }
-      Render.QueryPictFormats((err, reply) => {
-        if (err) {
-          this._pictFormatsPromise = null; // let a later call try again
-          reject(err);
-          return;
-        }
-        const formats = parsePictFormats(reply);
-        this._pictFormats = {
-          formats,
-          byVisual: visualFormats(this.display, formats, reply)
-        };
-        resolve(this._pictFormats);
-      });
+      const formats = parsePictFormats(reply);
+      this._pictFormats = {
+        formats,
+        byVisual: visualFormats(this.display, formats, reply)
+      };
+      resolve(this._pictFormats);
     });
     return this._pictFormatsPromise;
   }

--- a/lib/app.js
+++ b/lib/app.js
@@ -364,12 +364,14 @@ export default class App {
    * The node-x11 object for extension `name`, or `null` where the server has
    * none — asked once per connection, the absent answer included.
    *
-   * The cache has to be ours because node-x11's is one-sided: `X.require`
-   * keeps the extension object it built, but nothing remembers a query that
-   * came back absent, so on a server without the extension every call would
-   * cost another `QueryExtension` round trip. Here the absent answer is the
-   * interesting one — "can this machine run a compositor?" is a question
-   * about what is *not* there — so it is the one worth caching.
+   * node-x11 caches the `QueryExtension` reply itself since 4.0.1
+   * ([node-x11#287](https://github.com/sidorares/node-x11/issues/287)), so a
+   * repeated probe no longer costs a round trip even when the answer is
+   * absent — "can this machine run a compositor?" is a question about what is
+   * *not* there, and it used to pay for asking. This cache stays for what it
+   * does beyond that: one promise per name, so concurrent callers share the
+   * one query, `_routeExtensionEvents` runs once rather than per call, and an
+   * absent extension answers `null` instead of an error.
    *
    * `name` is node-x11's module name (`'fixes'`, not `'XFIXES'`), and the
    * accessors below are the whole supported set. Deliberately not public: a
@@ -418,12 +420,11 @@ export default class App {
     if (!this._extEvents) {
       this._extEvents = new Map();
       this.X.on('event', (ev) => {
-        // by the server-assigned type code, with the parser's event name
-        // standing in where the parsed event does not carry one — node-x11's
-        // DamageNotify parser is the one extension parser that sets `name`
-        // but not `type` (x11 <= 3.9). Only names this table registered can
-        // match, and core events always carry their type.
-        const route = this._extEvents.get(ev.type ?? ev.name);
+        // by the server-assigned type code, which every extension event
+        // carries since x11 4.0.0 (node-x11#284 — DamageNotify and a couple
+        // of others used to name themselves without it). Only the codes this
+        // table registered can match.
+        const route = this._extEvents.get(ev.type);
         if (!route) return;
         const target = this.X.event_consumers[ev[route.target]];
         // a consumer that is not an ntk drawable (a caller's own) keeps
@@ -439,9 +440,6 @@ export default class App {
       const offset = ext.events[key];
       if (offset === undefined) continue;
       this._extEvents.set(ext.firstEvent + offset, spec);
-      // the wire name doubles as a key, for parsed events missing `type` —
-      // number and string keys cannot collide in the one map
-      this._extEvents.set(key, spec);
     }
   }
 
@@ -685,7 +683,10 @@ export default class App {
           return;
         }
         const formats = parsePictFormats(reply);
-        this._pictFormats = { formats, byVisual: visualFormats(this.display, formats) };
+        this._pictFormats = {
+          formats,
+          byVisual: visualFormats(this.display, formats, reply)
+        };
         resolve(this._pictFormats);
       });
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,15 +158,14 @@ export function createClient(options, callback) {
           display.GLX = glxError ? null : GLX;
 
           const app = new App(display, appOptions);
-          // The visual -> picture format table (issue #295), assigned just
-          // below: a picture is bound synchronously, so the table has to be
-          // here before anything draws rather than fetched at the first
-          // paint. Its request goes out immediately behind the version
-          // declaration — RENDER wants that one first — so the two replies
-          // come back together and waiting for it costs the connection no
-          // round trip of its own. A server that cannot answer leaves every
-          // format picked from the depth, as before.
-          let pictFormats;
+          // Build the visual -> picture format table (issue #295) now: a
+          // picture is bound synchronously, so the table has to be here
+          // before anything draws rather than fetched at the first paint.
+          // It costs the connection nothing and no wait — node-x11 asked
+          // `QueryPictFormats` itself while requiring RENDER and kept the
+          // reply, so this only reads it. A server that cannot
+          // answer leaves every format picked from the depth, as before.
+          app.pictFormats().catch(() => null);
           // RENDER requires the client to declare its version before using
           // requests beyond 0.0, and the reply is what gates them afterwards
           // — CreateSolidFill needs 0.10 (see App#solidPicture). 0.11 is the
@@ -199,15 +198,14 @@ export function createClient(options, callback) {
             // that getContext() can choose a backend synchronously later.
             // Nothing to do under the default policy, which is why the common
             // case pays nothing for this.
-            if (!wantsDirect(glPolicy)) return pictFormats.then(() => resolve(app));
+            if (!wantsDirect(glPolicy)) return resolve(app);
             app.glCapabilities().then(
-              () => pictFormats.then(() => resolve(app)),
+              () => resolve(app),
               // a probe that throws is a probe that found nothing, and GL is
               // not what the connection is for
-              () => pictFormats.then(() => resolve(app))
+              () => resolve(app)
             );
           });
-          pictFormats = app.pictFormats().catch(() => null);
         });
       });
     });

--- a/lib/pictformat.js
+++ b/lib/pictformat.js
@@ -9,14 +9,18 @@
  * format has to be picked from (issue #295).
  *
  * The mapping the server keeps is in `QueryPictFormats`' screens/depths/
- * visuals section, which node-x11's parser drops
- * ([node-x11#280](https://github.com/sidorares/node-x11/issues/280)). Until it
- * lands, the mapping is reconstructed here the way the server built it in the
- * first place: a visual's `red_mask`/`green_mask`/`blue_mask` from the
- * connection handshake, matched against the shift/mask pairs of the formats
- * list. Both sides come from the same server, so this is a lookup rather than
- * a guess — the only thing it cannot recover is a format for an *indexed*
- * visual, which has no masks to match on.
+ * visuals section, which node-x11 decodes since 4.0.0
+ * ([node-x11#280](https://github.com/sidorares/node-x11/issues/280)) — that
+ * is the server's own answer, and it is what is used when the reply carries
+ * it.
+ *
+ * A visual the reply leaves out — one whose depth this server's RENDER does
+ * not describe — is reconstructed the way the server would have built it: a
+ * visual's `red_mask`/`green_mask`/`blue_mask` from the connection handshake,
+ * matched against the shift/mask pairs of the formats list. Both sides come
+ * from the same server, so this is a lookup rather than a guess — the only
+ * thing it cannot recover is a format for an *indexed* visual, which has no
+ * masks to match on and which only the reply can name.
  */
 
 /** `type` in a formats-list entry. */
@@ -122,19 +126,35 @@ export function matchVisualFormat(visual, depth, formats) {
 }
 
 /**
- * visual id -> format id, over every visual the connection was told about.
+ * visual id -> format id, from the reply's screens section where the server
+ * sent one, and matched on colour masks where it did not.
+ *
+ * Visual ids are unique across screens, so one flat map answers for all of
+ * them. The server's own table is the whole answer where it is there — it
+ * names indexed visuals too, which masks cannot — and mask matching then
+ * fills in only the visuals it left out.
  *
  * @param {object} display node-x11's display object
  * @param {Array<object>} formats parsed formats list
+ * @param {object} [reply] the `QueryPictFormats` reply, for its `screens`
  * @returns {Map<number, number>}
  */
-export function visualFormats(display, formats) {
+export function visualFormats(display, formats, reply) {
   const byVisual = new Map();
+  for (const screen of reply?.screens ?? []) {
+    for (const depth of screen?.depths ?? []) {
+      for (const { visual, format } of depth?.visuals ?? []) {
+        byVisual.set(visual >>> 0, format);
+      }
+    }
+  }
   for (const screen of display?.screen ?? []) {
     for (const depth in screen.depths ?? {}) {
       for (const visual of Object.values(screen.depths[depth])) {
+        const vid = visual.vid >>> 0;
+        if (byVisual.has(vid)) continue;
         const format = matchVisualFormat(visual, Number(depth), formats);
-        if (format != null) byVisual.set(visual.vid >>> 0, format);
+        if (format != null) byVisual.set(vid, format);
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "linebreak": "^1.1.0",
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
-        "x11": "^3.9.2"
+        "x11": "^4.0.1"
       },
       "devDependencies": {
         "@conventional-commits/parser": "^0.4.1",
@@ -464,9 +464,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.9.2.tgz",
-      "integrity": "sha512-IHIE2iKcJtPOtrTRW+sGkJ1l21F0Jiwl/tSlpZOZ9zN6qrAUvp4u5ITjKws/SoOtE7Oo8ifP3fc//AqLgwtV7g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-4.0.1.tgz",
+      "integrity": "sha512-24vEriWj4eu2fQxM+SP4wyTKaM8ZCG43BaFskjEy7teHE5I0skQrMuvIpv/4p6DOZFNcWEZHh6DaWQ1rWnibbA==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "linebreak": "^1.1.0",
     "parse-color": "^1.0.0",
     "pngjs": "^7.0.0",
-    "x11": "^3.9.2"
+    "x11": "^4.0.1"
   },
   "optionalDependencies": {
     "x11-dri": ">=0.2.0 <1"

--- a/test/close-event.test.js
+++ b/test/close-event.test.js
@@ -15,7 +15,39 @@ let server = null;
 let app = null; // the application
 let wm = null; // a second client, playing the window manager
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+/** a round trip on one connection, plus a turn for what it delivered */
+const settle = (client) =>
+  new Promise((resolve) => client.X.GetInputFocus(() => setImmediate(resolve)));
+
+/**
+ * The wm has spoken and the app has heard it. The wm's round trip proves the
+ * server processed what it sent; the app's proves the bytes the server wrote
+ * for it — the ClientMessage among them — arrived and were dispatched, since
+ * a reply cannot overtake an event already queued on the same stream.
+ */
+const delivered = async () => {
+  await settle(wm);
+  await settle(app);
+};
+
+/**
+ * Wait until `wnd` advertises `name` in WM_PROTOCOLS.
+ *
+ * `on('close')` starts the read-modify-write that advertises
+ * WM_DELETE_WINDOW and hands back no promise to wait on, so the property
+ * itself is the wait: read it until it names the atom, rather than guess how
+ * long the interning and the round trips behind it take. Each attempt is a
+ * round trip, which is what paces the loop.
+ */
+async function advertised(wnd, name = 'WM_DELETE_WINDOW') {
+  const atom = await wnd.atom(name);
+  for (let i = 0; i < 100; i++) {
+    const protocols = await wnd.getProperty('WM_PROTOCOLS', { as: 'numbers' });
+    if (protocols?.includes(atom)) return protocols;
+    await settle(app);
+  }
+  throw new Error(`WM_PROTOCOLS never came to name ${name}`);
+}
 
 before(async () => {
   server = xserver.createServer({ width: 200, height: 200 });
@@ -37,7 +69,7 @@ after(async () => {
 async function pair(onClose) {
   const wnd = app.createWindow({ width: 40, height: 40 });
   wnd.on('close', onClose);
-  await sleep(30); // let addProtocol's read-modify-write reach the server
+  await advertised(wnd);
   return { wnd, asWm: new Window(wm, { id: wnd.id }) };
 }
 
@@ -48,9 +80,8 @@ describe("on('close')", () => {
     assert.equal(await wnd.getProperty('WM_PROTOCOLS'), null, 'nothing advertised yet');
 
     wnd.on('close', () => {});
-    await sleep(30);
 
-    const protocols = await wnd.getProperty('WM_PROTOCOLS', { as: 'numbers' });
+    const protocols = await advertised(wnd);
     const del = await wnd.atom('WM_DELETE_WINDOW');
     assert.ok(protocols.includes(del));
     wnd.destroy();
@@ -60,8 +91,7 @@ describe("on('close')", () => {
     const wnd = app.createWindow({ width: 40, height: 40 });
     wnd.on('close', () => {});
     wnd.on('close', () => {});
-    await sleep(30);
-    const protocols = await wnd.getProperty('WM_PROTOCOLS', { as: 'numbers' });
+    const protocols = await advertised(wnd);
     assert.equal(protocols.length, 1, 'one atom, not one per listener');
     wnd.destroy();
   });
@@ -70,9 +100,8 @@ describe("on('close')", () => {
     const wnd = app.createWindow({ width: 40, height: 40 });
     await wnd.addProtocol('WM_TAKE_FOCUS');
     wnd.on('close', () => {});
-    await sleep(30);
 
-    const protocols = await wnd.getProperty('WM_PROTOCOLS', { as: 'numbers' });
+    const protocols = await advertised(wnd);
     assert.equal(protocols.length, 2);
     assert.ok(protocols.includes(await wnd.atom('WM_TAKE_FOCUS')));
     assert.ok(protocols.includes(await wnd.atom('WM_DELETE_WINDOW')));
@@ -84,14 +113,14 @@ describe("on('close')", () => {
     const { wnd, asWm } = await pair(() => fired++);
 
     assert.equal(await asWm.close(), true, 'asked rather than killed');
-    await sleep(30);
+    await delivered();
     assert.equal(fired, 1);
   });
 
   test('the default action is to destroy the window', async () => {
     const { wnd, asWm } = await pair(() => {});
     await asWm.close();
-    await sleep(30);
+    await delivered();
     assert.equal(wnd._destroyed, true);
   });
 
@@ -105,13 +134,13 @@ describe("on('close')", () => {
     });
 
     await asWm.close();
-    await sleep(30);
+    await delivered();
     assert.equal(asked, 1);
     assert.equal(wnd._destroyed, false, 'still open');
 
     // and asking again still works — declining is not a one-off
     await asWm.close();
-    await sleep(30);
+    await delivered();
     assert.equal(asked, 2);
     assert.equal(wnd._destroyed, false);
     wnd.destroy();
@@ -125,7 +154,7 @@ describe("on('close')", () => {
       seen.push(ev.defaultPrevented);
     });
     await asWm.close();
-    await sleep(30);
+    await delivered();
     assert.deepEqual(seen, [false, true]);
     wnd.destroy();
   });
@@ -134,10 +163,10 @@ describe("on('close')", () => {
     const wnd = app.createWindow({ width: 40, height: 40 });
     wnd.on('close', () => {}); // indifferent
     wnd.on('close', (ev) => ev.preventDefault()); // objects
-    await sleep(30);
+    await advertised(wnd);
 
     await new Window(wm, { id: wnd.id }).close();
-    await sleep(30);
+    await delivered();
     assert.equal(wnd._destroyed, false);
     wnd.destroy();
   });
@@ -149,7 +178,7 @@ describe("on('close')", () => {
       e.preventDefault();
     });
     await asWm.close();
-    await sleep(30);
+    await delivered();
     assert.equal(typeof ev.time, 'number');
     assert.equal(ev.target, wnd);
     assert.equal(ev.window, wnd);
@@ -165,7 +194,7 @@ describe("on('close') and the raw message event", () => {
 
     // _NET_WM_PING arrives down the same WM_PROTOCOLS channel
     wm.X.SendClientMessage(wnd.id, wnd.id, wmProtocols, 32, [ping, 1, wnd.id, 0, 0], 0);
-    await sleep(30);
+    await delivered();
     assert.equal(wnd._destroyed, false, 'a ping is not a close request');
     wnd.destroy();
   });
@@ -176,7 +205,7 @@ describe("on('close') and the raw message event", () => {
     const del = await wnd.atom('WM_DELETE_WINDOW');
 
     wm.X.SendClientMessage(wnd.id, wnd.id, other, 32, [del, 0, 0, 0, 0], 0);
-    await sleep(30);
+    await delivered();
     assert.equal(wnd._destroyed, false, 'matched on data alone, ignoring the type');
     wnd.destroy();
   });
@@ -190,10 +219,10 @@ describe("on('close') and the raw message event", () => {
       order.push('close');
       ev.preventDefault();
     });
-    await sleep(30);
+    await advertised(wnd);
 
     await new Window(wm, { id: wnd.id }).close();
-    await sleep(30);
+    await delivered();
     assert.deepEqual(order, ['message', 'close']);
     wnd.destroy();
   });
@@ -204,10 +233,9 @@ describe("on('close') and the raw message event", () => {
     await wnd.addProtocol('WM_DELETE_WINDOW');
     let messages = 0;
     wnd.on('message', () => messages++);
-    await sleep(30);
 
     await new Window(wm, { id: wnd.id }).close();
-    await sleep(30);
+    await delivered();
     assert.equal(messages, 1, 'the message arrived');
     assert.equal(wnd._destroyed, false, 'and ntk did not act on it');
     wnd.destroy();
@@ -217,7 +245,7 @@ describe("on('close') and the raw message event", () => {
 describe('the window manager side', () => {
   test('a window that never listened is killed rather than asked', async () => {
     const wnd = app.createWindow({ width: 40, height: 40 });
-    await sleep(20);
+    await settle(app); // the window exists on the server before the wm asks
     assert.equal(await new Window(wm, { id: wnd.id }).close(), false);
   });
 });

--- a/test/extension-events.test.js
+++ b/test/extension-events.test.js
@@ -132,15 +132,16 @@ test('ShapeNotify and the XFIXES notifies route by their window field', async ()
   assert.equal(cursor.time, 101, "the timestamp under the name ntk's other events use");
 });
 
-test('a parsed event with a name but no type still routes', async () => {
-  // node-x11's DamageNotify parser (x11 <= 3.9) sets `name` but not `type`,
-  // unlike every other extension parser — the wire name is the key then
+test('the type code is what routes, not the name the parser wrote', async () => {
+  // every extension parser sets `type` since x11 4.0.0 (node-x11#284), so the
+  // server-assigned code is the whole key: a name alone reaches nothing, and
+  // a type alone is enough
   const { app, X } = makeApp();
   const wnd = consumer();
   X.event_consumers[5001] = wnd;
 
   await app.damage();
-  X.emit('event', {
+  const damage = {
     name: 'DamageNotify',
     level: 0,
     drawable: 5001,
@@ -148,7 +149,11 @@ test('a parsed event with a name but no type still routes', async () => {
     time: 0,
     area: { x: 1, y: 1, w: 2, h: 2 },
     geometry: { x: 0, y: 0, w: 9, h: 9 }
-  });
+  };
+  X.emit('event', damage);
+  assert.equal(wnd.delivered.length, 0, 'a name is not a route');
+
+  X.emit('event', { ...damage, name: undefined, type: EXTS.damage.firstEvent });
   assert.equal(wnd.delivered.length, 1);
   assert.equal(wnd.delivered[0].name, 'damage');
 });

--- a/test/pict-format.test.js
+++ b/test/pict-format.test.js
@@ -424,3 +424,39 @@ test('the table arriving late rebinds a context that guessed', async () => {
   assert.equal(ctx.picture.format, 'r5g6b5', 'the answer arrives and the picture is rebuilt');
   wnd.destroy();
 });
+
+test("the reply's own screens section names the format, indexed visuals included", () => {
+  // node-x11 >= 4.0.0 decodes screens/depths/visuals, which is the server's
+  // own visual -> format table: it covers what masks cannot (an indexed
+  // visual) and it wins over mask matching where both have an answer.
+  const display = {
+    screen: [
+      {
+        depths: {
+          8: { 10: { vid: 10, red_mask: 0, green_mask: 0, blue_mask: 0 } },
+          24: { 34: visual(34, 0xff0000, 0xff00, 0xff) },
+          16: { 40: visual(40, 0xf800, 0x7e0, 0x1f) }
+        }
+      }
+    ]
+  };
+  const reply = {
+    screens: [
+      {
+        fallback: 41,
+        depths: [
+          { depth: 8, visuals: [{ visual: 10, format: 21 }] },
+          { depth: 24, visuals: [{ visual: 34, format: 41 }] }
+        ]
+      }
+    ]
+  };
+  assert.deepEqual(
+    [...visualFormats(display, FORMATS, reply)],
+    [
+      [10, 21], // indexed — only the server can name this one
+      [34, 41],
+      [40, 53] // left out of the reply, so matched on masks
+    ]
+  );
+});


### PR DESCRIPTION
node-x11 4 lands three things ntk had been working around, so the bump comes
with the workarounds removed.

**The visual -> picture format mapping now comes from the server.**
QueryPictFormats carries a screens/depths/visuals section that node-x11's
parser used to drop, which is node-x11#280 — the note at the top of
`lib/pictformat.js` was waiting on exactly that. It decodes it as of 4.0.0,
so `visualFormats()` takes the reply and reads the server's own table, and
falls back to matching colour masks only for visuals the reply leaves out.
That gains *indexed* visuals: PseudoColor and friends carry no masks to
match on, so mask matching structurally cannot name their format and they
used to fall through to the depth-based guess.

**Extension events route by their type code alone.** Every extension parser
sets `event.type` since 4.0.0, which is node-x11#284 — DamageNotify and a
couple of others used to name themselves without one, so `_extEvents`
registered each event under its wire name as well. That fallback is now dead
and is gone. Verified rather than assumed: the routing was instrumented to
log any name-keyed hit, and across a full suite run exactly one fired — the
synthetic fixture in the test that pinned the old behaviour. That test now
pins the real contract instead: a name alone routes nothing, a type alone is
enough.

**One fewer round trip per connection.** node-x11 sends its own
QueryPictFormats while requiring RENDER — that is where `rgb24`, `rgba32`
and `a8` come from — and since 4.0.0 it keeps the reply as
`Render.pictFormats`. So `App#pictFormats()` reads that instead of asking the
server the same question a second time, and `connect()` no longer waits on a
reply of its own before handing back the app. The table is still built during
the handshake, so a picture bound synchronously still finds it.

The 4.0.1 half of the bump is node-x11#287, which caches QueryExtension
replies for the life of a connection. That makes the stated rationale for
`App#_extension`'s own cache stale — it was there because a probe that came
back *absent* was not remembered upstream and cost a round trip every time —
so the comment now says what the cache still earns its place for: one promise
per name, `_routeExtensionEvents` run once, and an absent extension answering
`null` instead of an error.

### close-event.test.js waits on the protocol, not the clock

Dropping that round trip made the connection settle sooner than
`test/close-event.test.js` expected. It waited a fixed 30ms in nineteen
places, and the one covering the fire-and-forget property write behind
`wnd.on('close')` was no longer wide enough under load — a real fragility
rather than a new bug, since nothing made 30ms the right number.

Every one of those sleeps is now a wait for the thing the test is actually
about, in the idiom `test/event-send.test.js` already uses:

- `advertised(wnd)` reads WM_PROTOCOLS until it names the atom, so the
  advertise is awaited rather than estimated
- `delivered()` is a round trip on the wm and then on the app: the first
  proves the server processed what the wm sent, the second proves the bytes
  the server wrote for the app arrived and were dispatched, since a reply
  cannot overtake an event already queued on the same stream

The file is also about 3.5x faster — 1.1s to 0.3s — because the sleeps were
most of its runtime.

### Testing

`node --test` against a real X server, on x11 4.0.1. Four full runs with the
round trip dropped, all clean; before the test rewrite the same change failed
one run in three.
