### PR TITLE
fix(window): adopt a window without selecting events on it

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -116,6 +116,17 @@ const ctx = wnd.getContext('2d');   // now binds the right picture format
   answer is written back to `wnd.x`/`y`/`width`/`height`/`depth`, and
   settles `ready` if it was still pending.
 
+Wrapping a window selects nothing on the server. X event masks are absolute
+per client — a `ChangeWindowAttributes` replaces this connection's whole
+selection on a window rather than adding to it — and what another client's
+window already had selected on it is not something ntk can know. So adoption
+asks the two questions above and writes nothing at all, and the events an
+adopted window emits are the ones you ask for, with `.on(...)` or
+[`selectInput`](#claiming-the-role). Ask through ntk rather than around it
+once you have: a raw absolute write of your own on the same window would
+overwrite the mask ntk has accumulated, and ntk's next selection would
+overwrite yours.
+
 Size and position also arrive on their own, as `resize`
 ([ConfigureNotify](#resize-fires-for-moves)) — the **depth and the visual** do
 not, and they are the ones nothing recovers from. `getContext('2d')` picks its
@@ -1104,7 +1115,8 @@ try {
 ```
 
 `selectInput(mask)` ORs `mask` into whatever handlers already asked for and
-resolves once the server accepts it. Handler-driven selection
+resolves once the server accepts it — or immediately, without a request, when
+this connection holds every bit already. Handler-driven selection
 (`root.on('map_request', ...)`, or the `onMapRequest` creation argument)
 still works and covers the ordinary case; `selectInput` exists for the mask
 that can be refused, because a rejected selection is the answer rather than

--- a/lib/window.js
+++ b/lib/window.js
@@ -788,6 +788,9 @@ export default class Window extends Drawable {
     });
 
     this.on('newListener', (name) => {
+      // one of ntk's own handlers going on, not a caller asking for an
+      // event: nothing to arm and nothing to select — see _listenInternal
+      if (this._internalListen) return;
       // Listening for 'close' is the opt-in. WM_DELETE_WINDOW only reaches a
       // client that advertised it in WM_PROTOCOLS — a window manager kills
       // anyone else outright — and having to know that, on top of decoding a
@@ -821,14 +824,29 @@ export default class Window extends Drawable {
         // error hook rather than dropping it; selectInput() is the
         // explicit form that hands the error straight back.
         X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask }, (err) => {
-          if (err) this.app.options.onXError?.(err);
+          if (!err) return;
+          // the request failed as a whole, so the server kept the mask it
+          // had: drop the bits again rather than leave `eventMask` claiming
+          // a selection this connection does not hold. selectInput() trusts
+          // it to decide whether a write can be skipped.
+          this.eventMask &= ~eventMask;
+          this.app.options.onXError?.(err);
         });
       }
     });
 
-    this.on('map', () => (this._mapped = true));
-    this.on('unmap', () => (this._mapped = false));
-    this.on('destroy', () => {
+    // ntk's own bookkeeping listens for the same events an app does, and the
+    // hook above reads a listener as a caller expressing interest and selects
+    // for it. For a window ntk created that is free — StructureNotify is in
+    // the CreateWindow value list already — but for an adopted one the
+    // tracked mask starts at zero and the write is absolute, so it would
+    // replace whatever this connection had selected on a window another
+    // client owns (issue #322). Subscribe past the hook: adopting a window
+    // costs no requests and changes no server-side state, and a caller that
+    // wants these events still asks for them, with on('map') or selectInput.
+    this._listenInternal('map', () => (this._mapped = true));
+    this._listenInternal('unmap', () => (this._mapped = false));
+    this._listenInternal('destroy', () => {
       this._destroyed = true;
       this._forget();
       this._teardownFrame(false); // the server has already taken the window
@@ -839,6 +857,24 @@ export default class Window extends Drawable {
 
     if (typeof this.width !== 'undefined') {
       this._settleReady();
+    }
+  }
+
+  /**
+   * Attach one of ntk's own handlers without the `newListener` hook reading
+   * it as a caller asking for the event. The hook's job is to turn expressed
+   * interest into a server-side selection; ntk's internal bookkeeping
+   * expresses none — it only wants the events that arrive anyway — and on an
+   * adopted window a selection nobody asked for overwrites another
+   * subsystem's (issue #322). The flag is read synchronously by the hook,
+   * which EventEmitter emits before the listener is stored.
+   */
+  _listenInternal(name, fn) {
+    this._internalListen = true;
+    try {
+      this.on(name, fn);
+    } finally {
+      this._internalListen = false;
     }
   }
 
@@ -3517,13 +3553,26 @@ export default class Window extends Drawable {
    * either makes you the window manager or rejects with BadAccess because
    * something else already is. The mask is OR-ed into whatever handlers
    * have already asked for.
+   *
+   * A mask this connection already holds is a request that would change
+   * nothing, so it resolves without one — `eventMask` is what this
+   * connection selected and nothing else adds to it behind the caller's
+   * back. It resolves rather than returning undefined because the promise is
+   * the whole interface: an awaited no-op still has to mean "you have it".
    */
   selectInput(mask) {
-    this.eventMask |= mask;
+    const added = mask & ~this.eventMask;
+    if (added === 0) return Promise.resolve(this);
+    this.eventMask |= added;
     return new Promise((resolve, reject) => {
-      this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask }, (err) =>
-        err ? reject(err) : resolve(this)
-      );
+      this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask }, (err) => {
+        if (!err) return resolve(this);
+        // a refused write left the server's mask as it was — give back the
+        // bits, or the next call would find them held and skip a request
+        // that has not happened yet
+        this.eventMask &= ~added;
+        reject(err);
+      });
     });
   }
 

--- a/test/select-input.test.js
+++ b/test/select-input.test.js
@@ -1,0 +1,184 @@
+// What wrapping a window costs the server, and what selectInput writes.
+// X event masks are absolute per client, so a selection ntk makes on a
+// window it did not create replaces whatever this connection had on it:
+// adopting a window must therefore ask for nothing (issue #322), and a
+// selection already held must not go out again. Hermetic — node-x11's
+// in-process pure-JS X server answers the GetWindowAttributes each
+// assertion reads the server's side of the story from.
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import x11 from 'x11';
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+import Window from '../lib/window.js';
+
+const { createServer, createStreamPair } = xserver;
+
+let server = null;
+let app = null;
+let other = null; // a second connection, for the masks only one client may hold
+
+const connect = async () => {
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+};
+
+// a fresh server per test: the root's selections are per connection, and a
+// leaked SubstructureRedirect would decide the next test's outcome
+beforeEach(async () => {
+  server = createServer({ width: 400, height: 300 });
+  app = await connect();
+});
+
+afterEach(() => {
+  app?.X.terminate();
+  other?.X.terminate();
+  server = app = other = null;
+});
+
+const maskOf = (client, wid) =>
+  new Promise((resolve, reject) =>
+    client.X.GetWindowAttributes(wid, (err, attrs) =>
+      err ? reject(err) : resolve(attrs.myEventMasks)
+    )
+  );
+
+const settle = (client) =>
+  new Promise((resolve) => client.X.GetInputFocus(() => setImmediate(resolve)));
+
+// counts the writes rather than trusting the resulting mask: a request that
+// rewrites the mask it found is invisible in the attributes afterwards
+const countWrites = (client) => {
+  const real = client.X.ChangeWindowAttributes;
+  const calls = { n: 0 };
+  client.X.ChangeWindowAttributes = (...args) => {
+    calls.n++;
+    return real.apply(client.X, args);
+  };
+  calls.restore = () => {
+    client.X.ChangeWindowAttributes = real;
+  };
+  return calls;
+};
+
+test('adopting a window selects nothing and keeps what the connection had', async () => {
+  const rootId = app.display.screen[0].root;
+  app.X.ChangeWindowAttributes(rootId, { eventMask: x11.eventMask.PropertyChange });
+  await settle(app);
+
+  const writes = countWrites(app);
+  const root = app.rootWindow();
+  await settle(app);
+  writes.restore();
+
+  assert.equal(writes.n, 0, 'wrapping a window is not a request');
+  assert.equal(root.eventMask, 0, 'and ntk claims no selection of its own');
+  assert.equal(
+    await maskOf(app, rootId),
+    x11.eventMask.PropertyChange,
+    'the selection made before the adoption survives it'
+  );
+});
+
+test('a created window still selects StructureNotify, and adopting it costs nothing', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  await settle(app);
+  assert.ok(
+    (await maskOf(app, wnd.id)) & x11.eventMask.StructureNotify,
+    'CreateWindow carried the mask ntk needs'
+  );
+
+  const writes = countWrites(app);
+  const again = new Window(app, { id: wnd.id });
+  await settle(app);
+  writes.restore();
+  assert.equal(again, wnd, 'the same wrapper comes back');
+  assert.equal(writes.n, 0);
+});
+
+test("ntk's own bookkeeping still runs on an adopted window that is listened to", async () => {
+  other = await connect();
+  const theirs = other.createWindow({ width: 40, height: 30 });
+  await settle(other);
+
+  const adopted = new Window(app, { id: theirs.id });
+  const mapped = new Promise((resolve) => adopted.once('map', resolve));
+  // the caller asking is what selects — after which the internal handlers
+  // that were installed silently see the same events
+  await adopted.selectInput(x11.eventMask.StructureNotify);
+  theirs.map();
+  await mapped;
+  assert.equal(adopted._mapped, true, "the 'map' handler ran");
+});
+
+test('selectInput does not write a mask the connection already holds', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  await settle(app);
+
+  const writes = countWrites(app);
+  // StructureNotify came with CreateWindow, so this adds nothing
+  const resolved = await wnd.selectInput(x11.eventMask.StructureNotify);
+  writes.restore();
+
+  assert.equal(writes.n, 0, 'no request for a selection already held');
+  assert.equal(resolved, wnd, 'and it still resolves with the window');
+});
+
+test('selectInput writes when it adds a bit, and ORs into the rest', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  await wnd.selectInput(x11.eventMask.PropertyChange);
+
+  const mask = await maskOf(app, wnd.id);
+  assert.ok(mask & x11.eventMask.PropertyChange, 'the new bit');
+  assert.ok(mask & x11.eventMask.StructureNotify, 'and the one it was added to');
+});
+
+test('a refused selection is not remembered as held', async () => {
+  other = await connect();
+  await other.rootWindow().selectInput(x11.eventMask.SubstructureRedirect);
+
+  const root = app.rootWindow();
+  const refused = (err) => err.error === 10; // BadAccess
+  await assert.rejects(
+    () => root.selectInput(x11.eventMask.SubstructureRedirect),
+    refused,
+    'another window manager owns the screen'
+  );
+  assert.equal(
+    root.eventMask & x11.eventMask.SubstructureRedirect,
+    0,
+    'the bit the server refused is not in the tracked mask'
+  );
+  // the second ask must reach the server too — a skipped write that
+  // resolved would report the role as taken when it is not
+  await assert.rejects(
+    () => root.selectInput(x11.eventMask.SubstructureRedirect),
+    refused,
+    'and asking again still asks'
+  );
+});
+
+test('a handler whose selection is refused leaves the mask honest', async () => {
+  other = await connect();
+  await other.rootWindow().selectInput(x11.eventMask.SubstructureRedirect);
+
+  const errors = [];
+  app.options.onXError = (err) => errors.push(err);
+  const root = app.rootWindow();
+  root.on('map_request', () => {});
+  await settle(app);
+
+  assert.ok(errors.length > 0, 'the failure reached the app error hook');
+  assert.ok(
+    errors.every((err) => err.error === 10),
+    'as BadAccess'
+  );
+  assert.equal(root.eventMask & x11.eventMask.SubstructureRedirect, 0);
+  await assert.rejects(
+    () => root.selectInput(x11.eventMask.SubstructureRedirect),
+    (err) => err.error === 10
+  );
+});


### PR DESCRIPTION
X event masks are absolute per client, so a `ChangeWindowAttributes`
replaces this connection's whole selection on a window rather than adding
to it. `Window`'s constructor subscribed its own bookkeeping — `_mapped`,
`_destroyed` — through the public emitter, which trips the `newListener`
hook that exists to turn *a caller's* expressed interest into a server-side
selection. For a window ntk created that is free, StructureNotify being in
the `CreateWindow` value list already; for an adopted one the tracked mask
starts at zero and the write goes out absolute, discarding whatever else
the connection had selected on a window another client owns.

The reproduction from the issue, before and after:

```
                                    before     after
1. after the app selected PropertyChange  0x400000   0x400000
2. after app.rootWindow()                 0x20000    0x400000
3. after selectInput(StructureNotify)     0x20000    0x20000
```

Step 2 is the bug: no listener was added and no selection asked for, and
the app's PropertyChange was gone. The two masks then disagreed
permanently, so every later `selectInput` OR-ed into a fiction.

## What changed

- The three internal handlers go on past the hook, through a small
  `_listenInternal` helper. Adoption now writes nothing at all — it still
  asks its `GetGeometry`/`GetWindowAttributes` pair, and that is all. A
  caller that wants those events still asks for them, with `on('map')` or
  `selectInput`.
- `selectInput` skips the request when this connection holds every bit
  already, and resolves — `undefined` would break the callers that await
  it, and the promise is the whole interface. `sharedglyphs.js:150` was
  the in-tree case: it selected StructureNotify on a root the adoption two
  lines earlier had just selected it on.
- Skipping is only safe while the tracked mask cannot claim a selection
  the server refused, so a failed write gives its bits back on both paths
  — the handler-driven one and `selectInput`. Without that, a rejected
  `selectInput(SubstructureRedirect)` would leave the bit set and the next
  ask would resolve without a request, reporting the window manager role
  as taken when it is not.

## Notes

- Step 3 still overwrites the raw PropertyChange, because that selection
  was made around ntk rather than through it. That is the shape the
  accumulator has always had; sidorares/react-x11#388 is the matching fix
  on the other side. `docs/window.md` now says so where adoption is
  described.
- One behaviour follows from adoption selecting nothing: an adopted window
  that nobody listens to and whose parent this connection has no
  SubstructureNotify on will not hear its own DestroyNotify, so its
  wrapper stays in the per-connection cache. Nothing in the tree is in
  that position — a window manager holds SubstructureNotify on the root
  and node-x11 routes DestroyNotify by the destroyed window's id, xembed
  selects on the clients it adopts, and the root is never destroyed.

## Testing

`test/select-input.test.js`, hermetic against node-x11's in-process X
server, reading the server's side back with `GetWindowAttributes` and
counting the writes (a request that rewrites the mask it found is
invisible in the attributes afterwards): adoption selects nothing and
keeps what was there, a created window still gets StructureNotify from
`CreateWindow`, the internal bookkeeping still runs once a caller has
selected, `selectInput` skips a no-op and writes a real one, and a refused
selection is not remembered as held on either path.

Full suite: 1077 pass, 4 pre-existing failures on `master` here (RENDER
and Damage against this machine's X server, unrelated).

Fixes #322
