### PR TITLE
fix(window): adopt nothing on a closing connection, so a routed event cannot throw

### DIFF
--- a/docs/resource-management.md
+++ b/docs/resource-management.md
@@ -45,6 +45,16 @@ Cleanup — explicit or GC-driven — becomes a silent no-op once the connection
 is closing or closed: the X server frees all of a client's resources on
 disconnect, so late finalizers after `app.close()` have nothing left to do.
 
+The same holds for the bookkeeping the event dispatch does on its own.
+`app.close()` flags the connection immediately and then drains what is still
+in the read buffer, so events keep being delivered for a moment afterwards —
+including substructure events, which adopt a `Window` for the child they name.
+Those adoptions ask the server nothing once the connection is going away:
+`ready` resolves with the geometry still unknown, exactly as it does for a
+window that was destroyed before the reply came back. Nothing on that path
+throws, so a program that watches a window's children can exit while its
+notifications are still arriving.
+
 ## The connection keeps the process alive
 
 An open X connection holds the node event loop open. Call

--- a/docs/window.md
+++ b/docs/window.md
@@ -108,7 +108,9 @@ const ctx = wnd.getContext('2d');   // now binds the right picture format
   window need not know where it came from. It never rejects — a window
   destroyed before the replies arrive resolves all the same, with `width`
   still `undefined`, and the next request sent to it is what reports that it
-  is gone.
+  is gone. A window adopted while the connection is closing resolves the same
+  way, having asked nothing: adopting is what a substructure event does, and
+  those keep arriving for a moment after `app.close()`.
 - `wnd.getGeometry()` → `Promise<{ x, y, width, height, depth, borderWidth,
   root }>` — ask the server where the window is *now*, rather than take what
   the event stream last said. `x`/`y` are relative to the parent, as X

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,3 +1,4 @@
+import { connectionGone } from './cleanup.js';
 import Clipboard from './clipboard.js';
 import { CursorCache } from './cursor.js';
 import { GLError, backendFor, glCapabilities, glError, resolveGLPolicy } from './gl.js';
@@ -253,6 +254,12 @@ export default class App {
   _probeRefreshRate() {
     this._refreshProbe = null; // in progress; only ever started once
     const X = this.X;
+    // A connection on its way out is one more "no rate to be had". The probe
+    // is started lazily by the first window built on this connection, which
+    // may be one adopted from an event still arriving as it closes — and
+    // node-x11 throws synchronously at a request from then on, where the
+    // event dispatch has no caller to catch it (issue #321).
+    if (connectionGone(X)) return;
     X.require('randr', (err, R) => {
       if (err || !R) return;
       const root = this.display.screen[0].root;

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -1,11 +1,27 @@
-// Release a server-side resource, tolerating a connection that is closing or
-// already gone — the X server frees all of a client's resources on disconnect,
-// so there is nothing left to do and nothing worth throwing about. This
-// matters for FinalizationRegistry callbacks, which run after app.close() if
-// wrappers get garbage collected late and have no user code around them to
-// catch.
+/**
+ * Whether a request issued now would throw rather than reach the server.
+ * node-x11 throws *synchronously* ("client is in closing state") once
+ * `close()` has begun, and a destroyed or ended stream is the same state one
+ * step further along.
+ *
+ * The check matters wherever a request is issued from somewhere with no
+ * caller to catch: a FinalizationRegistry callback, a paced frame's timer, or
+ * the X event dispatch itself — events already in the read buffer keep being
+ * delivered after `close()` (issue #321).
+ */
+export function connectionGone(X) {
+  return !!(X._closing || !X.stream || X.stream.destroyed || X.stream.writableEnded);
+}
+
+// Issue requests — typically releasing a server-side resource — tolerating a
+// connection that is closing or already gone. The X server frees all of a
+// client's resources on disconnect, so there is nothing left to do and
+// nothing worth throwing about. This matters wherever the requests have no
+// caller around them to catch: FinalizationRegistry callbacks, which run
+// after app.close() if wrappers get garbage collected late, a paced frame's
+// timer, and the X event dispatch (issue #321).
 export function safeRelease(X, fn) {
-  if (X._closing || !X.stream || X.stream.destroyed || X.stream.writableEnded) return;
+  if (connectionGone(X)) return;
   try {
     fn();
   } catch {

--- a/lib/window.js
+++ b/lib/window.js
@@ -1,7 +1,7 @@
 import x11 from 'x11';
 
 import { builtin } from './builtin.js';
-import { safeRelease } from './cleanup.js';
+import { connectionGone, safeRelease } from './cleanup.js';
 import Drawable from './drawable.js';
 import { packIcons, unpackIcons } from './imagedata.js';
 import Pixmap from './pixmap.js';
@@ -606,22 +606,34 @@ export default class Window extends Drawable {
       // client chose the visual for (issue #295). They go out in the same
       // batch, so the pair costs one round trip, not two, and `ready` is the
       // wait for both.
-      this._readyPending = 2;
-      X.GetGeometry(this.id, (err, res) => {
-        // A window that was destroyed between the id reaching us and this
-        // request reaching the server answers BadWindow, and there is
-        // nothing to record. `ready` still resolves: adopting a window that
-        // has since gone is ordinary for a window manager, and a wait that
-        // never ends is worse than one that ends with width undefined.
-        this._readyPending--;
-        if (err) this._settleReady();
-        else this._applyGeometry(unpackGeometry(res));
-      });
-      X.GetWindowAttributes(this.id, (err, attrs) => {
-        this._readyPending--;
-        if (!err) this.visualId = attrs.visual;
+      //
+      // Nothing is asked of a connection that is going away: node-x11 throws
+      // synchronously at a request once close() has begun, and adoption
+      // happens from places with no caller to catch — a routed child-event,
+      // XEmbed, the shared glyph cache all build windows from inside the X
+      // event dispatch (issue #321). There is nothing to learn there either,
+      // so `ready` settles with the geometry unknown, the same outcome as a
+      // window destroyed before its reply landed (see the getter).
+      this._readyPending = connectionGone(X) ? 0 : 2;
+      if (this._readyPending) {
+        X.GetGeometry(this.id, (err, res) => {
+          // A window that was destroyed between the id reaching us and this
+          // request reaching the server answers BadWindow, and there is
+          // nothing to record. `ready` still resolves: adopting a window that
+          // has since gone is ordinary for a window manager, and a wait that
+          // never ends is worse than one that ends with width undefined.
+          this._readyPending--;
+          if (err) this._settleReady();
+          else this._applyGeometry(unpackGeometry(res));
+        });
+        X.GetWindowAttributes(this.id, (err, attrs) => {
+          this._readyPending--;
+          if (!err) this.visualId = attrs.visual;
+          this._settleReady();
+        });
+      } else {
         this._settleReady();
-      });
+      }
     }
 
     Window._cacheFor(app).set(this.id, this);
@@ -779,6 +791,12 @@ export default class Window extends Drawable {
     this.on('child-event', (ev) => {
       const eventName = xevents.eventName[ev.type];
       if (!eventName) return;
+      // Events buffered before `close()` keep being dispatched after it, and
+      // a window this client already saw destroyed has no substructure left
+      // to report. Neither is worth building a child for — and the questions
+      // the constructor would ask on the way out are what used to throw into
+      // the dispatcher (issue #321).
+      if (this._destroyed || connectionGone(X)) return;
       const child = new Window(app, { id: ev.wid });
       const ntkev = { ...ev, parent: this, window: child, target: child };
       // wait until we know that we track correct x,y,w,h values
@@ -817,6 +835,13 @@ export default class Window extends Drawable {
       const eventMask = xevents.mask[name];
       if (!eventMask) return;
       if ((eventMask & this.eventMask) === 0) {
+        // A connection on its way out can select nothing, and node-x11 throws
+        // synchronously at a request from then on. This hook runs from
+        // `.on()` — including the calls made while adopting a window from
+        // inside the X event dispatch, where there is no caller to catch it
+        // (issue #321). Before the mask is touched, so it goes on saying what
+        // this connection holds.
+        if (connectionGone(X)) return;
         this.eventMask |= eventMask;
         // the selection can legitimately fail — SubstructureRedirect is
         // one-client-only, so `on('map_request')` is how you find out
@@ -1134,7 +1159,11 @@ export default class Window extends Drawable {
 
   _handleExpose(ev) {
     if (this._backingValid) {
-      this.X.CopyArea(this._backing.id, this.id, this._presentGc, ev.x, ev.y, ev.x, ev.y, ev.width, ev.height);
+      // an expose can arrive after the connection started closing, and this
+      // runs inside the event dispatch where a throw has no caller (#321)
+      safeRelease(this.X, () => {
+        this.X.CopyArea(this._backing.id, this.id, this._presentGc, ev.x, ev.y, ev.x, ev.y, ev.width, ev.height);
+      });
     } else {
       this._requestRedraw();
     }

--- a/test/closing-dispatch.test.js
+++ b/test/closing-dispatch.test.js
@@ -1,0 +1,100 @@
+// Regression: the X event dispatch keeps delivering events that were already
+// in the read buffer after app.close() has set the client's _closing flag, and
+// node-x11 throws 'client is in closing state' synchronously at any request
+// issued from then on. A routed 'child-event' built a Window for the event's
+// target, whose constructor asks GetGeometry/GetWindowAttributes for an
+// adopted id — so a SubstructureNotify arriving on the way out threw from
+// inside the stream read handler, where nothing can catch it, and the process
+// died with an uncaughtException (issue #321, found by react-x11's
+// out-of-process frame panes exiting 1 instead of 0).
+//
+// Same family as test/window-title-close-race.test.js, one layer earlier: not
+// a reply callback issuing a follow-up, but the event dispatch itself. The
+// failure mode is an uncaught exception that takes the process down, so the
+// assertion is mostly completing cleanly.
+//
+// Hermetic: in-process pure-JS X server, no $DISPLAY.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import x11 from 'x11';
+import xserver from 'x11/lib/xserver/index.js';
+
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const { createServer, createStreamPair } = xserver;
+
+function freshServer() {
+  const server = createServer({ width: 400, height: 300 });
+  return async () => {
+    const [serverEnd, clientEnd] = createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+  };
+}
+
+// let the notifications still in flight reach the closing client, and any
+// callbacks scheduled behind them fire, before the test is declared done
+const settle = () => new Promise((resolve) => setTimeout(resolve, 100));
+
+test('a child-event arriving as the connection closes does not crash', async () => {
+  const connect = freshServer();
+  const watcher = await connect();
+  const other = await connect();
+
+  // adopt the root and ask to hear about its children — what any window
+  // manager does, and what rootWindow() + a text-drawing app does by way of
+  // the shared glyph cache
+  const root = watcher.rootWindow();
+  await root.selectInput(x11.eventMask.SubstructureNotify);
+
+  // somebody else fills the root with windows; the watcher is told about each
+  for (let i = 0; i < 40; i++) {
+    const id = other.X.AllocID();
+    other.X.CreateWindow(id, other.X.display.screen[0].root, 0, 0, 10, 10, 0, 0, 0, 0, {});
+    other.X.MapWindow(id);
+  }
+  other.X.flush();
+
+  // …and the watcher goes away while those notifications are still arriving,
+  // which is what any short-lived process does at exit
+  watcher.X.close();
+  await settle();
+
+  assert.ok(root, 'the create notifications drained without throwing');
+  other.X.terminate();
+});
+
+test('adopting a window on a closing connection resolves ready, and does not throw', async () => {
+  const connect = freshServer();
+  const app = await connect();
+  const rootId = app.display.screen[0].root;
+
+  await app.close();
+
+  // every adoption site — a routed child-event, xembed.js, sharedglyphs.js —
+  // reaches this constructor from somewhere with no caller to catch
+  const wnd = app.createWindow({ id: rootId });
+  const settled = await Promise.race([
+    wnd.ready,
+    new Promise((resolve) => setTimeout(() => resolve(null), 200))
+  ]);
+  assert.equal(settled, wnd, 'ready resolves rather than waiting for a reply that cannot come');
+  assert.equal(wnd.width, undefined, 'with the geometry unknown, as for a window already gone');
+});
+
+test('listening on an adopted window after close does not throw', async () => {
+  const connect = freshServer();
+  const app = await connect();
+  const rootId = app.display.screen[0].root;
+  const wnd = app.createWindow({ id: rootId });
+  await wnd.ready;
+
+  await app.close();
+
+  // a new listener extends the server-side event mask, which is one more
+  // request with nowhere to report a failure
+  wnd.on('mousedown', () => {});
+  await settle();
+  assert.ok(wnd, 'the selection was dropped rather than thrown');
+});


### PR DESCRIPTION
`Window`'s `child-event` handler built a `Window` for the event's target
unconditionally, and the constructor asks `GetGeometry`/`GetWindowAttributes`
for an adopted id. node-x11 throws **synchronously** at a request once
`close()` has begun, and `app.close()` then drains whatever is already in the
read buffer — so a substructure notification arriving on the way out threw
from inside the X event dispatch, where there is no caller to catch it, and
the process died with an `uncaughtException`.

Any program that watches a window's children and then exits could die on the
way out with an exit code that is not its own. It is not only window
managers: `sharedglyphs.js` adopts the root on the first glyph a client draws,
so it sits on the default path for any ntk app that draws text and exits
promptly.

## The fix

Declined at both ends, so every adoption site is covered rather than the one
handler:

- **The constructor asks nothing of a connection that is going away.** `ready`
  settles with the geometry still unknown — the same outcome as a window
  destroyed before its reply landed, which the getter already documents. This
  is what covers `xembed.js` and `sharedglyphs.js` too.
- **`child-event` builds no child** once the connection is closing, or once
  this window has seen its own `destroy`.
- **The rest of the dispatch's bookkeeping goes through the same tolerance** —
  the expose blit, the event mask a new listener extends, and the lazy
  refresh-rate probe that a first window starts. Each of them is a request
  issued with no caller around it, and each one throws on a closing
  connection: the probe and the mask are what the reproduction hits next once
  the constructor stops throwing. In the `newListener` hook the check comes
  *before* `eventMask` is OR-ed, so the tracked mask goes on saying what this
  connection actually holds — the invariant #323 introduced.

`connectionGone(X)` is the check `safeRelease` already made inline, named and
exported so the paths that decline work rather than release a resource can ask
the same question.

## Verification

The issue's reproduction, unchanged: 5/5 `UNCAUGHT: client is in closing
state`, exit 3, before — 5/5 `no crash`, exit 0, after.

`test/closing-dispatch.test.js` is the regression suite, hermetic against
node-x11's in-process JS server: a child-event storm delivered into a closing
connection, an adoption after `close()` that must settle `ready` instead of
throwing, and a listener added after `close()` whose mask extension must be
dropped rather than thrown. All three fail on master, pass here.

Full suite: 1084 passing, 0 failing, 3 skipped, against XQuartz — rebased on
master with #323, whose `newListener` change this touches the same lines of.

Fixes #321
