### PR TITLE
feat(gl): direct rendering on macOS/XQuartz via the Apple-DRI extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,12 @@ client) with familiar, modern API concepts:
   composition, gradients and glyph drawing happen **server-side**
 - a webgl-ish **opengl context** over indirect GLX (OpenGL 1.4 command
   serialization, no client GL library)
-- a **direct rendering context** — OpenGL ES 2 on the GPU, frames handed to
-  the server as dma-buf descriptors over DRI3 + Present — where the optional
-  `x11-dri` addon and a local DRI3 server are both there. Off by default;
-  `glPolicy` chooses (docs/context-gles.md)
+- a **direct rendering context** — shader GL on the GPU with no pixels on
+  the socket, where the optional `x11-dri` addon and a local server that can
+  take it are both there. Two flavors behind one contract: OpenGL ES 2 with
+  frames handed over as dma-buf descriptors via DRI3 + Present (Linux), and
+  CGL drawing into the window surface the server exports via Apple-DRI
+  (macOS/XQuartz). Off by default; `glPolicy` chooses (docs/context-gles.md)
 
 ### Direction
 
@@ -65,12 +67,19 @@ lib/renderingcontext_opengl.js  indirect GLX context (queues GL commands
                            until MakeCurrent's context tag arrives)
 lib/glx.js                 GLX visual/fbconfig discovery (app.chooseGLXConfig)
 lib/gl.js                  which GL backend, and whether it can: glPolicy,
-                           the x11-dri probe, GLError, app.glCapabilities()
-lib/renderingcontext_gles.js    direct rendering context (OpenGL ES 2 on the
-                           GPU); also wraps the 'opengl' factory so that name
-                           dispatches on glPolicy
+                           the x11-dri probe, GLError, app.glCapabilities(),
+                           the direct flavor per platform (dri3 / appledri)
+lib/renderingcontext_gles.js    direct rendering context, dri3 flavor
+                           (OpenGL ES 2 on the GPU); also wraps the 'opengl'
+                           factory so that name dispatches on glPolicy
 lib/glswapchain.js         its buffers: dma-buf -> DRI3 pixmap -> Present,
                            recycled on IdleNotify, generations across resizes
+lib/appledri.js            the Apple-DRI protocol binding (XQuartz's
+                           direct-rendering extension): requests, replies,
+                           the SurfaceNotify event, the extension errors
+lib/renderingcontext_cgl.js     direct rendering context, appledri flavor
+                           (CGL into the server-exported window surface);
+                           wraps 'opengl' above the gles module's dispatch
 lib/renderingcontext_x11.js     raw core-X drawing context
 lib/picture.js             XRender Picture wrapper (+ blur filter)
 lib/pictformat.js          which RENDER picture format describes a drawable:

--- a/README.md
+++ b/README.md
@@ -122,9 +122,16 @@ Server-side resources support `using` / `await using` (Node 24+):
 
 ## 3d graphics
 
-Only indirect GLX is supported, with most of the OpenGL 1.4 api implemented.
-Note that on many systems indirect GLX is disabled by default —
-[you'll need to enable it for gl to work](https://github.com/sidorares/node-x11/issues/117#issuecomment-214762185).
+Two backends, chosen by `glPolicy`
+([docs/context-gles.md](docs/context-gles.md)):
+
+- **direct** (opt-in) — shader GL on the real GPU with no pixels on the
+  socket: OpenGL ES 2 over DRI3 + Present on Linux, CGL over the Apple-DRI
+  extension on macOS/XQuartz. Needs the optional `x11-dri` addon.
+- **indirect GLX** (default) — most of the OpenGL 1.4 api, serialized into
+  the X connection. Note that on many systems indirect GLX is disabled by
+  default —
+  [you'll need to enable it for gl to work](https://github.com/sidorares/node-x11/issues/117#issuecomment-214762185).
 
 ```js
 import { createClient } from 'ntk';

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,8 +41,9 @@ matching file here (see AGENTS.md).
 - [SVG widget](svg.md) — `SvgView`: static SVG rendering through the 2d
   context (shapes, gradients, transforms, `use`), plus `Path2D`/SVG path data
 - [OpenGL rendering context](context-opengl.md) — indirect GLX / OpenGL 1.4 API
-- [Direct rendering](context-gles.md) — OpenGL ES 2 on the GPU, frames handed to
-  the server over DRI3 + Present; `glPolicy` and what makes it available
+- [Direct rendering](context-gles.md) — shader GL on the GPU with no pixels on
+  the socket: DRI3 + Present on Linux, Apple-DRI + CGL on macOS/XQuartz;
+  `glPolicy` and what makes it available
 - [Raw X11 rendering context](context-x11.md) — core X drawing requests
 - [Resource management](resource-management.md) — `using` / `Symbol.dispose`, GC-based cleanup
 - [Packaging](packaging.md) — bundling to one file, and shipping a single

--- a/docs/context-gles.md
+++ b/docs/context-gles.md
@@ -1,8 +1,7 @@
-# Direct rendering: OpenGL ES 2 on the GPU
+# Direct rendering: shader GL on the GPU
 
-ntk can draw a window's contents on the GPU and hand the finished frame to
-the X server as a buffer it already has — no pixels on the socket, no GL
-commands on the socket, and a modern shader pipeline instead of a
+ntk can draw a window's contents on the GPU with no pixels on the socket, no
+GL commands on the socket, and a modern shader pipeline instead of a
 fixed-function one.
 
 This is the **direct** backend. The other one, [indirect
@@ -10,6 +9,21 @@ GLX](context-opengl.md), serializes GL commands into the X connection and is
 what ntk has always used. They are different pipelines with different APIs,
 and which one a window gets is [`glPolicy`](#glpolicy) — whose default is
 still `indirect`, so nothing changes until you ask.
+
+The direct backend comes in two *flavors*, one per platform, behind one
+context contract and one `gl` API:
+
+- **`dri3`** (Linux): OpenGL ES 2 on a DRM render node, finished frames
+  handed to the server as dma-buf descriptors over DRI3 + Present.
+- **`appledri`** ([macOS/XQuartz](#macos)): the server exports the window's
+  WindowServer surface over the Apple-DRI extension, and a CGL context draws
+  straight into it — Apple's GL-on-Metal, ES2-compatible, so the same
+  shaders compile.
+
+Draw code does not choose between them: `getContext('opengl')` picks the
+flavor for the platform, and everything below applies to both except where a
+flavor is named. The Linux flavor is described first; [macOS](#macos) covers
+what differs.
 
 ![A shaded cube in an ntk window, its faces patterned by a fragment shader](img/direct-gl-cube.png)
 
@@ -33,6 +47,7 @@ wnd.map();
 
 const gl = wnd.getContext('opengl', config);
 await gl.ready; // the whole path is proven, or this rejects with a reason
+draw(); // an expose that raced `ready` had nothing to present into yet
 
 function draw() {
   gl.makeCurrent();
@@ -44,7 +59,7 @@ function draw() {
 }
 ```
 
-## How it works
+## How it works (the `dri3` flavor)
 
 ```
 GPU (DRM render node)                     X server
@@ -111,11 +126,16 @@ Object form knobs, over `DEFAULT_GL_POLICY`:
 | `maxInFlight` | `2` | presents outstanding before a frame waits for a buffer |
 | `linearFallback` | `true` | retry a refused buffer once with a linear layout, which is what makes rendering on one GPU and displaying on another work |
 
+The three knobs below `mode` describe dma-buf machinery the `appledri`
+flavor does not have — it ignores them silently.
+
 ## What is available, and why not
 
 ```js
 const caps = await app.glCapabilities();
-// { direct: true, indirect: true, device: '/dev/dri/renderD128', reason: null }
+// { direct: true, indirect: true, flavor: 'dri3',
+//   device: '/dev/dri/renderD128', reason: null }
+// — and on macOS/XQuartz: { direct: true, flavor: 'appledri', device: null }
 ```
 
 `reason` is an `Error` whose `code` is one of `GLError` — branch on the code,
@@ -124,13 +144,15 @@ not the message:
 | code | meaning | remedy |
 | --- | --- | --- |
 | `GL_NO_ADDON` | `x11-dri` is not installed | `npm install x11-dri` |
-| `GL_NO_DRIVER` | no `libgbm`/`libEGL`/`libGLESv2`, or not Linux | install Mesa; direct rendering is Linux-only |
-| `GL_NO_DEVICE` | no readable `/dev/dri/renderD*` | map the device into the container, or join the `render` group |
+| `GL_NO_DRIVER` | the platform libraries are missing — `libgbm`/`libEGL`/`libGLESv2` on Linux, libXplugin/OpenGL.framework on macOS — or the platform has no direct path | install Mesa / install XQuartz; elsewhere direct rendering does not exist |
+| `GL_NO_DEVICE` | no readable `/dev/dri/renderD*` (Linux) | map the device into the container, or join the `render` group |
 | `GL_REMOTE_DISPLAY` | a TCP or forwarded display | direct rendering is local-only; use indirect over a network |
-| `GL_NO_FD_PASSING` | local display, but this runtime cannot pass a descriptor | run under Node — Bun does not implement the internal x11 uses |
-| `GL_NO_DRI3` | the server has no DRI3/Present | Xvfb, Xephyr and XQuartz have none |
+| `GL_NO_FD_PASSING` | local display, but this runtime cannot pass a descriptor (`dri3` flavor only) | run under Node — Bun does not implement the internal x11 uses |
+| `GL_NO_DRI3` | the server has no DRI3/Present | Xvfb, Xephyr and XQuartz have none (XQuartz has [its own path](#macos)) |
+| `GL_NO_APPLEDRI` | macOS, and the server has no usable Apple-DRI | is the display an XQuartz server? |
+| `GL_NO_WINDOWSERVER` | macOS, but no WindowServer session — SSH | run from the logged-in GUI session |
 | `GL_IMPORT_FAILED` | the server refused the buffer | usually different DRM devices — set `devicePath` |
-| `GL_CONTEXT_FAILED` | GBM/EGL setup failed | the message says what did |
+| `GL_CONTEXT_FAILED` | GPU context setup failed | the message says what did |
 | `GL_DISABLED` | `glPolicy: 'off'` | — |
 
 The probe runs during `createClient()` whenever the policy could choose
@@ -142,28 +164,28 @@ be created.
 
 ### Runtimes
 
-Direct rendering needs a runtime that can send a file descriptor over a unix
-socket, because that is how DRI3 hands the server a buffer. `x11` does it
-through Node's internal `process.binding('pipe_wrap')`, so:
+The `dri3` flavor needs a runtime that can send a file descriptor over a
+unix socket, because that is how DRI3 hands the server a buffer. `x11` does
+it through Node's internal `process.binding('pipe_wrap')`, so:
 
-| runtime | direct | indirect |
-| --- | --- | --- |
-| Node | yes | yes |
-| Bun | **no** — `process.binding('pipe_wrap')` is not implemented | yes |
+| runtime | direct (`dri3`) | direct (`appledri`) | indirect |
+| --- | --- | --- | --- |
+| Node | yes | yes | yes |
+| Bun | **no** — `process.binding('pipe_wrap')` is not implemented | yes — no descriptor ever crosses the socket | yes |
 
-Under Bun the capability probe reports `GL_NO_FD_PASSING` and `'auto'` falls
-back to indirect GLX, which needs no descriptor passing at all. Nothing else
-about the display has to change.
+Under Bun on Linux the capability probe reports `GL_NO_FD_PASSING` and
+`'auto'` falls back to indirect GLX, which needs no descriptor passing at
+all. Nothing else about the display has to change.
 
 ## The API is not the GLX one
 
-| | direct (`'gles'`) | indirect (`'opengl'`) |
+| | direct | indirect (`'opengl'`) |
 | --- | --- | --- |
-| pipeline | OpenGL ES 2.0 | OpenGL 1.x fixed-function |
+| pipeline | OpenGL ES 2.0 (`dri3`) / desktop GL, ES2-compatible (`appledri`) | OpenGL 1.x fixed-function |
 | naming | `gl.clearColor`, `gl.drawArrays` | `gl.ClearColor`, `gl.Begin` |
 | shaders | **yes**, GLSL ES 1.00 | none — the protocol encodes no shader objects |
 | geometry | VBOs, `drawArrays`/`drawElements` | immediate mode + display lists |
-| reach | local connections, Linux, a GPU | any server allowing indirect contexts |
+| reach | local connections, Linux or macOS/XQuartz, a GPU | any server allowing indirect contexts |
 
 Code that runs on either branches on `gl.backend`, which is `'direct'` or
 `'indirect'`:
@@ -174,8 +196,11 @@ else gl.Clear(gl.COLOR_BUFFER_BIT);
 ```
 
 `getContext('opengl')` is the backend-neutral name and obeys the policy.
-`getContext('gles')` asks for the direct one by name and throws if it is not
-available — useful when the code only knows how to drive ES 2 anyway.
+`getContext('gles')` asks for the Linux direct flavor by name and
+`getContext('cgl')` for the macOS one; each throws where its flavor is not
+the one available — useful when the code wants no silent substitution.
+Direct contexts also carry `gl.flavor` (`'dri3'` or `'appledri'`) for the
+rare code that cares which pipeline is under it.
 
 The ES 2 surface is whatever `x11-dri` exposes, which is the core of ES 2
 (shaders, programs, uniforms, buffers, attributes, draws, `readPixels`) and
@@ -184,10 +209,12 @@ entry point is a small wrapper in that package.
 
 ### Context lifetime
 
-- **One GPU context per app and pixel format.** Programs, buffers and other
-  GL objects are shared between surfaces on a connection, the way they are
-  between canvases in a browser tab, and exactly one surface is current at a
-  time.
+- **One GPU context per app and pixel format** on the `dri3` flavor.
+  Programs, buffers and other GL objects are shared between surfaces on a
+  connection, the way they are between canvases in a browser tab, and
+  exactly one surface is current at a time. (The `appledri` flavor owns one
+  CGL context per window instead — see [macOS](#macos); code that caches GL
+  resources by the `gl` object identity is correct on both.)
 - `gl.makeCurrent()` binds this context's surface and picks up a resize —
   call it at the top of every frame. Individual `gl.*` calls also bind if
   another surface stole currency, so a stray call cannot draw into the wrong
@@ -220,6 +247,11 @@ entry point is a small wrapper in that package.
   shows them at the next vblank and may flip rather than copy. Frame *pacing*
   is still the window's frame clock ([window.md](window.md)); the swap chain
   only bounds how many frames can be in flight.
+- The `appledri` flavor keeps the same contract with different machinery
+  underneath: there is no swap chain and the server applies no backpressure,
+  so each `SwapBuffers()` closes the `canRender()` gate itself for one
+  display period and `onFrameAvailable` reopens it. A loop written as above
+  runs at ~display rate on both flavors.
 
 ### Draw on expose
 
@@ -233,6 +265,65 @@ draws on expose:
 wnd.on('expose', draw); // adding the listener is what selects Exposure
 wnd.map();
 ```
+
+## macOS
+
+XQuartz never implemented DRI3 — its direct rendering is the **Apple-DRI**
+extension, and it runs the transfer the other way round. Where DRI3 is
+client-allocates-and-pushes, Apple-DRI is server-exports-and-attaches:
+
+```
+this process                              X server (XQuartz)
+------------                              ------------------
+apple.clientId()  --- AppleDRICreateSurface(win, cid) --->  exports the
+                  <-------------- key[2] ----------------   window's surface
+ctx.attach(key)      (import surface + bind a CGL context)
+gl draws straight into the window's backing store
+ctx.flush()          (CGLFlushDrawable — the WindowServer composites)
+                  <--- AppleDRISurfaceNotify ------------   moved / resized /
+                                                            destroyed
+```
+
+After the attach, nothing crosses the X socket per frame — no pixels, no
+descriptors, no requests. Rendering is the real GPU (Apple's GL-on-Metal;
+`gl.renderer` reports the chip), and the same `gl` API and the same GLSL ES
+1.00 shaders as the Linux flavor. The pieces:
+
+| piece | what it is | where it comes from |
+| --- | --- | --- |
+| `x11-dri` >= 0.5.0 | the WindowServer handshake, the surface import and the CGL context | the same optional dependency, prebuilt for macOS arm64 |
+| Apple-DRI | exports a window's surface to a local process | the X server — XQuartz only |
+| a GUI session | the WindowServer connection surfaces are imported into | log in at the machine; SSH sessions report `GL_NO_WINDOWSERVER` |
+
+The protocol half — the requests, the reply layouts and the
+`AppleDRISurfaceNotify` event — is pure JS in `lib/appledri.js`; the halves
+that cannot be (Xplugin, CGL) are the addon's `dri.apple` namespace.
+
+What differs from the `dri3` flavor, beyond the wire:
+
+- **The surface exists only while the window is mapped.** The context is
+  created synchronously and `gl.*` works immediately (shaders compile,
+  FBOs render), but `gl.ready` settles — and `canRender()` first turns
+  true — after `map()`, when the server has a physical window to export.
+  Unmapping destroys the surface (`AppleDRISurfaceNotify` says so) and the
+  context re-attaches by itself on the next map. The draw-on-expose pattern
+  above absorbs all of this without extra code.
+- **One CGL context per window**, not a shared one per app: a CGL context
+  attaches to exactly one surface. GL resources are therefore per-window on
+  this flavor; cache them by the `gl` object identity and both flavors are
+  handled.
+- **The GL dialect is desktop 4.1 core with `ARB_ES2_compatibility`**, not
+  ES: GLSL ES 1.00 sources compile unchanged (the addon injects
+  `#version 100` where a source has no version line), ES3-class entry
+  points (VAOs, instancing) exist, but `#version 300 es` shaders do not
+  compile — ES 3.00 *shading* is Linux-only today.
+- **Verify pixels with `gl.readPixels`, not `GetImage`.** The GL surface is
+  composited by the WindowServer *above* the X framebuffer, so X-side reads
+  of a GL window — `GetImage`, screenshots of the X screen — show stale
+  contents by design.
+- Depth-32/ARGB windows are untested on this flavor (XQuartz typically
+  publishes no 32-bit visual, so `chooseGLConfig({ ALPHA_SIZE: 8 })` fails
+  there with `GL_CONTEXT_FAILED`).
 
 ## Choosing a window to draw into
 
@@ -256,7 +347,11 @@ spec is ignored there, and honoured by
 ## Testing
 
 `test/gl-policy.test.js` covers the decisions — policy resolution, the client
-probe, capability gating, error codes — hermetically, with the addon stubbed,
-so it runs with no display and no GPU. `test/gl-direct-live.test.js` renders a
-shader-drawn triangle and reads the window back with `GetImage`; it skips
-wherever the path is unavailable, which includes CI (Xvfb has no DRI3).
+probe, capability gating, error codes, flavor dispatch — hermetically, with
+the addon stubbed, so it runs with no display and no GPU, and
+`test/appledri.test.js` checks the Apple-DRI wire encoding the same way. The
+live halves skip wherever their path is unavailable, which includes CI (Xvfb
+has neither DRI3 nor Apple-DRI): `test/gl-direct-live.test.js` renders a
+shader-drawn triangle over DRI3 and reads the window back with `GetImage`;
+`test/gl-appledri-live.test.js` does the same against XQuartz and verifies
+with `gl.readPixels` (see [macOS](#macos) for why not `GetImage`).

--- a/examples/gles-triangle.js
+++ b/examples/gles-triangle.js
@@ -3,11 +3,13 @@
 //
 //   node examples/gles-triangle.js
 //
-// Needs the optional x11-dri addon (`npm install x11-dri`), a DRM render node,
-// and a server with DRI3 — Xorg with glamor or Xwayland. Where any of those is
-// missing it says which, and the same drawing has to be written against the
-// fixed-function pipeline instead (examples/glclock.js). Compare the two: this
-// one has shaders, and its per-frame cost is one request.
+// Needs the optional x11-dri addon (`npm install x11-dri`) and a server with
+// a direct path: DRI3 plus a DRM render node on Linux (Xorg with glamor,
+// Xwayland), or Apple-DRI on macOS (XQuartz, from the logged-in GUI
+// session). Where any of that is missing it says which, and the same drawing
+// has to be written against the fixed-function pipeline instead
+// (examples/glclock.js). Compare the two: this one has shaders, and its
+// per-frame cost is one request on Linux and none at all on macOS.
 import { createClient } from '../lib/index.js';
 
 const app = await createClient({ glPolicy: 'auto' });
@@ -41,7 +43,7 @@ wnd.on('expose', () => wnd.requestAnimationFrame(draw));
 wnd.map();
 
 const gl = wnd.getContext('opengl', config);
-console.log(`${gl.backend} rendering on ${caps.device}: ${gl.renderer}`);
+console.log(`${gl.backend} rendering (${caps.flavor}) on ${caps.device ?? 'the window surface'}: ${gl.renderer}`);
 
 try {
   await gl.ready;
@@ -108,9 +110,14 @@ const uAngle = gl.getUniformLocation(program, 'uAngle');
 const started = Date.now();
 let frames = 0;
 
-// A buffer the server still holds cannot be drawn into. Rather than spin,
-// stop — and pick up again when one comes back.
+// A frame that cannot go out — every buffer with the server (Linux), or the
+// surface not attached / the pacing gate closed (macOS) — is not drawn.
+// Rather than spin, stop, and pick up again when the gate reopens.
 gl.onFrameAvailable = () => wnd.requestAnimationFrame(draw);
+// The expose that started the loop can land while canRender() was still
+// false and before this handler was installed — kick it once now that
+// everything is wired; a redundant frame is absorbed by the guard in draw().
+wnd.requestAnimationFrame(draw);
 
 function draw() {
   if (!gl.canRender()) return;

--- a/lib/app.js
+++ b/lib/app.js
@@ -603,11 +603,11 @@ export default class App {
    * `createWindow` and the whole object to `wnd.getContext('opengl', config)`.
    *
    * The spec is GLX's attribute vocabulary either way, because a caller
-   * should not have to write the request twice: `DEPTH_SIZE` becomes the EGL
-   * depth-buffer size on the direct backend, and `ALPHA_SIZE` picks an ARGB
-   * visual there rather than an fbconfig with an alpha channel. Direct needs
-   * no round trip to answer — there are no fbconfigs in it, only a window the
-   * GPU's buffers can be copied or flipped into.
+   * should not have to write the request twice: `DEPTH_SIZE` becomes the
+   * depth-buffer size of the direct backend's context (EGL on Linux, CGL on
+   * macOS), and `ALPHA_SIZE` picks an ARGB visual there rather than an
+   * fbconfig with an alpha channel. Direct needs no round trip to answer —
+   * there are no fbconfigs in it, only a window the GPU draws for.
    *
    * @param {object} [spec] GLX attributes, e.g. `{ DEPTH_SIZE: 24 }`
    */
@@ -629,6 +629,8 @@ export default class App {
     }
     return {
       backend: 'direct',
+      // which direct pipeline this connection runs: 'dri3' or 'appledri'
+      flavor: caps.flavor,
       // depth 24 on the root visual needs no colormap of its own, which is
       // why an opaque GL window here is an ordinary window
       visual: argb?.visual ?? screen.root_visual,

--- a/lib/appledri.js
+++ b/lib/appledri.js
@@ -1,0 +1,177 @@
+// Apple-DRI: XQuartz's direct-rendering extension — the macOS counterpart of
+// DRI3. Where DRI3 passes dma-buf descriptors from client to server,
+// Apple-DRI runs the other way: the *server* owns a WindowServer surface for
+// the drawable and exports it to the client's WindowServer connection,
+// identified by (client_id, key[2]). What the client does with the key —
+// import it and attach an OpenGL context through the Xplugin/CGL system
+// libraries — is native-code territory: the x11-dri addon's `apple`
+// namespace (lib/renderingcontext_cgl.js is the consumer).
+//
+// The protocol half lives here rather than in node-x11 because node-x11 does
+// not ship it yet; the binding is written in node-x11's lib/ext style so it
+// can move there verbatim when it does (docs/context-gles.md#macos).
+//
+// Protocol source (there is no shipped header — the extension is defined in
+// the XQuartz server tree):
+//   https://github.com/XQuartz/xorg-server/blob/master/hw/xquartz/xpr/appledristr.h
+//   https://github.com/XQuartz/xorg-server/blob/master/hw/xquartz/xpr/appledri.h
+
+/*
+#define X_AppleDRIQueryVersion                0
+#define X_AppleDRIQueryDirectRenderingCapable 1
+#define X_AppleDRICreateSurface               2
+#define X_AppleDRIDestroySurface              3
+(4..8: AuthConnection and the shm pixmap requests — the accelerated path
+needs none of them, so they are not bound)
+*/
+
+/** Sub-codes of the AppleDRISurfaceNotify event's `kind`. */
+export const NotifyKind = {
+  /** the window moved or resized under the surface: `ctx.update()` */
+  Changed: 0,
+  /** the surface is gone (window unmapped, frame recreated): CreateSurface + attach anew */
+  Destroyed: 1
+};
+
+/**
+ * Bind the Apple-DRI extension on a node-x11 display.
+ *
+ * Resolves the extension object — with the requests, `events`, `NotifyKind`
+ * and `errors` below on it — or `null` where the server has no Apple-DRI,
+ * which is every server that is not XQuartz. Asked once per connection and
+ * cached; the event and error parsers are registered on first resolution.
+ *
+ * The requests are callback-style, like every node-x11 extension:
+ *
+ * - `QueryVersion(cb)` -> `{ major, minor, patch }`
+ * - `QueryDirectRenderingCapable(screen, cb)` -> `boolean`
+ * - `CreateSurface(screen, drawable, clientId, cb)` -> `{ key: [k0, k1], uid }`
+ * - `DestroySurface(screen, drawable)` (void)
+ *
+ * `CreateSurface` makes the server create (or reference) a WindowServer
+ * surface for the drawable and export it to the process whose WindowServer
+ * id is `clientId` (x11-dri: `dri.apple.clientId()`). `key` is what
+ * `AppleContext.attach()` consumes; `uid` is the server-side surface id that
+ * SurfaceNotify events carry as `arg` — route by uid, not by window id.
+ *
+ * The `AppleDRISurfaceNotify` event is *classic* (type `firstEvent + 3`),
+ * not a GenericEvent, and is sent unsolicited to the client that created the
+ * surface — there is no event mask to select. It reaches node-x11's
+ * client-level `'event'` stream only (no `wid` field for per-window
+ * routing), parsed as `{ name: 'AppleDRISurfaceNotify', kind, time, arg }`.
+ *
+ * @param {object} display node-x11 display
+ * @returns {Promise<object|null>}
+ */
+export function requireAppleDRI(display) {
+  const X = display.client;
+  if (X._appleDRIPromise) return X._appleDRIPromise;
+  X._appleDRIPromise = new Promise((resolve) => {
+    X.QueryExtension('Apple-DRI', (err, ext) => {
+      if (err || !ext.present) return resolve(null);
+
+      // -> { major, minor, patch }
+      ext.QueryVersion = (cb) => {
+        X.seq_num++;
+        const b = Buffer.alloc(4);
+        b.writeUInt8(ext.majorOpcode, 0);
+        b.writeUInt8(0, 1);
+        b.writeUInt16LE(1, 2);
+        X.pack_stream.put(b);
+        X.replies[X.seq_num] = [
+          (buf) => ({
+            major: buf.readUInt16LE(0),
+            minor: buf.readUInt16LE(2),
+            patch: buf.readUInt32LE(4)
+          }),
+          cb
+        ];
+        X.pack_stream.submit(true);
+      };
+
+      // -> boolean
+      ext.QueryDirectRenderingCapable = (screen, cb) => {
+        X.seq_num++;
+        const b = Buffer.alloc(8);
+        b.writeUInt8(ext.majorOpcode, 0);
+        b.writeUInt8(1, 1);
+        b.writeUInt16LE(2, 2);
+        b.writeUInt32LE(screen >>> 0, 4);
+        X.pack_stream.put(b);
+        X.replies[X.seq_num] = [(buf) => buf.readUInt8(0) !== 0, cb];
+        X.pack_stream.submit(true);
+      };
+
+      // -> { key: [key0, key1], uid }
+      ext.CreateSurface = (screen, drawable, clientId, cb) => {
+        X.seq_num++;
+        const b = Buffer.alloc(16);
+        b.writeUInt8(ext.majorOpcode, 0);
+        b.writeUInt8(2, 1);
+        b.writeUInt16LE(4, 2);
+        b.writeUInt32LE(screen >>> 0, 4);
+        b.writeUInt32LE(drawable >>> 0, 8);
+        b.writeUInt32LE(clientId >>> 0, 12);
+        X.pack_stream.put(b);
+        X.replies[X.seq_num] = [
+          (buf) => ({
+            key: [buf.readUInt32LE(0), buf.readUInt32LE(4)],
+            uid: buf.readUInt32LE(8)
+          }),
+          cb
+        ];
+        X.pack_stream.submit(true);
+      };
+
+      ext.DestroySurface = (screen, drawable) => {
+        X.seq_num++;
+        const b = Buffer.alloc(12);
+        b.writeUInt8(ext.majorOpcode, 0);
+        b.writeUInt8(3, 1);
+        b.writeUInt16LE(3, 2);
+        b.writeUInt32LE(screen >>> 0, 4);
+        b.writeUInt32LE(drawable >>> 0, 8);
+        X.pack_stream.put(b);
+        X.pack_stream.submit(false);
+      };
+
+      ext.events = {
+        AppleDRISurfaceNotify: 3 // 0..2 are obsolete
+      };
+      ext.NotifyKind = NotifyKind;
+
+      X.eventParsers[ext.firstEvent + ext.events.AppleDRISurfaceNotify] = (
+        type,
+        seq,
+        extra,
+        code,
+        raw
+      ) => ({
+        type,
+        seq,
+        name: 'AppleDRISurfaceNotify',
+        kind: code, // NotifyKind
+        time: extra,
+        arg: raw.readUInt32LE(4) // the surface uid, NOT a window id
+      });
+
+      ext.errors = {
+        ClientNotLocal: 0,
+        OperationNotSupported: 1
+      };
+      // node-x11 names an extension error it cannot decode after a core one;
+      // give both of Apple-DRI's a message that says what to do instead
+      X.errorParsers[ext.firstError + ext.errors.ClientNotLocal] = (error) => {
+        error.message =
+          'Apple-DRI: the client is not local — surfaces can only be exported to a process on the same machine as the X server';
+      };
+      X.errorParsers[ext.firstError + ext.errors.OperationNotSupported] = (error) => {
+        error.message =
+          'Apple-DRI: operation not supported — the server refused the request for this drawable (a root or already-destroyed window, or a server running without the Xplugin backend)';
+      };
+
+      resolve(ext);
+    });
+  });
+  return X._appleDRIPromise;
+}

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -7,11 +7,17 @@
 //    into the X connection. Reaches any server that allows indirect contexts,
 //    including over a network, and is a fixed-function OpenGL 1.x pipeline
 //    with no shaders, because that is what the GLX protocol encodes.
-//  - **direct** (lib/renderingcontext_gles.js) — a GPU render node draws the
-//    frame, and the finished buffer reaches the server as a dma-buf
-//    descriptor over DRI3 + Present. OpenGL ES 2 with real shaders, and no
-//    pixels on the socket; local connections only, and it needs the optional
-//    `x11-dri` addon.
+//  - **direct** — the GPU draws the frame and no pixels cross the socket;
+//    real shaders; local connections only; needs the optional `x11-dri`
+//    addon. It comes in two *flavors*, one per platform, behind the same
+//    context contract:
+//      - `dri3` (Linux, lib/renderingcontext_gles.js): OpenGL ES 2 on a DRM
+//        render node, finished buffers handed to the server as dma-buf
+//        descriptors over DRI3 + Present.
+//      - `appledri` (macOS/XQuartz, lib/renderingcontext_cgl.js): the server
+//        exports the window's WindowServer surface over the Apple-DRI
+//        extension, and a CGL context draws straight into it — desktop GL
+//        with ES2 compatibility, so the same shaders compile.
 //
 // Which one runs is `glPolicy`, and the default is `indirect` — the backend
 // that has always run. See docs/context-gles.md.
@@ -20,6 +26,7 @@
 // caller asked for, and what that resolves to. Neither context imports the
 // other, and the direct one is only ever loaded when the answer is `direct`.
 
+import { requireAppleDRI } from './appledri.js';
 import { nodeRequire } from './builtin.js';
 
 /**
@@ -29,18 +36,28 @@ import { nodeRequire } from './builtin.js';
  * - `GL_DISABLED` — `glPolicy: 'off'`; nothing tried.
  * - `GL_NO_ADDON` — the optional `x11-dri` addon is not installed or would
  *   not load. `npm install x11-dri`.
- * - `GL_NO_DRIVER` — the addon loaded but the GPU libraries it needs are
- *   missing (`libgbm`, `libEGL`, `libGLESv2`), or this is not Linux.
- * - `GL_NO_DEVICE` — no readable DRM render node (`/dev/dri/renderD*`).
- * - `GL_REMOTE_DISPLAY` — a TCP or forwarded display, so there is no local
- *   socket to hand the server a buffer down.
+ * - `GL_NO_DRIVER` — the addon loaded but the platform libraries it needs
+ *   are missing: `libgbm`/`libEGL`/`libGLESv2` on Linux,
+ *   libXplugin/OpenGL.framework on macOS — or the platform has no direct
+ *   path at all.
+ * - `GL_NO_DEVICE` — no readable DRM render node (`/dev/dri/renderD*`);
+ *   Linux only, macOS needs no device node.
+ * - `GL_REMOTE_DISPLAY` — a TCP or forwarded display; both flavors are
+ *   local-only by construction.
  * - `GL_NO_FD_PASSING` — the display is local, but this JavaScript runtime
  *   cannot send a descriptor over the socket. Bun is the case in the field;
- *   x11 does it through a Node internal Bun does not implement.
- * - `GL_NO_DRI3` — the server has no DRI3/Present (Xvfb, Xephyr, XQuartz).
+ *   x11 does it through a Node internal Bun does not implement. Linux only —
+ *   Apple-DRI passes no descriptors.
+ * - `GL_NO_DRI3` — the server has no DRI3/Present (Xvfb, Xephyr, XQuartz —
+ *   though XQuartz has its own path, see `GL_NO_APPLEDRI`).
+ * - `GL_NO_APPLEDRI` — macOS, and the server has no Apple-DRI extension:
+ *   not XQuartz, or an XQuartz running without its Xplugin backend.
+ * - `GL_NO_WINDOWSERVER` — macOS, but this process has no WindowServer
+ *   session to import surfaces into — an SSH session. Run from the
+ *   logged-in GUI session.
  * - `GL_IMPORT_FAILED` — the server refused the buffer; usually client and
  *   server on different DRM devices.
- * - `GL_CONTEXT_FAILED` — GBM/EGL setup failed for some other reason.
+ * - `GL_CONTEXT_FAILED` — GPU context setup failed for some other reason.
  */
 export const GLError = {
   DISABLED: 'GL_DISABLED',
@@ -50,6 +67,8 @@ export const GLError = {
   REMOTE_DISPLAY: 'GL_REMOTE_DISPLAY',
   NO_FD_PASSING: 'GL_NO_FD_PASSING',
   NO_DRI3: 'GL_NO_DRI3',
+  NO_APPLEDRI: 'GL_NO_APPLEDRI',
+  NO_WINDOWSERVER: 'GL_NO_WINDOWSERVER',
   IMPORT_FAILED: 'GL_IMPORT_FAILED',
   CONTEXT_FAILED: 'GL_CONTEXT_FAILED'
 };
@@ -161,11 +180,18 @@ tools are needed; anything else compiles with node-gyp and a C toolchain. ntk
 does not depend on it — without it, GL runs through indirect GLX.`;
 
 /**
- * What the *client side* can do, before any server is asked: the addon, the
- * GPU libraries under it, and a render node to draw on. Never throws.
+ * What the *client side* can do, before any server is asked: the addon and
+ * the platform libraries under it — plus, on Linux, a render node to draw
+ * on. Never throws.
+ *
+ * `flavor` on an ok answer says which direct pipeline this machine runs:
+ * `'dri3'` (Linux — GBM/EGL, dma-buf to the server) or `'appledri'`
+ * (macOS — Apple-DRI surface export, CGL). macOS needs no device scan; the
+ * window's surface is the render target, so `device` is `null` there.
  *
  * @returns {{ok: boolean, code?: string, message?: string, hint?: string,
- *   device?: string, devices?: string[], probe?: object}}
+ *   flavor?: 'dri3'|'appledri', device?: string|null, devices?: string[],
+ *   probe?: object}}
  */
 export function probeDirect(policy = DEFAULT_GL_POLICY) {
   const dri = loadDriAddon();
@@ -185,6 +211,28 @@ export function probeDirect(policy = DEFAULT_GL_POLICY) {
     return { ok: false, code: GLError.NO_DRIVER, message: `x11-dri probe() failed: ${err.message}` };
   }
 
+  if (probe.platform === 'darwin') {
+    // The macOS path draws through Apple-DRI + CGL, not GBM/EGL — probe()
+    // reports it as `appledri`: `true`, or the string saying why not. An
+    // addon from before 0.5.0 has no such key at all.
+    if (probe.appledri !== true) {
+      return {
+        ok: false,
+        code: GLError.NO_DRIVER,
+        message: `the libraries direct rendering needs on macOS are unavailable (appledri: ${
+          probe.appledri ?? 'not reported — this x11-dri predates Apple-DRI support'
+        })`,
+        hint:
+          probe.appledri === undefined
+            ? 'Upgrade the addon: npm install x11-dri@latest (Apple-DRI support arrived in 0.5.0).'
+            : 'The macOS path needs XQuartz installed (it dlopen()s libXplugin from /opt/X11)\nand the system OpenGL framework — https://www.xquartz.org.',
+        probe
+      };
+    }
+    // no render nodes on macOS: the window's own surface is the target
+    return { ok: true, flavor: 'appledri', device: null, devices: [], probe };
+  }
+
   // probe() reports each capability as `true` or as the string saying why not
   const missing = ['gbm', 'egl', 'gles'].filter((key) => probe[key] !== true);
   if (missing.length) {
@@ -195,7 +243,7 @@ export function probeDirect(policy = DEFAULT_GL_POLICY) {
       message: `the GPU libraries direct rendering needs are unavailable (${detail})`,
       hint:
         probe.platform && probe.platform !== 'linux'
-          ? `Direct rendering is Linux-only — dma-buf, GBM and DRI3 have no equivalent on ${probe.platform}.`
+          ? `Direct rendering needs Linux (DRI3/dma-buf) or macOS (Apple-DRI/XQuartz) — ${probe.platform} has neither path.`
           : 'Install Mesa (libgbm1, libegl1, libgles2 on Debian/Ubuntu). They are dlopen()ed at\nrun time, so no rebuild of x11-dri is needed once they are there.',
       probe
     };
@@ -219,7 +267,7 @@ export function probeDirect(policy = DEFAULT_GL_POLICY) {
       devices
     };
   }
-  return { ok: true, device, devices, probe };
+  return { ok: true, flavor: 'dri3', device, devices, probe };
 }
 
 // ---------------------------------------------------------------------------
@@ -253,13 +301,20 @@ const requireExt = (X, name) =>
 /**
  * Everything about `app` that decides the backend, answered once and cached.
  *
- * The two extension queries are the only round trips, and they only happen
+ * The extension queries are the only round trips, and they only happen
  * under a policy that could use direct — `createClient` warms this during the
  * connect handshake for exactly that reason, so `getContext` can decide
  * synchronously afterwards.
  *
- * @returns {Promise<{direct: boolean, indirect: boolean, device: string|null,
- *   reason: Error|null, DRI3: object|null, Present: object|null}>}
+ * `flavor` names the direct pipeline where `direct` is true: `'dri3'`
+ * carries `DRI3` and `Present`, `'appledri'` carries `AppleDRI` (the
+ * lib/appledri.js extension object) and `appleClientId` (this process's
+ * WindowServer id, which CreateSurface exports surfaces to).
+ *
+ * @returns {Promise<{direct: boolean, indirect: boolean,
+ *   flavor: 'dri3'|'appledri'|null, device: string|null, reason: Error|null,
+ *   DRI3: object|null, Present: object|null, AppleDRI: object|null,
+ *   appleClientId: number|null}>}
  */
 export function glCapabilities(app) {
   if (app._glCaps) return app._glCaps;
@@ -269,10 +324,13 @@ export function glCapabilities(app) {
     const fail = (code, message, hint) => ({
       direct: false,
       indirect,
+      flavor: null,
       device: null,
       reason: glError(code, message, hint),
       DRI3: null,
-      Present: null
+      Present: null,
+      AppleDRI: null,
+      appleClientId: null
     });
 
     if (policy.mode === 'off') {
@@ -281,11 +339,67 @@ export function glCapabilities(app) {
     if (!app.display.isLocalSocket) {
       return fail(
         GLError.REMOTE_DISPLAY,
-        'this X connection is not a local socket, and DRI3 works by passing a descriptor down one',
-        'Direct rendering is local-only by construction. Over a network, indirect GLX is\n' +
-          'the backend that can work at all — leave glPolicy at its default.'
+        'this X connection is not a local socket, and direct rendering is same-machine by construction (DRI3 passes a descriptor down the socket; Apple-DRI exports a surface to a local process)',
+        'Over a network, indirect GLX is the backend that can work at all — leave\n' +
+          'glPolicy at its default.'
       );
     }
+
+    const client = probeDirect(policy);
+    if (!client.ok) return fail(client.code, client.message, client.hint);
+
+    if (client.flavor === 'appledri') {
+      // No descriptor ever crosses this socket — the fd-passing checks the
+      // dri3 flavor needs below do not apply, which is also what lets this
+      // path work under runtimes that cannot send one.
+      const dri = loadDriAddon();
+      let appleClientId;
+      try {
+        // the WindowServer handshake happens on first call; a session with
+        // no WindowServer (SSH into the machine) is where it throws
+        appleClientId = dri.apple.clientId();
+      } catch (err) {
+        return fail(
+          GLError.NO_WINDOWSERVER,
+          `this process has no WindowServer session to import surfaces into (${err.message})`,
+          'Apple-DRI hands the window surface to the WindowServer connection of this\n' +
+            'process, which an SSH session does not have. Run the app from the logged-in\n' +
+            'GUI session; over SSH, indirect GLX is the backend that can work.'
+        );
+      }
+      const AppleDRI = await requireAppleDRI(app.display);
+      if (!AppleDRI) {
+        return fail(
+          GLError.NO_APPLEDRI,
+          `${displayName()} does not have the Apple-DRI extension, so it cannot export a window surface to render into`,
+          'Apple-DRI is XQuartz\'s direct-rendering extension — is this display an\n' +
+            'XQuartz server? Indirect GLX is the backend that can work on any other.'
+        );
+      }
+      const capable = await new Promise((resolve) =>
+        AppleDRI.QueryDirectRenderingCapable(0, (err, answer) => resolve(err ? false : answer))
+      );
+      if (!capable) {
+        return fail(
+          GLError.NO_APPLEDRI,
+          `${displayName()} has Apple-DRI but reports it not direct-rendering capable`,
+          'XQuartz answers this false when its Xplugin backend is not driving a real\n' +
+            'display. Indirect GLX is the backend that can work on such a server.'
+        );
+      }
+      return {
+        direct: true,
+        indirect,
+        flavor: 'appledri',
+        device: null,
+        reason: null,
+        DRI3: null,
+        Present: null,
+        AppleDRI,
+        appleClientId
+      };
+    }
+
     if (!canPassDescriptors(app.display)) {
       // The socket is local; what is missing is the ability to send a
       // descriptor along it. x11 does that through Node's internal
@@ -301,9 +415,6 @@ export function glCapabilities(app) {
           'default and use indirect GLX, which needs no descriptor passing at all.'
       );
     }
-
-    const client = probeDirect(policy);
-    if (!client.ok) return fail(client.code, client.message, client.hint);
 
     const X = app.X;
     const [DRI3, Present] = await Promise.all([requireExt(X, 'dri3'), requireExt(X, 'present')]);
@@ -325,7 +436,17 @@ export function glCapabilities(app) {
       );
     }
 
-    return { direct: true, indirect, device: client.device, reason: null, DRI3, Present };
+    return {
+      direct: true,
+      indirect,
+      flavor: 'dri3',
+      device: client.device,
+      reason: null,
+      DRI3,
+      Present,
+      AppleDRI: null,
+      appleClientId: null
+    };
   })();
   return app._glCaps;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,13 +55,15 @@ import { TextLayout } from './text/layout.js';
 import SvgView from './widgets/svgview.js';
 import { cssColor, cssColorStraight, premultiply } from './color.js';
 
-// rendering context modules register themselves on Drawable. The direct one
-// comes last on purpose: it wraps the 'opengl' factory the indirect one just
-// registered, so that the backend-neutral name can dispatch on glPolicy.
+// rendering context modules register themselves on Drawable. The direct ones
+// come last on purpose: each wraps the 'opengl' factory the one before it
+// registered, so that the backend-neutral name can dispatch on glPolicy —
+// indirect underneath, then the dri3 flavor, then the appledri one on top.
 import './renderingcontext_x11.js';
 import { CanvasGradient, CanvasPattern } from './renderingcontext_2d.js';
 import './renderingcontext_opengl.js';
 import './renderingcontext_gles.js';
+import './renderingcontext_cgl.js';
 
 // One socket write per frame instead of one per request (x11 >= 3.6). A frame
 // is emitted in one synchronous run of _runFrame() and ends with the frame

--- a/lib/renderingcontext_cgl.js
+++ b/lib/renderingcontext_cgl.js
@@ -1,0 +1,439 @@
+// Direct rendering context, macOS/XQuartz flavor: OpenGL on the GPU through
+// CGL, drawing straight into the window's WindowServer surface, which the
+// server exports over the Apple-DRI extension (lib/appledri.js).
+//
+// The mirror image of the DRI3 flavor (lib/renderingcontext_gles.js): DRI3
+// is client-allocates-and-pushes — GBM buffers travel to the server as
+// dma-buf descriptors and are shown with Present — where Apple-DRI is
+// server-exports-and-client-attaches:
+//
+//   this process                              X server (XQuartz)
+//   ------------                              ------------------
+//   apple.clientId()  --- AppleDRICreateSurface(win, cid) --->  exports the
+//                     <-------------- key[2] ----------------   window's surface
+//   ctx.attach(key)      (import surface + bind CGL context)
+//   gl draws straight into the window's backing store
+//   ctx.flush()          (CGLFlushDrawable — WindowServer composites)
+//                     <--- AppleDRISurfaceNotify ------------   moved/resized/
+//                                                               destroyed
+//
+// After attach, no pixels and no per-frame requests cross the X socket at
+// all. The GL the context speaks is the same WebGL-shaped camelCase table
+// the DRI3 flavor installs — the addon serves both from one `gl` object, and
+// on Apple's GL (4.1 core on Metal, ES2-compatible) the same GLSL ES 1.00
+// shaders compile unchanged — so draw code written against `gl.backend ===
+// 'direct'` runs on either. See docs/context-gles.md#macos.
+//
+// Two structural differences from the GLES flavor, both consequences of the
+// server owning the buffer:
+//
+//  - **The surface exists only while the physical (Quartz) window does**, so
+//    setup is not synchronous: the CGL context is created in the
+//    constructor (and `gl.*` works immediately — an unattached context
+//    compiles shaders and renders to FBOs), but the attach waits for
+//    MapNotify, and `SurfaceNotify(destroyed)` (unmap, frame recreated)
+//    means export-and-attach again. `ready`/`canRender()` report it, and
+//    the existing `onFrameAvailable` contract absorbs the wait.
+//  - **No backpressure from the server**: `flush()` always succeeds
+//    immediately, so a loop that draws whenever it can would spin at 100%
+//    CPU. Rather than a second pacing model, the swap itself closes the
+//    `canRender()` gate for one display period and a timer reopens it —
+//    the same gate IdleNotify drives on Linux, so a draw loop written for
+//    one flavor paces correctly on the other.
+
+import { connectionGone } from './cleanup.js';
+import Drawable from './drawable.js';
+import { GLError, backendFor, glError, loadDriAddon } from './gl.js';
+
+/** pacing fallback where the display's rate is not known (see App#frameInterval) */
+const FALLBACK_FRAME_INTERVAL = 1000 / 60;
+
+/**
+ * The app-level uid -> context routes for AppleDRISurfaceNotify.
+ *
+ * The event is classic (not a GenericEvent, so `_setGenericEventSink` never
+ * sees it), unsolicited (no mask to select), and names its surface by the
+ * **uid** from the CreateSurface reply rather than by window id — so the
+ * per-window `event_consumers` dispatch cannot route it either. One
+ * client-level listener per connection, keyed by uid, is the whole scheme.
+ */
+function appleSurfaceRoutes(app) {
+  if (app._appleSurfaces) return app._appleSurfaces;
+  const routes = new Map();
+  app._appleSurfaces = routes;
+  app.X.on('event', (ev) => {
+    if (ev.name !== 'AppleDRISurfaceNotify') return;
+    routes.get(ev.arg)?._surfaceNotify(ev);
+  });
+  return routes;
+}
+
+class RenderingContextCGL {
+  constructor(window, config = {}) {
+    const app = window.app;
+    const caps = app._glCapsResolved;
+    if (!caps) {
+      throw glError(
+        GLError.CONTEXT_FAILED,
+        "getContext('cgl') needs the direct-rendering probe to have answered, and it has not",
+        `createClient() runs the probe during the handshake when glPolicy could pick the
+direct backend, so a context can be created synchronously afterwards. Under the
+default policy ('indirect') it does not run, and asking for this context by name
+does not make it retroactive. Either:
+
+  const app = await createClient({ glPolicy: 'auto' });   // probe at connect
+  await app.glCapabilities();                             // or ask, once, later`
+      );
+    }
+    if (!caps.direct) throw caps.reason;
+    if (caps.flavor !== 'appledri') {
+      throw glError(
+        GLError.CONTEXT_FAILED,
+        `this connection's direct backend is ${caps.flavor}, not Apple-DRI/CGL`,
+        "getContext('opengl') is the backend-neutral name and picks the right flavor;\n'cgl' asks for this one by name and only exists on macOS/XQuartz."
+      );
+    }
+
+    const dri = loadDriAddon();
+    this.window = window;
+    this.app = app;
+    this.X = window.X;
+    this.dri = dri;
+    this.AppleDRI = caps.AppleDRI;
+    /** which backend this is, for code that runs on either */
+    this.backend = 'direct';
+    /** which direct pipeline, for the curious ('dri3' on Linux) */
+    this.flavor = 'appledri';
+    this.error = null;
+
+    const depth = window.depth || app.display.screen[0].root_depth || 24;
+    if (depth !== 24 && depth !== 32) {
+      throw glError(
+        GLError.CONTEXT_FAILED,
+        `direct rendering needs a 24- or 32-bit window, and this one is ${depth}-bit`,
+        'Create the window with depth 24 (opaque) or 32 (per-pixel alpha, via\napp.findArgbVisual()).'
+      );
+    }
+    this.depth = depth;
+    this._screen = config.screen ?? 0;
+    this._clientId = caps.appleClientId ?? dri.apple.clientId();
+
+    // One CGL context per context object, not a shared one per app: a CGL
+    // context can be attached to exactly one surface, and contexts are cheap
+    // where EGL ones are not. The visible consequence is that GL resources
+    // (programs, textures) are per-window on this flavor where the GLES one
+    // shares them — key caches by the `gl` object identity and both are
+    // covered (docs/context-gles.md#macos).
+    try {
+      this.ctx = new dri.apple.Context({
+        depthSize: config.depthSize ?? config.DEPTH_SIZE ?? 16
+      });
+    } catch (err) {
+      throw glError(
+        GLError.CONTEXT_FAILED,
+        `could not create a CGL context: ${err.message}`,
+        null,
+        err
+      );
+    }
+
+    this._routes = appleSurfaceRoutes(app);
+    this._uid = undefined;
+    this._attached = false;
+    this._pendingSurface = false;
+    this._throttled = false;
+    this._timer = null;
+    this._frameWanted = null;
+    this._destroyed = false;
+
+    /**
+     * Resolves once the window's surface has been exported and attached —
+     * the whole path proven — and rejects with a coded error if it cannot
+     * be. Settles only after the window is mapped: the physical Quartz
+     * window has to exist before the server has a surface to export, so
+     * `map()` first, then `await gl.ready`.
+     */
+    this.ready = new Promise((resolve, reject) => {
+      this._settleReady = (err) => {
+        this._settleReady = null;
+        if (err) reject(err);
+        else resolve(this);
+      };
+    });
+    // a rejection nobody is listening for must not take the process down;
+    // `error` is the other way to find out
+    this.ready.catch(() => {});
+
+    // GL entry points and constants, bound so that this context is the
+    // current one when they run
+    this._installGL();
+    this.makeCurrent();
+
+    // The attach dance: surface after MapNotify, again after a Destroyed
+    // notify once the window is viewable again. `on('map')` also selects
+    // StructureNotify where the window does not have it yet (adopted ids).
+    this._onMap = () => {
+      if (!this._attached && !this._pendingSurface) this._createSurface();
+    };
+    window.on('map', this._onMap);
+    if (window._mapped) this._createSurface();
+  }
+
+  /**
+   * Copy the addon's GL namespace onto this context.
+   *
+   * Same shape as the GLES flavor: every function is wrapped with a currency
+   * check, because another context may have made itself current since the
+   * last call here — `app._glCurrent` is one slot shared by every direct
+   * context on the connection, whichever flavor.
+   */
+  _installGL() {
+    const table = this.dri.gl;
+    for (const key in table) {
+      const value = table[key];
+      if (typeof value !== 'function') {
+        this[key] = value; // GL constants
+        continue;
+      }
+      this[key] = (...args) => {
+        if (this.app._glCurrent !== this) this._bind();
+        return value(...args);
+      };
+    }
+  }
+
+  /**
+   * Ask the server to export the window's surface, then attach to it.
+   *
+   * Called from MapNotify (the physical window now exists) and from the
+   * SurfaceNotify(destroyed) recovery path. Attaching again on the same CGL
+   * context replaces whatever surface it held.
+   */
+  _createSurface() {
+    if (this._destroyed || this.error || this.window._destroyed || connectionGone(this.X)) return;
+    this._pendingSurface = true;
+    this.AppleDRI.CreateSurface(this._screen, this.window.id, this._clientId, (err, surf) => {
+      this._pendingSurface = false;
+      if (this._destroyed || this.window._destroyed) return;
+      if (err) {
+        return this._fail(
+          glError(
+            GLError.CONTEXT_FAILED,
+            `Apple-DRI could not export a surface for this window: ${err.message}`,
+            null,
+            err
+          )
+        );
+      }
+      if (this._uid !== undefined) this._routes.delete(this._uid);
+      this._uid = surf.uid;
+      this._routes.set(surf.uid, this);
+      try {
+        this.ctx.attach(surf.key);
+      } catch (attachErr) {
+        return this._fail(
+          glError(
+            GLError.CONTEXT_FAILED,
+            `could not attach the CGL context to the exported surface: ${attachErr.message}`,
+            null,
+            attachErr
+          )
+        );
+      }
+      this.app._glCurrent = this; // attach leaves the context current
+      this._attached = true;
+      this._settleReady?.(null);
+      this._onFrameAvailable();
+    });
+    this.X.flush?.();
+  }
+
+  /** the app-level route target for this context's SurfaceNotify events */
+  _surfaceNotify(ev) {
+    if (this._destroyed || this.error) return;
+    if (ev.kind === this.AppleDRI.NotifyKind.Changed) {
+      // moved or resized under the surface: refresh the context's idea of it
+      if (this._attached) {
+        try {
+          this.ctx.update();
+        } catch {
+          // a surface torn down between the event and now; the Destroyed
+          // notify that follows is what handles it
+        }
+      }
+      return;
+    }
+    // Destroyed: the Quartz window went away — unmapped, or its frame was
+    // recreated. The context survives; the surface has to be exported and
+    // attached again once there is a window to export.
+    this._attached = false;
+    if (this._uid !== undefined) {
+      this._routes.delete(this._uid);
+      this._uid = undefined;
+    }
+    if (this.window._mapped && !this._pendingSurface) this._createSurface();
+    // not mapped: the 'map' listener picks it up when it is again
+  }
+
+  /**
+   * Make this context current, and pick up a resize.
+   *
+   * Call it at the top of a frame, as on the GLES flavor. A size change
+   * needs no new buffers here — the surface is the window's backing store
+   * and tracks it — but the context has to be told to re-read the geometry.
+   */
+  makeCurrent() {
+    if (this.error || this._destroyed || this.window._destroyed) return this;
+    this._bind();
+    const width = this.window.width;
+    const height = this.window.height;
+    if (width !== this._width || height !== this._height) {
+      this._width = width;
+      this._height = height;
+      if (this._attached) {
+        try {
+          this.ctx.update();
+        } catch {
+          // surface gone; the Destroyed notify re-attaches
+        }
+      }
+    }
+    return this;
+  }
+
+  _bind() {
+    if (this.error || this._destroyed) return;
+    this.ctx.makeCurrent();
+    this.app._glCurrent = this;
+  }
+
+  /**
+   * Is a frame worth drawing right now?
+   *
+   * False until the surface is attached (nowhere to draw to), and false for
+   * one display period after each swap (the pacing gate). `onFrameAvailable`
+   * fires when either turns true.
+   */
+  canRender() {
+    if (this.error || this._destroyed) return false;
+    return this._attached && !this._throttled;
+  }
+
+  /** Called when `canRender()` became true again — attach settled, or the pacing gate reopened. */
+  set onFrameAvailable(fn) {
+    this._frameWanted = fn;
+  }
+
+  get onFrameAvailable() {
+    return this._frameWanted;
+  }
+
+  _onFrameAvailable() {
+    this._frameWanted?.();
+  }
+
+  /**
+   * Show the frame just drawn (CGLFlushDrawable — the WindowServer
+   * composites the surface; no X request is involved).
+   *
+   * Returns false when there is no attached surface yet or the pacing gate
+   * is closed — the same contract as the GLES flavor's "every buffer is with
+   * the server", and `onFrameAvailable` reopens it the same way.
+   */
+  SwapBuffers() {
+    if (this.error || this._destroyed || this.window._destroyed) return false;
+    if (!this._attached || this._throttled) return false;
+    try {
+      this.ctx.flush();
+    } catch (err) {
+      this._fail(glError(GLError.CONTEXT_FAILED, `CGL flush failed: ${err.message}`, null, err));
+      return false;
+    }
+    // The pacing gate: flush() never blocks and the server sends no
+    // done-with-it event, so an unthrottled loop would spin. Close the gate
+    // for most of a display period; the timer reopens it and fires
+    // onFrameAvailable, which is exactly what IdleNotify does on Linux.
+    // Most of one rather than a full one because callers paced by
+    // requestAnimationFrame already wait a display period of their own, and
+    // a full gate in series with it would drop below display rate; at 3/4
+    // the frame clock stays the pacer and this gate only stops the spin.
+    // (ctx.setSwapInterval(1) — a blocking vsync'd flush — remains available
+    // on the raw context for callers who want real vsync.)
+    this._throttled = true;
+    this._timer = setTimeout(() => {
+      this._timer = null;
+      this._throttled = false;
+      this._onFrameAvailable();
+    }, (this.app.frameInterval ?? FALLBACK_FRAME_INTERVAL) * 0.75);
+    return true;
+  }
+
+  swapBuffers() {
+    return this.SwapBuffers();
+  }
+
+  /** The GL renderer string — "Apple M1 Pro" and the like, handy in bug reports. */
+  get renderer() {
+    try {
+      return this.dri.gl.getString(this.dri.GL.RENDERER);
+    } catch {
+      return null;
+    }
+  }
+
+  _fail(err) {
+    if (this.error) return;
+    this.error = err;
+    this._settleReady?.(err);
+  }
+
+  destroy() {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    this.window.removeListener('map', this._onMap);
+    if (this._uid !== undefined) {
+      this._routes.delete(this._uid);
+      this._uid = undefined;
+    }
+    // release the server's reference to the surface; with the window (or the
+    // connection) already gone the server has done it for us
+    if (!this.window._destroyed && !connectionGone(this.X)) {
+      try {
+        this.AppleDRI.DestroySurface(this._screen, this.window.id);
+      } catch {
+        // the connection is closing; the server frees everything with it
+      }
+    }
+    if (this.app._glCurrent === this) this.app._glCurrent = null;
+    try {
+      this.ctx.destroy();
+    } catch {
+      // already torn down
+    }
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
+  }
+}
+
+Drawable.renderingContextFactory['cgl'] = (window, config) => new RenderingContextCGL(window, config);
+
+// The 'opengl' dispatcher was registered by renderingcontext_gles.js (which
+// index.js imports first); this wrap slots the Apple flavor in ahead of it.
+// The chain: appledri flavor -> this context; everything else -> the GLES
+// module's dispatch, which handles dri3, indirect, off and not-yet-probed.
+const dispatchBelow = Drawable.renderingContextFactory['opengl'];
+Drawable.renderingContextFactory['opengl'] = (window, config) => {
+  const app = window.app;
+  if (backendFor(app) === 'direct' && app._glCapsResolved?.flavor === 'appledri') {
+    return new RenderingContextCGL(window, config);
+  }
+  return dispatchBelow(window, config);
+};
+
+export default RenderingContextCGL;

--- a/lib/renderingcontext_gles.js
+++ b/lib/renderingcontext_gles.js
@@ -67,6 +67,13 @@ does not make it retroactive. Either:
       );
     }
     if (!caps.direct) throw caps.reason;
+    if (caps.flavor && caps.flavor !== 'dri3') {
+      throw glError(
+        GLError.CONTEXT_FAILED,
+        `this connection's direct backend is ${caps.flavor}, not DRI3/GLES`,
+        "getContext('opengl') is the backend-neutral name and picks the right flavor;\n'gles' asks for the Linux one by name. On macOS/XQuartz the flavor is 'cgl'\n(lib/renderingcontext_cgl.js), same contract and the same gl surface."
+      );
+    }
 
     const dri = loadDriAddon();
     this.window = window;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "node": ">=18.19.0"
       },
       "optionalDependencies": {
-        "x11-dri": ">=0.2.0 <1"
+        "x11-dri": ">=0.5.0 <1"
       }
     },
     "node_modules/@conventional-commits/parser": {
@@ -472,10 +472,11 @@
       }
     },
     "node_modules/x11-dri": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.4.0.tgz",
-      "integrity": "sha512-DmNis7rUWuGm4l00DUAlCt+ld4pV2vqw2id+Q1EEIJz9gTFo1Dd1LzCUHrfq3LZxhY0crho0NFESMyylQG5g/w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.5.0.tgz",
+      "integrity": "sha512-tJ9whTTg3JhCXnyOtTLDAb3X8aKW4HY1TVOV3e759H1YK3xgxGJvMPJtBPT2SvPtNXB5q6tq+B8tpO33YUvyhg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "x11": "^4.0.1"
   },
   "optionalDependencies": {
-    "x11-dri": ">=0.2.0 <1"
+    "x11-dri": ">=0.5.0 <1"
   },
   "scripts": {
     "test": "NTK_STRICT_COLORS=1 node --test",

--- a/test/appledri.test.js
+++ b/test/appledri.test.js
@@ -1,0 +1,164 @@
+// The Apple-DRI protocol binding, hermetically: request bytes, reply
+// decoding, the SurfaceNotify event parser and the two extension errors,
+// against a stub of node-x11's client surface (pack_stream / replies /
+// eventParsers / errorParsers). No display, no macOS, no addon — the wire
+// encoding is the same everywhere, which is what makes this checkable on CI.
+// The live half is test/gl-appledri-live.test.js.
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { NotifyKind, requireAppleDRI } from '../lib/appledri.js';
+
+const OPCODE = 130;
+const FIRST_EVENT = 90;
+const FIRST_ERROR = 140;
+
+function fakeDisplay({ present = 1 } = {}) {
+  const X = {
+    seq_num: 0,
+    replies: {},
+    eventParsers: {},
+    errorParsers: {},
+    requests: [],
+    queries: 0,
+    pack_stream: {
+      put(b) {
+        X.requests.push(Buffer.from(b));
+      },
+      submit() {}
+    },
+    QueryExtension(name, cb) {
+      X.queries++;
+      assert.equal(name, 'Apple-DRI');
+      queueMicrotask(() =>
+        cb(null, {
+          present,
+          majorOpcode: OPCODE,
+          firstEvent: FIRST_EVENT,
+          firstError: FIRST_ERROR
+        })
+      );
+    }
+  };
+  return { client: X };
+}
+
+/** run the decode half registered for the last request */
+const decodeLast = (X, buf) => X.replies[X.seq_num][0](buf);
+
+describe('requireAppleDRI', () => {
+  test('a server without the extension answers null, once, cached', async () => {
+    const display = fakeDisplay({ present: 0 });
+    assert.equal(await requireAppleDRI(display), null);
+    assert.equal(await requireAppleDRI(display), null);
+    assert.equal(display.client.queries, 1);
+  });
+
+  test('QueryVersion: 1-word request, version triple out of the reply', async () => {
+    const display = fakeDisplay();
+    const ext = await requireAppleDRI(display);
+    const X = display.client;
+
+    ext.QueryVersion(() => {});
+    const req = X.requests.at(-1);
+    assert.deepEqual([...req], [OPCODE, 0, 1, 0]);
+    assert.equal(X.seq_num, 1, 'one request issued, sequence tracked');
+
+    const reply = Buffer.alloc(24);
+    reply.writeUInt16LE(1, 0);
+    reply.writeUInt16LE(0, 2);
+    reply.writeUInt32LE(23, 4);
+    assert.deepEqual(decodeLast(X, reply), { major: 1, minor: 0, patch: 23 });
+  });
+
+  test('QueryDirectRenderingCapable: screen in, boolean out', async () => {
+    const display = fakeDisplay();
+    const ext = await requireAppleDRI(display);
+    const X = display.client;
+
+    ext.QueryDirectRenderingCapable(0, () => {});
+    const req = X.requests.at(-1);
+    assert.equal(req.length, 8);
+    assert.equal(req.readUInt8(0), OPCODE);
+    assert.equal(req.readUInt8(1), 1); // minor opcode
+    assert.equal(req.readUInt16LE(2), 2); // length in words
+    assert.equal(req.readUInt32LE(4), 0); // screen
+
+    assert.equal(decodeLast(X, Buffer.from([1])), true);
+    assert.equal(decodeLast(X, Buffer.from([0])), false);
+  });
+
+  test('CreateSurface: screen/drawable/clientId in, key pair and uid out', async () => {
+    const display = fakeDisplay();
+    const ext = await requireAppleDRI(display);
+    const X = display.client;
+
+    ext.CreateSurface(0, 0x0200004a, 0x1234, () => {});
+    const req = X.requests.at(-1);
+    assert.equal(req.length, 16);
+    assert.equal(req.readUInt8(1), 2); // minor opcode
+    assert.equal(req.readUInt16LE(2), 4); // length in words
+    assert.equal(req.readUInt32LE(4), 0); // screen
+    assert.equal(req.readUInt32LE(8), 0x0200004a); // drawable
+    assert.equal(req.readUInt32LE(12), 0x1234); // client_id
+
+    const reply = Buffer.alloc(24);
+    reply.writeUInt32LE(0xdeadbeef, 0);
+    reply.writeUInt32LE(0x00c0ffee, 4);
+    reply.writeUInt32LE(7, 8);
+    assert.deepEqual(decodeLast(X, reply), { key: [0xdeadbeef, 0x00c0ffee], uid: 7 });
+  });
+
+  test('DestroySurface: void request, no reply handler registered', async () => {
+    const display = fakeDisplay();
+    const ext = await requireAppleDRI(display);
+    const X = display.client;
+
+    ext.DestroySurface(0, 0x0200004a);
+    const req = X.requests.at(-1);
+    assert.equal(req.length, 12);
+    assert.equal(req.readUInt8(1), 3); // minor opcode
+    assert.equal(req.readUInt16LE(2), 3); // length in words
+    assert.equal(req.readUInt32LE(4), 0); // screen
+    assert.equal(req.readUInt32LE(8), 0x0200004a); // drawable
+    assert.equal(X.replies[X.seq_num], undefined, 'nothing awaits a reply');
+  });
+
+  test('SurfaceNotify: classic event at firstEvent + 3, kind in the code byte, uid in arg', async () => {
+    const display = fakeDisplay();
+    const ext = await requireAppleDRI(display);
+    const X = display.client;
+
+    assert.equal(ext.events.AppleDRISurfaceNotify, 3);
+    assert.deepEqual(ext.NotifyKind, { Changed: 0, Destroyed: 1 });
+    assert.equal(ext.NotifyKind, NotifyKind);
+
+    const parse = X.eventParsers[FIRST_EVENT + 3];
+    assert.equal(typeof parse, 'function');
+    const raw = Buffer.alloc(24);
+    raw.writeUInt32LE(7, 4); // the surface uid — NOT a window id
+    const ev = parse(FIRST_EVENT + 3, 42, 123456, NotifyKind.Destroyed, raw);
+    assert.deepEqual(ev, {
+      type: FIRST_EVENT + 3,
+      seq: 42,
+      name: 'AppleDRISurfaceNotify',
+      kind: NotifyKind.Destroyed,
+      time: 123456,
+      arg: 7
+    });
+  });
+
+  test('the two protocol errors decode to messages that say what to do', async () => {
+    const display = fakeDisplay();
+    const ext = await requireAppleDRI(display);
+    const X = display.client;
+
+    assert.deepEqual(ext.errors, { ClientNotLocal: 0, OperationNotSupported: 1 });
+    const local = { message: 'unknown' };
+    X.errorParsers[FIRST_ERROR + 0](local);
+    assert.match(local.message, /not local.*same machine/s);
+    const unsupported = { message: 'unknown' };
+    X.errorParsers[FIRST_ERROR + 1](unsupported);
+    assert.match(unsupported.message, /not supported/);
+  });
+});

--- a/test/gl-appledri-live.test.js
+++ b/test/gl-appledri-live.test.js
@@ -1,0 +1,273 @@
+// The Apple-DRI flavor of the direct backend, end to end, against a real
+// XQuartz: a GLSL-shaded triangle drawn by the GPU straight into the
+// window's exported surface, presented with a CGL flush, and verified with
+// gl.readPixels.
+//
+// readPixels rather than GetImage on purpose: the GL surface is composited
+// by the WindowServer *above* the X framebuffer, so X-side reads of the
+// window show stale contents by design (docs/context-gles.md#macos). The
+// wire encoding this path speaks is checked hermetically in
+// test/appledri.test.js; this file is the half that needs the real thing,
+// and it skips everywhere the real thing is missing — any non-mac, any
+// non-XQuartz server, an SSH session — the same shape as
+// test/gl-direct-live.test.js for the dri3 flavor.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import { createClient } from '../lib/index.js';
+import { withTimeout } from './helpers/async.js';
+
+let app = null;
+let skip = false;
+let keepalive = null;
+
+const VERTEX = `
+attribute vec2 position;
+void main() { gl_Position = vec4(position, 0.0, 1.0); }`;
+
+const FRAGMENT = `
+precision mediump float;
+uniform vec3 uColor;
+void main() { gl_FragColor = vec4(uColor, 1.0); }`;
+
+function buildProgram(gl) {
+  const compile = (type, source, what) => {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    assert.ok(gl.getShaderParameter(shader, gl.COMPILE_STATUS), `${what}: ${gl.getShaderInfoLog(shader)}`);
+    return shader;
+  };
+  const program = gl.createProgram();
+  gl.attachShader(program, compile(gl.VERTEX_SHADER, VERTEX, 'vertex shader'));
+  gl.attachShader(program, compile(gl.FRAGMENT_SHADER, FRAGMENT, 'fragment shader'));
+  gl.linkProgram(program);
+  assert.ok(gl.getProgramParameter(program, gl.LINK_STATUS), `link: ${gl.getProgramInfoLog(program)}`);
+  return program;
+}
+
+/** one pixel out of the current framebuffer as [r, g, b] (readPixels is bottom-up) */
+function pixelAt(gl, x, y) {
+  const px = new Uint8Array(4);
+  gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px);
+  return [px[0], px[1], px[2]];
+}
+
+const close = (a, b, tolerance = 6) => Math.abs(a - b) <= tolerance;
+const near = (got, want) => got.every((c, i) => close(c, want[i]));
+
+function mapAndWait(wnd, timeout = 1000) {
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      setTimeout(resolve, 50);
+    };
+    const timer = setTimeout(done, timeout);
+    wnd.once('expose', done);
+    wnd.map();
+  });
+}
+
+before(async () => {
+  if (!process.env.DISPLAY) {
+    skip = 'no DISPLAY set';
+    return;
+  }
+  keepalive = setInterval(() => {}, 1000);
+  try {
+    app = await withTimeout(
+      createClient({ glPolicy: 'auto' }),
+      5000,
+      'connecting to X server',
+      (late) => late.close()
+    );
+  } catch (err) {
+    skip = `cannot connect to X server: ${err.message}`;
+    return;
+  }
+  const caps = await app.glCapabilities();
+  if (!caps.direct) skip = `no direct rendering here: ${caps.reason.code} — ${caps.reason.message}`;
+  else if (caps.flavor !== 'appledri') skip = `direct here is ${caps.flavor}, not Apple-DRI`;
+});
+
+after(async () => {
+  clearInterval(keepalive);
+  await app?.close();
+});
+
+test('a shader-drawn frame renders into the exported surface', async (t) => {
+  if (skip) return t.skip(skip);
+  const width = 160;
+  const height = 120;
+
+  const config = await app.chooseGLConfig({ DEPTH_SIZE: 24 });
+  assert.equal(config.backend, 'direct');
+  assert.equal(config.flavor, 'appledri');
+
+  const wnd = app.createWindow({
+    width,
+    height,
+    visual: config.visual,
+    depth: config.depth,
+    backingStore: false
+  });
+
+  // gl.* works before the surface exists — the CGL context is synchronous —
+  // but nothing can be presented until the mapped window's surface attaches
+  const gl = wnd.getContext('opengl', config);
+  assert.equal(gl.backend, 'direct');
+  assert.equal(gl.flavor, 'appledri');
+  assert.equal(gl.canRender(), false, 'no surface before the window is mapped');
+  assert.equal(gl.SwapBuffers(), false, 'nothing to present into yet');
+
+  await mapAndWait(wnd);
+  await withTimeout(gl.ready, 5000, 'Apple-DRI surface attach');
+  assert.equal(gl.canRender(), true);
+  assert.ok(gl.renderer, 'a real renderer string once attached');
+
+  const program = buildProgram(gl);
+  gl.useProgram(program);
+  const buffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1]), gl.STATIC_DRAW);
+  const position = gl.getAttribLocation(program, 'position');
+  gl.enableVertexAttribArray(position);
+  gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+  // a triangle covering the bottom-left half in green, on a blue clear
+  gl.makeCurrent();
+  gl.viewport(0, 0, width, height);
+  gl.clearColor(0, 0, 1, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+  gl.uniform3f(gl.getUniformLocation(program, 'uColor'), 0, 1, 0);
+  gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+  // verified in the framebuffer before the flush — X-side GetImage cannot
+  // see a WindowServer-composited surface, readPixels can (bottom-up: low y
+  // is the bottom of the window, where the triangle is)
+  assert.ok(near(pixelAt(gl, 4, 4), [0, 255, 0]), `bottom-left should be the triangle, got ${pixelAt(gl, 4, 4)}`);
+  assert.ok(
+    near(pixelAt(gl, width - 4, height - 4), [0, 0, 255]),
+    `top-right should be the clear colour, got ${pixelAt(gl, width - 4, height - 4)}`
+  );
+
+  assert.equal(gl.SwapBuffers(), true, 'the frame was presented');
+
+  gl.destroy();
+  wnd.destroy();
+});
+
+test('the swap paces the loop: the gate closes on flush and reopens on its own', async (t) => {
+  if (skip) return t.skip(skip);
+  const config = await app.chooseGLConfig();
+  const wnd = app.createWindow({
+    width: 64,
+    height: 64,
+    visual: config.visual,
+    depth: config.depth,
+    backingStore: false
+  });
+  await mapAndWait(wnd);
+  const gl = wnd.getContext('opengl', config);
+  await withTimeout(gl.ready, 5000, 'Apple-DRI surface attach');
+
+  gl.makeCurrent();
+  gl.clearColor(0.2, 0.2, 0.2, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  assert.equal(gl.SwapBuffers(), true);
+  // no backpressure comes from the server on this path, so this gate is what
+  // keeps frameLoop-style callers at display rate instead of spinning
+  assert.equal(gl.canRender(), false, 'throttled right after a swap');
+  assert.equal(gl.SwapBuffers(), false, 'a second immediate swap is refused');
+
+  await withTimeout(
+    new Promise((resolve) => {
+      gl.onFrameAvailable = resolve;
+    }),
+    2000,
+    'the pacing gate reopening'
+  );
+  assert.equal(gl.canRender(), true);
+
+  gl.destroy();
+  wnd.destroy();
+});
+
+test('losing the surface on unmap re-attaches on the next map', async (t) => {
+  if (skip) return t.skip(skip);
+  const config = await app.chooseGLConfig();
+  const wnd = app.createWindow({
+    width: 64,
+    height: 64,
+    visual: config.visual,
+    depth: config.depth,
+    backingStore: false
+  });
+  await mapAndWait(wnd);
+  const gl = wnd.getContext('opengl', config);
+  await withTimeout(gl.ready, 5000, 'Apple-DRI surface attach');
+
+  // unmapping destroys the physical Quartz window, and the server says so
+  // with SurfaceNotify(destroyed) — no mask ever selected it
+  wnd.unmap();
+  await withTimeout(
+    new Promise((resolve) => {
+      const check = () => (gl.canRender() ? setTimeout(check, 10) : resolve());
+      check();
+    }),
+    2000,
+    'the surface-destroyed notify closing the gate'
+  );
+
+  // mapping again re-exports and re-attaches without a new context
+  const reattached = new Promise((resolve) => {
+    gl.onFrameAvailable = resolve;
+  });
+  wnd.map();
+  await withTimeout(reattached, 5000, 'the re-attach after remap');
+  assert.equal(gl.canRender(), true);
+
+  gl.makeCurrent();
+  gl.viewport(0, 0, 64, 64);
+  gl.clearColor(0, 1, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  assert.ok(near(pixelAt(gl, 32, 32), [0, 255, 0]), 'drawing works on the fresh surface');
+  assert.equal(gl.SwapBuffers(), true, 'and presenting does too');
+
+  gl.destroy();
+  wnd.destroy();
+});
+
+test('a resize is picked up by makeCurrent and drawn at the new size', async (t) => {
+  if (skip) return t.skip(skip);
+  const config = await app.chooseGLConfig();
+  const wnd = app.createWindow({
+    width: 120,
+    height: 90,
+    visual: config.visual,
+    depth: config.depth,
+    backingStore: false
+  });
+  await mapAndWait(wnd);
+  const gl = wnd.getContext('opengl', config);
+  await withTimeout(gl.ready, 5000, 'Apple-DRI surface attach');
+
+  gl.makeCurrent();
+  gl.clearColor(0, 0, 1, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.SwapBuffers();
+
+  wnd.resize(200, 150);
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  // the surface tracks the window server-side; makeCurrent tells the context
+  gl.makeCurrent();
+  gl.viewport(0, 0, 200, 150);
+  gl.clearColor(1, 0, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  const corner = pixelAt(gl, 196, 146);
+  assert.ok(near(corner, [255, 0, 0]), `the far corner exists at the new size and is red, got ${corner}`);
+
+  gl.destroy();
+  wnd.destroy();
+});

--- a/test/gl-direct-live.test.js
+++ b/test/gl-direct-live.test.js
@@ -97,6 +97,9 @@ before(async () => {
   }
   const caps = await app.glCapabilities();
   if (!caps.direct) skip = `no direct rendering here: ${caps.reason.code} — ${caps.reason.message}`;
+  // this file exercises the dri3 flavor (swapchain, DRI3 imports, Present
+  // pacing); the appledri one has its own — test/gl-appledri-live.test.js
+  else if (caps.flavor !== 'dri3') skip = `direct here is ${caps.flavor}, not DRI3`;
 });
 
 after(async () => {

--- a/test/gl-policy.test.js
+++ b/test/gl-policy.test.js
@@ -20,10 +20,11 @@ import {
 } from '../lib/gl.js';
 import { GLXError } from '../lib/glx.js';
 
-// registers both GL contexts on Drawable; the direct one wraps the 'opengl'
-// factory, which is what the dispatch tests below exercise
+// registers the GL contexts on Drawable; the direct ones wrap the 'opengl'
+// factory in turn, which is what the dispatch tests below exercise
 import '../lib/renderingcontext_opengl.js';
 import '../lib/renderingcontext_gles.js';
+import '../lib/renderingcontext_cgl.js';
 
 const withEnv = (value, fn) => {
   const had = Object.hasOwn(process.env, 'NTK_GL_POLICY');
@@ -44,25 +45,64 @@ const workingAddon = {
   listRenderNodes: () => ['/dev/dri/renderD128']
 };
 
-// a connection that can pass descriptors and has the extensions
+// the macOS shape of the same: no GBM/EGL, Apple-DRI + a WindowServer session
+const darwinAddon = {
+  probe: () => ({
+    platform: 'darwin',
+    gbm: 'GBM needs Linux DRM/dma-buf — no equivalent on darwin',
+    egl: 'no libEGL on this platform',
+    gles: true,
+    appledri: true
+  }),
+  listRenderNodes: () => [],
+  apple: { clientId: () => 0x1234 },
+  gl: {}
+};
+
+// a connection that can pass descriptors and has the extensions. `appledri`
+// simulates the server side of the Apple-DRI handshake glCapabilities runs on
+// the darwin flavor: the QueryExtension answer plus a wire stub that replies
+// to the one replied request the probe sends (QueryDirectRenderingCapable).
 function fakeApp({
   local = true,
   fdCapable = true,
   exts = { dri3: { fdCapable: true, major: 1, minor: 4 }, present: { major: 1, minor: 2 } },
+  appledri = null,
   glx = {},
   options = {}
 } = {}) {
+  const X = {
+    stream: fdCapable ? { _fdCapable: true, sendFds: () => {} } : {},
+    require: (name, cb) =>
+      queueMicrotask(() => (exts[name] ? cb(null, exts[name]) : cb(new Error(`unknown extension: ${name}`)))),
+    on: () => {}
+  };
+  if (appledri) {
+    const { present = true, capable = true } = appledri;
+    X.seq_num = 0;
+    X.replies = {};
+    X.eventParsers = {};
+    X.errorParsers = {};
+    X.QueryExtension = (name, cb) =>
+      queueMicrotask(() =>
+        cb(null, present ? { present: 1, majorOpcode: 130, firstEvent: 90, firstError: 140 } : { present: 0 })
+      );
+    X.pack_stream = {
+      put: () => {},
+      submit: (expectsReply) => {
+        if (!expectsReply) return;
+        const seq = X.seq_num;
+        queueMicrotask(() => {
+          const [decode, cb] = X.replies[seq];
+          cb(null, decode(Buffer.from([capable ? 1 : 0])));
+        });
+      }
+    };
+  }
   const app = {
     options,
-    display: {
-      isLocalSocket: local,
-      GLX: glx,
-      client: { stream: fdCapable ? { _fdCapable: true, sendFds: () => {} } : {} }
-    }
-  };
-  app.X = {
-    require: (name, cb) =>
-      queueMicrotask(() => (exts[name] ? cb(null, exts[name]) : cb(new Error(`unknown extension: ${name}`))))
+    X,
+    display: { isLocalSocket: local, GLX: glx, client: X }
   };
   Object.defineProperty(app, 'glPolicy', { get: () => resolveGLPolicy(app.options) });
   return app;
@@ -141,15 +181,50 @@ describe('probeDirect', () => {
     assert.match(probe.hint, /npm install x11-dri/);
   });
 
-  test('missing GPU libraries report which ones, and say Linux-only off Linux', () => {
+  test('missing GPU libraries report which ones, and name the supported platforms elsewhere', () => {
     setDriAddon({
-      probe: () => ({ platform: 'darwin', gbm: 'no libgbm on this platform', egl: true, gles: true }),
+      probe: () => ({ platform: 'freebsd', gbm: 'no libgbm on this platform', egl: true, gles: true }),
       listRenderNodes: () => []
     });
     const probe = probeDirect(DEFAULT_GL_POLICY);
     assert.equal(probe.code, GLError.NO_DRIVER);
     assert.match(probe.message, /no libgbm/);
-    assert.match(probe.hint, /Linux-only/);
+    assert.match(probe.hint, /Linux.*macOS/s);
+  });
+
+  test('darwin: the Apple-DRI flavor, no render node needed', () => {
+    setDriAddon(darwinAddon);
+    const probe = probeDirect(DEFAULT_GL_POLICY);
+    assert.equal(probe.ok, true);
+    assert.equal(probe.flavor, 'appledri');
+    assert.equal(probe.device, null, 'the window surface is the target — no DRM device scan');
+  });
+
+  test('darwin: an unusable Apple-DRI reports the reason and names XQuartz', () => {
+    setDriAddon({
+      ...darwinAddon,
+      probe: () => ({ platform: 'darwin', appledri: 'dlopen(/opt/X11/lib/libXplugin.1.dylib) failed' })
+    });
+    const probe = probeDirect(DEFAULT_GL_POLICY);
+    assert.equal(probe.code, GLError.NO_DRIVER);
+    assert.match(probe.message, /libXplugin/);
+    assert.match(probe.hint, /XQuartz/);
+  });
+
+  test('darwin: an addon predating Apple-DRI support says to upgrade', () => {
+    // x11-dri < 0.5.0 probes darwin without an `appledri` key at all
+    setDriAddon({
+      probe: () => ({ platform: 'darwin', gbm: 'no equivalent on darwin', egl: true, gles: true }),
+      listRenderNodes: () => []
+    });
+    const probe = probeDirect(DEFAULT_GL_POLICY);
+    assert.equal(probe.code, GLError.NO_DRIVER);
+    assert.match(probe.hint, /npm install x11-dri@latest/);
+  });
+
+  test('linux answers carry the flavor too', () => {
+    setDriAddon(workingAddon);
+    assert.equal(probeDirect(DEFAULT_GL_POLICY).flavor, 'dri3');
   });
 
   test('no render node is a permissions/container answer', () => {
@@ -253,6 +328,60 @@ describe('glCapabilities', () => {
     assert.equal(caps.indirect, false);
   });
 
+  test('darwin: direct through Apple-DRI, with no fd passing required', async () => {
+    setDriAddon(darwinAddon);
+    // fdCapable false is the point: Apple-DRI sends no descriptors, so the
+    // runtime check that gates the dri3 flavor must not gate this one
+    const caps = await glCapabilities(
+      fakeApp({ fdCapable: false, appledri: {}, options: { glPolicy: 'auto' } })
+    );
+    assert.equal(caps.direct, true);
+    assert.equal(caps.flavor, 'appledri');
+    assert.equal(caps.device, null);
+    assert.equal(caps.appleClientId, 0x1234);
+    assert.ok(caps.AppleDRI, 'the extension object rides along for the context');
+    assert.equal(caps.DRI3, null);
+  });
+
+  test('darwin: a server without Apple-DRI asks whether this is XQuartz', async () => {
+    setDriAddon(darwinAddon);
+    const caps = await glCapabilities(
+      fakeApp({ appledri: { present: false }, options: { glPolicy: 'auto' } })
+    );
+    assert.equal(caps.reason.code, GLError.NO_APPLEDRI);
+    assert.match(caps.reason.hint, /XQuartz/);
+  });
+
+  test('darwin: a server that answers "not capable" is the same coded no', async () => {
+    setDriAddon(darwinAddon);
+    const caps = await glCapabilities(
+      fakeApp({ appledri: { capable: false }, options: { glPolicy: 'auto' } })
+    );
+    assert.equal(caps.reason.code, GLError.NO_APPLEDRI);
+    assert.match(caps.reason.message, /not direct-rendering capable/);
+  });
+
+  test('darwin: no WindowServer session (SSH) is its own remedy', async () => {
+    setDriAddon({
+      ...darwinAddon,
+      apple: {
+        clientId: () => {
+          throw new Error('xp_init failed: no connection to the WindowServer');
+        }
+      }
+    });
+    const caps = await glCapabilities(fakeApp({ appledri: {}, options: { glPolicy: 'auto' } }));
+    assert.equal(caps.reason.code, GLError.NO_WINDOWSERVER);
+    assert.match(caps.reason.hint, /SSH/);
+    assert.match(caps.reason.hint, /GUI session/);
+  });
+
+  test('darwin: a remote display is refused before anything else, like linux', async () => {
+    setDriAddon(darwinAddon);
+    const caps = await glCapabilities(fakeApp({ local: false, options: { glPolicy: 'auto' } }));
+    assert.equal(caps.reason.code, GLError.REMOTE_DISPLAY);
+  });
+
   test('asked once, cached after', async () => {
     setDriAddon(workingAddon);
     const app = fakeApp({ options: { glPolicy: 'auto' } });
@@ -341,6 +470,69 @@ describe("getContext('opengl') dispatch", () => {
       assert.throws(() => dispatch(fakeWindow('direct', { direct: false, reason })), {
         code: GLError.NO_DEVICE
       });
+    });
+  });
+
+  // enough of a darwin capability answer and a window for the CGL context to
+  // construct against — an unmapped window, so no surface round trip starts
+  const appleCaps = () => ({
+    direct: true,
+    flavor: 'appledri',
+    AppleDRI: { NotifyKind: { Changed: 0, Destroyed: 1 } },
+    appleClientId: 0x1234
+  });
+  const appleContextStub = class {
+    attach() {}
+    makeCurrent() {}
+    flush() {}
+    update() {}
+    destroy() {}
+  };
+  const fakeAppleWindow = () => {
+    const window = fakeWindow('auto', appleCaps());
+    window.on = () => {};
+    window.removeListener = () => {};
+    window._mapped = false;
+    return window;
+  };
+
+  test("the appledri flavor routes 'opengl' to the CGL context", () => {
+    withEnv(undefined, () => {
+      setDriAddon({ ...darwinAddon, apple: { ...darwinAddon.apple, Context: appleContextStub } });
+      const gl = dispatch(fakeAppleWindow());
+      assert.equal(gl.backend, 'direct');
+      assert.equal(gl.flavor, 'appledri');
+      assert.equal(gl.canRender(), false, 'nothing to render into before the surface attaches');
+    });
+  });
+
+  test("'gles' by name on the appledri flavor points at the neutral name", () => {
+    withEnv(undefined, () => {
+      setDriAddon(darwinAddon);
+      assert.throws(
+        () => Drawable.renderingContextFactory['gles'](fakeAppleWindow(), {}),
+        (err) => {
+          assert.equal(err.code, GLError.CONTEXT_FAILED);
+          assert.match(err.message, /appledri/);
+          assert.match(err.hint, /'opengl'/);
+          return true;
+        }
+      );
+    });
+  });
+
+  test("'cgl' by name on the dri3 flavor points back the same way", () => {
+    withEnv(undefined, () => {
+      setDriAddon(workingAddon);
+      const window = fakeWindow('auto', { direct: true, flavor: 'dri3', device: '/dev/dri/renderD128' });
+      assert.throws(
+        () => Drawable.renderingContextFactory['cgl'](window, {}),
+        (err) => {
+          assert.equal(err.code, GLError.CONTEXT_FAILED);
+          assert.match(err.message, /dri3/);
+          return true;
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
The direct GL backend gains a second flavor: on macOS/XQuartz the server exports the window's WindowServer surface over the Apple-DRI extension and a CGL context draws straight into it — the same `gl` API, the same GLSL ES 1.00 shaders and the same context contract as the Linux DRI3 path, so `getContext('opengl')` draw code runs unchanged on both. Client half shipped by x11-dri 0.5.0; integration map in sidorares/node-x11-dri#12.

## How the path works

DRI3 is client-allocates-and-pushes; Apple-DRI is the mirror image — the server exports the window's surface to the client:

```
this process                              X server (XQuartz)
------------                              ------------------
apple.clientId()  --- AppleDRICreateSurface(win, cid) --->  exports the
                  <-------------- key[2] ----------------   window's surface
ctx.attach(key)      import surface + bind a CGL context
gl draws straight into the window's backing store
ctx.flush()          CGLFlushDrawable - the WindowServer composites
                  <--- AppleDRISurfaceNotify ------------   moved / resized /
                                                            destroyed
```

After attach, no pixels, no descriptors and no per-frame requests cross the X socket.

## What's in the PR

- **`lib/appledri.js`** — the Apple-DRI protocol binding, requests, replies, events and errors: `QueryVersion`, `QueryDirectRenderingCapable`, `CreateSurface` -> `{ key, uid }`, `DestroySurface`, the unsolicited classic `AppleDRISurfaceNotify` event, and the two extension errors decoded to actionable messages. Written in node-x11's `lib/ext` style so it can move upstream verbatim.
- **`lib/gl.js`** — the direct backend now resolves a per-platform *flavor*, `dri3` or `appledri`, exposed on `glCapabilities()` and `chooseGLConfig()`. The darwin branch needs no render node and **no fd passing** — the runtime gate that blocks Bun on Linux does not apply. New coded errors: `GL_NO_APPLEDRI` for a server that is not XQuartz, `GL_NO_WINDOWSERVER` for SSH sessions, each with its own remedy.
- **`lib/renderingcontext_cgl.js`** — the context, same contract as the GLES one: surface export + attach after MapNotify with `ready` settling there; `AppleDRISurfaceNotify` routed by surface uid through an app-level map — it is a classic event with no window id, so neither the GenericEvent sink nor per-window dispatch can carry it; kind 0 -> `ctx.update()`, kind 1 -> automatic re-export and re-attach on the next map; and since `flush()` has no backpressure, each swap closes the `canRender()` gate for 3/4 of a display period and `onFrameAvailable` reopens it — the same pacing contract IdleNotify drives on Linux, so draw loops written for one flavor pace correctly on the other.
- **Dispatch** — `getContext('opengl')` picks the flavor; `'gles'` and `'cgl'` name one each and cross-throw with pointers to the neutral name.
- **Tests** — `test/appledri.test.js` pins the wire encoding hermetically; `test/gl-policy.test.js` grows the darwin probe/capability/dispatch decisions, all CI-runnable with the addon stubbed; `test/gl-appledri-live.test.js` runs the real thing against XQuartz and verifies with `gl.readPixels`; the DRI3 live suite now skips itself on the other flavor.
- **Docs** — `docs/context-gles.md` rewritten around the two flavors with a macOS section; README, docs index and AGENTS updated. `x11-dri` floor raised to 0.5.0, keeping the any-0.x range.

## Verified on Apple M1 Pro, macOS 15, XQuartz 21.1.23

| check | result |
| --- | --- |
| shader triangle via `getContext('opengl')` | renderer "Apple M1 Pro", GL 4.1 Metal, verified by `readPixels` |
| `examples/gles-triangle.js` unchanged draw code | animates at the window frame clock's rate |
| pacing | gate closes on swap, `onFrameAvailable` reopens it |
| unmap -> `SurfaceNotify` destroyed -> remap | re-exports and re-attaches on its own |
| resize | picked up by `makeCurrent()`, drawn at the new size |
| full suite `DISPLAY=:9 npm test` | 1107 pass, 0 fail |
| no DISPLAY / Xvfb shape | live suites skip, hermetic suites pass |

<img src="https://github.com/user-attachments/assets/15980378-7e50-4ac9-9adf-fe2ccc42a496" width="480" alt="gradient shader triangle rendered on the GPU through XQuartz">

*Rendered by this branch's own code and read back with `gl.readPixels` — X-side `GetImage` deliberately not used: the WindowServer composites the GL surface above the X framebuffer, so X-side reads show stale pixels. That quirk is documented in the new macOS docs section.*
