### PR TITLE
fix(app): fall back to the native display rate when RandR's answer is implausible

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,7 +1,7 @@
 import { connectionGone } from './cleanup.js';
 import Clipboard from './clipboard.js';
 import { CursorCache } from './cursor.js';
-import { GLError, backendFor, glCapabilities, glError, resolveGLPolicy } from './gl.js';
+import { GLError, backendFor, glCapabilities, glError, nativeRefreshRate, resolveGLPolicy } from './gl.js';
 import { chooseGLXConfig } from './glx.js';
 import Picture from './picture.js';
 import Pixmap from './pixmap.js';
@@ -254,6 +254,19 @@ export default class App {
   _probeRefreshRate() {
     this._refreshProbe = null; // in progress; only ever started once
     const X = this.X;
+    // RandR's answer, or the native layer's where RandR has no usable one.
+    // An implausible rate is treated as no answer, not clamped: XQuartz
+    // synthesizes real timing for its canned mode list but fills the current
+    // desktop-sized mode with dot_clock = width * height — exactly 1 Hz — so
+    // the number that describes what is actually driving the panel has to
+    // come from the OS (x11-dri >= 0.6.0, apple.refreshRate()).
+    const plausible = (rate) => rate >= MIN_REFRESH_RATE && rate <= MAX_REFRESH_RATE;
+    const settle = (rate) => {
+      if (!plausible(rate)) rate = nativeRefreshRate();
+      if (!rate || !plausible(rate)) return;
+      this._refreshRate = rate;
+      this._adoptFrameInterval(1000 / rate);
+    };
     // A connection on its way out is one more "no rate to be had". The probe
     // is started lazily by the first window built on this connection, which
     // may be one adopted from an event still arriving as it closes — and
@@ -261,10 +274,10 @@ export default class App {
     // event dispatch has no caller to catch it (issue #321).
     if (connectionGone(X)) return;
     X.require('randr', (err, R) => {
-      if (err || !R) return;
+      if (err || !R) return settle(0);
       const root = this.display.screen[0].root;
       R.GetScreenResourcesCurrent(root, (resourcesError, resources) => {
-        if (resourcesError || !resources?.crtcs?.length) return;
+        if (resourcesError || !resources?.crtcs?.length) return settle(0);
         const modes = new Map(resources.modeinfos.map((mode) => [mode.id, mode]));
         let pending = resources.crtcs.length;
         let best = 0;
@@ -273,9 +286,7 @@ export default class App {
             // a crtc with no mode is one that is switched off
             if (!crtcError && info) best = Math.max(best, modeRate(modes.get(info.mode)));
             if (--pending) return;
-            if (best < MIN_REFRESH_RATE || best > MAX_REFRESH_RATE) return;
-            this._refreshRate = best;
-            this._adoptFrameInterval(1000 / best);
+            settle(best);
           });
         }
       });

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -171,6 +171,22 @@ export function setDriAddon(module) {
   addon = module;
 }
 
+/**
+ * The display's refresh rate asked of the native layer, in Hz, for servers
+ * whose RandR carries no usable timing — XQuartz reports the current
+ * desktop-sized mode with dot_clock = width * height, exactly 1 Hz.
+ * `null` everywhere there is no answer: not darwin, no addon (or one
+ * predating 0.6.0), or a session with no display to ask.
+ */
+export function nativeRefreshRate() {
+  if (globalThis.process?.platform !== 'darwin') return null;
+  try {
+    return loadDriAddon()?.apple?.refreshRate?.() ?? null;
+  } catch {
+    return null;
+  }
+}
+
 const INSTALL_HINT = `Direct rendering needs the optional native addon:
 
   npm install x11-dri

--- a/test/refresh-rate.test.js
+++ b/test/refresh-rate.test.js
@@ -4,10 +4,22 @@
 // so an animation loop on a 165Hz screen is not held to the 62.5fps that a
 // hardcoded 16ms implies.
 import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { afterEach, beforeEach, test } from 'node:test';
 import { setImmediate as tick } from 'node:timers/promises';
 
 import App from '../lib/app.js';
+import { setDriAddon } from '../lib/gl.js';
+
+// Hermetic by default: the probe's native fallback (nativeRefreshRate) must
+// see the addon this file stubs, never a real x11-dri that happens to be
+// installed on the machine running the tests.
+beforeEach(() => setDriAddon(null));
+afterEach(() => setDriAddon(undefined)); // back to the real loader
+
+// nativeRefreshRate answers null off darwin before ever touching the addon,
+// so the stub-fed fallback tests only mean something there. CI still runs
+// every RandR-side test, including the 1Hz fixture degrading to the default.
+const onDarwin = { skip: process.platform !== 'darwin' && 'nativeRefreshRate is darwin-only' };
 
 let nextId = 0xd000;
 
@@ -29,6 +41,13 @@ const MODE_60 = {
 };
 /** What Xvfb reports: a mode with no pixel clock at all. */
 const MODE_VIRTUAL = { id: 3, dot_clock: 0, h_total: 0, v_total: 0, modeflags: 0 };
+/**
+ * What XQuartz reports as the *current* mode: a dynamically-created
+ * desktop-sized entry with dot_clock = width * height — exactly 1Hz. Real
+ * timing exists in its canned mode list, but the CRTC points here (issue
+ * #328). Copied verbatim from a live XQuartz dump.
+ */
+const MODE_XQUARTZ_1HZ = { id: 4, dot_clock: 12_902_400, h_total: 5120, v_total: 2520, modeflags: 0 };
 
 /** every reply lands a tick later, the way a real server's does */
 const reply = (cb, ...args) => setImmediate(() => cb(...args));
@@ -139,6 +158,78 @@ test('a mode with no pixel clock leaves the default alone', async () => {
 
 test('a server without RandR leaves the default alone', async () => {
   const app = makeApp({ randr: false });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.equal(app.refreshRate, null);
+  assert.equal(wnd.frameInterval, 16);
+  wnd.destroy();
+});
+
+test('an implausible rate is no answer, not a rate', async () => {
+  // XQuartz's 1Hz current mode, with nothing native to fall back on: the
+  // 1 must be discarded (a 1Hz display is not a display), not adopted and
+  // not clamped — this is the shape that defeats `if (!rate)`, since 1 is
+  // truthy. This is also the CI path on Linux, where the native layer
+  // answers null by construction.
+  const app = makeApp({ modeinfos: [MODE_XQUARTZ_1HZ], crtcs: { 10: 4 } });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.equal(app.refreshRate, null, 'no rate to be had');
+  assert.equal(wnd.frameInterval, 16, 'so the window keeps the default');
+  wnd.destroy();
+});
+
+test("XQuartz's 1Hz current mode falls back to the native rate", onDarwin, async () => {
+  setDriAddon({ apple: { refreshRate: () => 120 } });
+  const app = makeApp({ modeinfos: [MODE_XQUARTZ_1HZ], crtcs: { 10: 4 } });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 120) < 0.5, `the OS's 120Hz: ${app.refreshRate}`);
+  assert.ok(
+    Math.abs(wnd.frameInterval - 1000 / 120) < 0.01,
+    `8.33ms, adopted by the window: ${wnd.frameInterval}`
+  );
+  wnd.destroy();
+});
+
+test('a server without RandR still gets the native rate', onDarwin, async () => {
+  setDriAddon({ apple: { refreshRate: () => 120 } });
+  const app = makeApp({ randr: false });
+  app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 120) < 0.5, `120Hz: ${app.refreshRate}`);
+});
+
+test('RandR stays authoritative when its answer is plausible', onDarwin, async () => {
+  let asked = 0;
+  setDriAddon({
+    apple: {
+      refreshRate: () => {
+        asked++;
+        return 120;
+      }
+    }
+  });
+  const app = makeApp(); // one output, a real 165Hz mode
+  app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.ok(Math.abs(app.refreshRate - 165) < 0.5, `RandR's 165, not the OS's 120: ${app.refreshRate}`);
+  assert.equal(asked, 0, 'the native layer was never consulted');
+});
+
+test('an implausible native answer is discarded like an implausible RandR one', onDarwin, async () => {
+  setDriAddon({ apple: { refreshRate: () => 1 } });
+  const app = makeApp({ modeinfos: [MODE_VIRTUAL], crtcs: { 10: 3 } });
+  const wnd = app.createWindow({ width: 100, height: 100 });
+  await settle();
+  assert.equal(app.refreshRate, null, 'no rate to be had');
+  assert.equal(wnd.frameInterval, 16);
+  wnd.destroy();
+});
+
+test('an addon predating apple.refreshRate leaves the default alone', onDarwin, async () => {
+  setDriAddon({ apple: {} }); // x11-dri < 0.6.0
+  const app = makeApp({ modeinfos: [MODE_VIRTUAL], crtcs: { 10: 3 } });
   const wnd = app.createWindow({ width: 100, height: 100 });
   await settle();
   assert.equal(app.refreshRate, null);


### PR DESCRIPTION
Closes #328.

On the Apple-DRI flavor everything paced by `app.frameInterval` — the fence clock, `requestAnimationFrame`, and `RenderingContextCGL`'s post-swap gate — ran at the 60Hz fallback on a 120Hz panel. XQuartz fills the dynamically-created *current* mode with `dot_clock = width × height` — exactly 1Hz — which `_probeRefreshRate` correctly discards as below `MIN_REFRESH_RATE`, leaving no rate at all. The canned mode list carries real synthetic timing, but it describes what the panel *could* do, not what drives it, so the number has to come from the OS.

### Change

- **`lib/gl.js`**: `nativeRefreshRate()` next to `loadDriAddon()` — asks x11-dri ≥ 0.6.0's `apple.refreshRate()` (sidorares/node-x11-dri#14 / #15), behind a darwin guard so Linux never touches the addon loader. `null` everywhere there is no answer.
- **`lib/app.js`**: `_probeRefreshRate` funnels every give-up point through one `settle` step: an absent *or implausible* RandR answer consults the native layer. Crucially the fallback triggers on implausibility, not falsiness — 1 is truthy, which defeats `if (!rate)`.

Design notes (from the issue, all hold in this implementation):

- RandR stays authoritative — the native query only runs when RandR's answer is absent or outside `[MIN_REFRESH_RATE, MAX_REFRESH_RATE]`.
- Linux/CI untouched by construction: platform guard before the loader, and Xvfb's all-zero modes degrade exactly as today (`settle(0)` → native `null` → no rate → default).
- No new async — `apple.refreshRate()` is synchronous, so the "windows adopt the interval when it lands" flow is unchanged.
- No dependency change: `>=0.5.0 <1` already admits 0.6.0; an older addon answers `undefined` → `null`.

### Tests

`test/refresh-rate.test.js` now pins the addon seam (`setDriAddon(null)`) so the fallback never sees a real x11-dri on the machine running the suite, and adds:

- the **1Hz-current-mode regression fixture** (verbatim from a live XQuartz dump), cross-platform: an implausible rate is *no answer*, not a rate — the shape that defeats `if (!rate)`;
- darwin-only stub tests (skipped elsewhere, where the platform guard makes the stub unreachable by design): 1Hz mode → native 120 → 8.33ms adopted by windows; no-RandR server → native rate; RandR authoritative when plausible (native never consulted); implausible native answer discarded; pre-0.6.0 addon leaves the default alone.

### Verified

- `node --test test/refresh-rate.test.js`: 13/13 pass.
- Full suite: 1105 pass / 4 fail — the 4 (`extension-events-live`, `pict-format`) fail identically on `master` on this machine, pre-existing and unrelated.
- **End-to-end on a live XQuartz** (M1 Pro, 120Hz ProMotion) with x11-dri 0.6.0 fed through `setDriAddon`: `app.refreshRate` = 120, `app.frameInterval` = 8.33ms, adopted by a window created before the probe answered — previously `null` / 16ms default.