### PR TITLE
fix(window): answer the motion hint with QueryPointer, so it thins motion instead of stopping it

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -567,6 +567,48 @@ up the fence, and so does the vblank clock (a completion is an event, not a
 reply); the flush then happens when the event loop is about to poll — still
 one write per frame.
 
+### Hinted motion — `setMouseHintOnly(isOn)`
+
+Coalescing decides how much motion your handlers *see*; it does nothing about
+how much of it crosses the wire. Every `MotionNotify` is 32 bytes the server
+sends whether or not the frame it lands in wants it, and a window on XI2 pays
+around 136 bytes per pointer move — some 8 KB/s at 60 Hz. On a local socket
+that is free. Over ssh, a tunnel or a slow network it is not.
+
+`setMouseHintOnly(true)` selects X's `PointerMotionHint`, which changes the
+deal with the server: it reports the pointer moving **once**, with a
+`MotionNotify` whose detail is `NotifyHint`, and then says nothing more about
+it until the client asks where the pointer went. ntk does the asking — the
+frame that delivers a hinted move sends the `QueryPointer` that lets the
+server speak again, one poll per frame and one in flight at a time, which is
+the same rate coalescing already reduces motion to. The reply is delivered as
+a `mousemove` too when it lands somewhere no event reported (`synthetic:
+true`), which is how the last position of a gesture that ends mid-flight
+still arrives.
+
+What you buy and what you pay are the same thing: motion stops being paced by
+the input device and starts being paced by the connection.
+
+- **bandwidth** falls, a lot. Measured on XQuartz, 600 pointer moves: 21.9 KB
+  from the server without the hint, 8.4 KB with it, for the same number of
+  events delivered to the handler. On a link where bytes are the constraint
+  the saving grows with the round-trip time, because that is what now sets
+  the sampling rate.
+- **latency** rises. A handler acts on a position up to one round trip old,
+  and no amount of pointer movement produces a sample faster than the
+  connection answers.
+
+So: reach for it when bandwidth is the problem, leave it alone when latency
+is — which is the opposite of what "reduces motion events" usually suggests.
+`setMouseHintOnly(false)` puts the stream back.
+
+Two things it is not. It does not *select* motion — the hint modifies
+`PointerMotion`, so a window with no `mousemove` listener still receives
+nothing — and it is not an XI2 control: a window that called
+`selectXI2(['Motion'])` is off the core motion stream altogether (see
+[Wheel and smooth scrolling](#wheel-and-smooth-scrolling)), and the core
+hint has nothing left to thin.
+
 ### requestAnimationFrame
 
 For animation and manual render scheduling, windows offer the DOM-style
@@ -660,7 +702,11 @@ All return `this` unless noted.
   AlreadyGrabbed. With `ownerEvents` the client's own windows still get
   their events normally, so a submenu keeps working
 - `grabKeyboard(options, cb)` / `ungrabKeyboard(time)` — the same for keys
-- `queryPointer(cb)`, `setMouseHintOnly(isOn)`
+- `queryPointer(cb)` — `cb(err, { root, child, rootX, rootY, childX, childY,
+  keyMask, sameScreen })`: where the pointer is right now
+- `setMouseHintOnly(isOn)` — trade motion events for round trips on a
+  bandwidth-constrained connection, see
+  [Hinted motion](#hinted-motion--setmousehintonlyison)
 - `selectXI2(types, options)` — take this window's input from XInput 2:
   smooth scrolling, per-device ids, touch. Returns a promise for whether the
   server has XI2, not `this` — see
@@ -1321,7 +1367,7 @@ constructor arg) automatically extends the window's X event mask.
 | event | X event | notes |
 |---|---|---|
 | `mousedown` / `mouseup` | ButtonPress/Release | `ev.x`, `ev.y`, `ev.keycode` (button) |
-| `mousemove` | MotionNotify | coalesced per frame; full trail in `ev.coalesced` |
+| `mousemove` | MotionNotify | coalesced per frame; full trail in `ev.coalesced`. Under [hinted motion](#hinted-motion--setmousehintonlyison) one per frame may be `synthetic`, built from a `QueryPointer` reply |
 | `wheel` | ButtonPress 4-7, or an XI2 scroll valuator | derived: `ev.deltaX`/`ev.deltaY` in notches, positive down and right. Coalesced per frame, and a frame's deltas **add up**. See [Wheel and smooth scrolling](#wheel-and-smooth-scrolling) |
 | `touchstart` / `touchmove` / `touchend` | XI2 TouchBegin/Update/End | only with `selectXI2(['TouchBegin', …])`; `ev.touchId` identifies the finger |
 | `mouseover` / `mouseout` | Enter/LeaveNotify | |

--- a/lib/window.js
+++ b/lib/window.js
@@ -109,6 +109,16 @@ const REFRESH_QUANTILE = 0.25;
 const STALL_TIMEOUT = 2000;
 const STALL_TIMEOUT_FIRST = 250;
 
+/**
+ * MotionNotify detail saying "this is the only motion you get until you ask".
+ *
+ * The core protocol calls it NotifyHint and puts it in the event's detail
+ * byte; node-x11 parses a MotionNotify's detail into `keycode`, the field
+ * that carries a button number on ButtonPress — so this is compared against
+ * `ev.keycode`, not `ev.detail`, which motion events do not have.
+ */
+const MOTION_NOTIFY_HINT = 1;
+
 function rectArea(r) {
   return Math.max(0, r.w) * Math.max(0, r.h);
 }
@@ -493,6 +503,15 @@ export default class Window extends Drawable {
     this._geSinkOpcode = 0;
     // XI2 state, once a window has selected it (see selectXI2)
     this._xi2 = null;
+    // PointerMotionHint bookkeeping (see setMouseHintOnly and
+    // _rearmMotionHint): whether a frame owes the server the QueryPointer
+    // that re-arms the hint, whether one is already in flight, the timestamp
+    // of the hint that asked for it, and the last position delivered — a
+    // reply that repeats it is not an event.
+    this._hintRearm = false;
+    this._hintPollPending = false;
+    this._hintTime = 0;
+    this._hintLast = null;
     // The vblank clock (see _onPresentComplete): the period learnt from
     // completion events, the samples it is drawn from, and the latch the
     // watchdog sets when completions stop arriving.
@@ -761,6 +780,21 @@ export default class Window extends Drawable {
           ev.group = key.group;
           if (key.codepoint !== undefined) ev.codepoint = key.codepoint;
         }
+      }
+      // the server saying "the pointer moved, and I will say no more about it
+      // until you ask": the event still carries the position it was generated
+      // at, so it is delivered like any other move, but the conversation has
+      // to be picked back up or this is the last one (see _rearmMotionHint)
+      if (eventName === 'mousemove' && ev.keycode === MOTION_NOTIFY_HINT) {
+        this._hintTime = ev.time;
+        this._hintLast = { x: ev.x, y: ev.y };
+        this._hintRearm = true;
+        this._deliverEvent(eventName, ntkev);
+        // the frame that just took the move sends the poll — one per frame,
+        // which is the rate a frame's worth of motion is reduced to anyway.
+        // An uncoalesced window has no frame to hang it on, so it goes now.
+        if (!this._coalesce) this._rearmMotionHint();
+        return;
       }
       // a wheel is a button in the core protocol; say so in the units a
       // consumer wants. Suppressed once XI2 is delivering the same scroll as
@@ -1393,6 +1427,9 @@ export default class Window extends Drawable {
     )
       return;
     this._flushCoalesced();
+    // after the flush: the frame's motion has been delivered, so what the
+    // server is asked for now is what happened since
+    if (this._hintRearm) this._rearmMotionHint();
     if (f.needsRedraw) {
       f.needsRedraw = false;
       const ev = {
@@ -1987,6 +2024,9 @@ export default class Window extends Drawable {
     f.rafCbs = [];
     f.needsRedraw = false;
     this._presentPending = false;
+    // a window with no frames left has nothing to send the poll from
+    this._hintRearm = false;
+    this._hintLast = null;
   }
 
   /**
@@ -3252,17 +3292,108 @@ export default class Window extends Drawable {
     return this;
   }
 
+  /**
+   * Trade motion events for round trips: ask the server to report the pointer
+   * moving *once*, and then wait to be asked where it went.
+   *
+   * PointerMotionHint is a two-party protocol. With it selected the server
+   * may send a single MotionNotify carrying detail NotifyHint and then say
+   * nothing more about the pointer until the client asks — so a window that
+   * only sets the bit hears about one move and then silence (issue #319).
+   * ntk holds up the other end: a hinted move is delivered with the position
+   * it carries, and the frame it lands in sends the QueryPointer that lets
+   * the server speak again (see _rearmMotionHint).
+   *
+   * What that buys, and what it costs, are the same thing. Motion stops being
+   * paced by the input device and starts being paced by the connection: one
+   * event per round trip instead of one per hardware sample, which is a large
+   * saving on a link where bytes are scarce — X over ssh, a tunnel, a slow
+   * network — and no saving at all on a local socket, where the poll costs
+   * more bytes than the events it replaced. It also means a handler acts on a
+   * position that is up to one round trip old. Reach for it when bandwidth is
+   * the problem; leave it alone when latency is.
+   *
+   * Two things it is not:
+   *
+   *   - not a substitute for selecting motion. The hint modifies
+   *     PointerMotion, it does not imply it — a window with no `mousemove`
+   *     listener and no PointerMotion in its mask receives nothing either way.
+   *   - not an XI2 control. A window that called `selectXI2(['Motion'])` is
+   *     off the core motion stream entirely (see lib/xi2.js), and the core
+   *     hint has nothing left to thin.
+   */
   setMouseHintOnly(isOn) {
     if (isOn && !(this.eventMask & x11.eventMask.PointerMotionHint)) {
       this.eventMask |= x11.eventMask.PointerMotionHint;
     } else if (!isOn && this.eventMask & x11.eventMask.PointerMotionHint) {
       this.eventMask &= ~x11.eventMask.PointerMotionHint;
+      // the server will report motion on its own again, so no frame owes it a
+      // question. A poll already in flight is left alone: its answer is a
+      // real position, and it is deduped against the last one like any other.
+      this._hintRearm = false;
     } else {
       return this;
     }
     // no callback: it would only buy node-x11's void-sync round trip, see setCursor
     this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask });
     return this;
+  }
+
+  /**
+   * Answer a NotifyHint: ask where the pointer is, which is what re-arms the
+   * server, and deliver the answer if it moved somewhere no event reported.
+   *
+   * The reply is not redundant with the hint that asked for it. Between the
+   * hint being generated and the server processing this request the pointer
+   * may have moved again, and that motion produces no event — it is exactly
+   * what the hint suppressed. Dropped, the last position of a gesture that
+   * ends mid-flight is lost and the window's idea of where the pointer is
+   * stays wrong until it moves again. So the poll's position is delivered as
+   * a motion event when it differs from the last one delivered, and nothing
+   * is emitted when the pointer sat still.
+   *
+   * One poll at a time, and one per frame: a burst of motion cannot queue a
+   * round trip each, and the flag stays raised if a poll is already out, so
+   * the next frame picks it up.
+   */
+  _rearmMotionHint() {
+    if (this._hintPollPending) return;
+    this._hintRearm = false;
+    if (this._destroyed || connectionGone(this.X)) return;
+    this._hintPollPending = true;
+    const time = this._hintTime;
+    this.X.QueryPointer(this.id, (err, pointer) => {
+      this._hintPollPending = false;
+      if (err || this._destroyed || connectionGone(this.X)) return;
+      // the pointer is on another screen: `child` and the window-relative
+      // coordinates are zero by protocol, not a position (core QueryPointer)
+      if (!pointer.sameScreen) return;
+      const last = this._hintLast;
+      if (last && last.x === pointer.childX && last.y === pointer.childY) return;
+      this._hintLast = { x: pointer.childX, y: pointer.childY };
+      this._deliverEvent('mousemove', {
+        type: 6,
+        name: 'MotionNotify',
+        // the poll has no timestamp of its own — QueryPointer's reply carries
+        // no time — so the event is stamped with the hint that prompted it
+        time,
+        keycode: 0,
+        root: pointer.root,
+        wid: this.id,
+        child: pointer.child,
+        rootx: pointer.rootX,
+        rooty: pointer.rootY,
+        x: pointer.childX,
+        y: pointer.childY,
+        buttons: pointer.keyMask,
+        sameScreen: pointer.sameScreen,
+        // built from a reply rather than read off the wire, the way a paced
+        // window's redraw events are
+        synthetic: true,
+        window: this,
+        target: this
+      });
+    });
   }
 
   queryPointer(callback) {

--- a/test/motion-hint-live.test.js
+++ b/test/motion-hint-live.test.js
@@ -1,0 +1,108 @@
+// PointerMotionHint against a real X server (issue #319).
+//
+// The half a mock cannot supply: whether the server actually stops talking.
+// With the hint selected it may send one MotionNotify carrying detail
+// NotifyHint and then say nothing more until the client asks — measured on
+// XQuartz, 600 pointer warps produced exactly one event from a client that
+// never asked, and continuous motion from one that does. Only a server
+// decides that, so only a server can show the fix works.
+//
+// Skipped where there is no DISPLAY.
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+
+import { createClient } from '../lib/index.js';
+import { withTimeout } from './helpers/async.js';
+
+let app = null;
+let skip = false;
+let keepalive = null;
+
+before(async () => {
+  if (!process.env.DISPLAY) {
+    skip = 'no DISPLAY set';
+    return;
+  }
+  keepalive = setInterval(() => {}, 1000);
+  try {
+    app = await withTimeout(createClient(), 5000, 'connecting to X server', (late) => late.close());
+  } catch (err) {
+    skip = `cannot connect to X server: ${err.message}`;
+  }
+});
+
+after(async () => {
+  clearInterval(keepalive);
+  await app?.close();
+});
+
+/** Map and wait until the server will deliver pointer events to the window. */
+const mapAndWait = (wnd) =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, 1000);
+    wnd.once('expose', () => {
+      clearTimeout(timer);
+      setTimeout(resolve, 50);
+    });
+    wnd.map();
+  });
+
+/** A round trip, which is also long enough for a frame to have run. */
+const settle = () =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setTimeout(resolve, 25)));
+
+/**
+ * Move the pointer to a spot in the window and wait for the move to be
+ * reported there.
+ *
+ * Matched on the coordinates rather than on "an event arrived", because a
+ * real server has a real pointer on it and the suite runs its files in
+ * parallel: someone brushing the touchpad, or another test warping the
+ * pointer into its own window, is otherwise a failure. Re-warping on each
+ * try is what makes that recoverable.
+ */
+const warpTo = async (wnd, x, y, seen) => {
+  const before = seen.length;
+  for (let tries = 0; tries < 20; tries++) {
+    app.X.WarpPointer(0, wnd.id, 0, 0, 0, 0, x, y);
+    await settle();
+    if (seen.slice(before).some((ev) => ev.x === x && ev.y === y)) return true;
+  }
+  return false;
+};
+
+const SPOTS = [
+  [30, 40],
+  [70, 55],
+  [120, 90],
+  [45, 130],
+  [150, 25]
+];
+
+test('a window that asks for hinted motion keeps hearing about it', async (t) => {
+  if (skip) return t.skip(skip);
+  const wnd = app.createWindow({ width: 200, height: 200, backingStore: false });
+  const moves = [];
+  wnd.on('mousemove', (ev) => moves.push(ev));
+  await mapAndWait(wnd);
+  await warpTo(wnd, 10, 10, moves); // pointer inside before anything is measured
+
+  wnd.setMouseHintOnly(true);
+  await settle();
+  const reached = [];
+  for (const [x, y] of SPOTS) {
+    if (await warpTo(wnd, x, y, moves)) reached.push([x, y]);
+  }
+  // the bug: the server sends one NotifyHint and waits to be asked, so a
+  // client that never asks sees the first of these and nothing after it
+  assert.deepEqual(
+    reached,
+    SPOTS,
+    'every hinted move was reported — one that leaves the hint unanswered gets only the first'
+  );
+
+  wnd.setMouseHintOnly(false);
+  await settle();
+  assert.ok(await warpTo(wnd, 60, 60, moves), 'and turning it off leaves plain motion working');
+  wnd.destroy();
+});

--- a/test/motion-hint.test.js
+++ b/test/motion-hint.test.js
@@ -1,0 +1,253 @@
+// PointerMotionHint, the client's half of it (lib/window.js, issue #319).
+//
+// The hint is a conversation: the server sends one MotionNotify with detail
+// NotifyHint and then waits to be asked where the pointer went. These tests
+// drive that from a mock X client — hint events are fed into the window's
+// raw event stream and QueryPointer replies are released by hand, so a poll
+// can be held outstanding for as long as an assertion needs it. What no mock
+// can check is that a real server actually goes quiet after the hint; that is
+// motion-hint-live.test.js.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as tick } from 'node:timers/promises';
+
+import x11 from 'x11';
+
+import Window from '../lib/window.js';
+
+let nextId = 0xc000;
+
+function makeMockApp() {
+  const polls = []; // QueryPointer callbacks, released by tests
+  const fences = []; // GetInputFocus callbacks — the frame clock
+  const masks = []; // every eventMask written to the server
+  const X = {
+    _closing: false,
+    stream: { destroyed: false, writableEnded: false },
+    event_consumers: {},
+    keycode2keysyms: {},
+    atoms: { WM_NAME: 39, STRING: 31 },
+    AllocID: () => nextId++,
+    ReleaseID() {},
+    CreateWindow() {},
+    DestroyWindow() {},
+    ChangeWindowAttributes(wid, values) {
+      if (typeof values.eventMask === 'number') masks.push(values.eventMask);
+    },
+    ChangeProperty() {},
+    CreateGC() {},
+    CreatePixmap() {},
+    FreePixmap() {},
+    PolyFillRectangle() {},
+    CopyArea() {},
+    QueryPointer(wid, cb) {
+      polls.push(cb);
+    },
+    GetInputFocus(cb) {
+      fences.push(cb);
+    }
+  };
+  const display = { client: X, screen: [{ root: 1, root_depth: 24, white_pixel: 0xffffff }] };
+  return { app: { X, display }, polls, fences, masks };
+}
+
+/** A core MotionNotify. `keycode` is where node-x11 puts the detail byte. */
+const motion = (x, y, keycode = 0) => ({
+  type: 6,
+  x,
+  y,
+  rootx: x,
+  rooty: y,
+  time: 1000 + x,
+  keycode
+});
+const hinted = (x, y) => motion(x, y, 1);
+
+/** What QueryPointer replies with — node-x11's field names, not the event's. */
+const pointerAt = (x, y, extra = {}) => ({
+  sameScreen: 1,
+  root: 1,
+  child: 0,
+  rootX: x,
+  rootY: y,
+  childX: x,
+  childY: y,
+  keyMask: 0,
+  ...extra
+});
+
+/** Let the frame clock run again: a fence reply ends the frame it paced. */
+const releaseFences = async (fences) => {
+  for (const cb of fences.splice(0)) cb(null, {});
+  await tick();
+};
+
+test('a hinted move is delivered, and answered with the QueryPointer that re-arms it', async () => {
+  const { app, polls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', hinted(10, 20));
+  assert.equal(polls.length, 0, 'nothing asked synchronously: the poll is paced by the frame');
+
+  await tick();
+  assert.equal(got.length, 1, 'the hint carries a real position, so it is a move like any other');
+  assert.deepEqual([got[0].x, got[0].y], [10, 20]);
+  assert.equal(polls.length, 1, 'and the frame asks the server where the pointer is now');
+  wnd.destroy();
+});
+
+test('the poll delivers the motion the hint suppressed', async () => {
+  const { app, polls, fences } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', hinted(10, 20));
+  await tick();
+  // the pointer moved on after the hint was generated, and that motion
+  // produced no event — it is exactly what the hint held back
+  polls[0](null, pointerAt(33, 44, { keyMask: 0x100, child: 7 }));
+  // the answer is an event like any other on a paced window: it lands in the
+  // frame after the one that asked
+  await releaseFences(fences);
+
+  assert.equal(got.length, 2);
+  const [, polled] = got;
+  assert.deepEqual([polled.x, polled.y], [33, 44], 'window-relative, from the reply');
+  assert.deepEqual([polled.rootx, polled.rooty], [33, 44]);
+  assert.equal(polled.buttons, 0x100, "the reply's modifier/button state");
+  assert.equal(polled.child, 7);
+  assert.equal(polled.synthetic, true, 'built from a reply, not read off the wire');
+  assert.equal(polled.time, 1010, 'stamped with the hint that prompted it — a reply has no time');
+  assert.equal(polled.window, wnd);
+  assert.equal(polled.target, wnd);
+  wnd.destroy();
+});
+
+test('a poll that finds the pointer where the hint left it delivers nothing', async () => {
+  const { app, polls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', hinted(10, 20));
+  await tick();
+  polls[0](null, pointerAt(10, 20));
+  await tick();
+  assert.equal(got.length, 1, 'the pointer sat still: there is no second move to report');
+  wnd.destroy();
+});
+
+test('a poll finding the pointer on another screen is not a position', async () => {
+  const { app, polls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', hinted(10, 20));
+  await tick();
+  // core QueryPointer: with the pointer on another screen the window-relative
+  // coordinates and `child` are zero by protocol, which is not the origin
+  polls[0](null, pointerAt(0, 0, { sameScreen: 0 }));
+  await tick();
+  assert.equal(got.length, 1);
+  wnd.destroy();
+});
+
+test('an unhinted motion stream asks the server nothing', async () => {
+  const { app, polls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  wnd.on('mousemove', () => {});
+
+  wnd.emit('event', motion(1, 1));
+  wnd.emit('event', motion(2, 2));
+  await tick();
+  assert.equal(polls.length, 0, 'the server is talking freely; there is nothing to re-arm');
+  wnd.destroy();
+});
+
+test('a burst of hints costs one round trip, not one each', async () => {
+  const { app, polls, fences } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', hinted(1, 1));
+  wnd.emit('event', hinted(2, 2));
+  wnd.emit('event', hinted(3, 3));
+  await tick();
+  assert.equal(got.length, 1, 'coalesced to one move');
+  assert.equal(got[0].coalesced.length, 3);
+  assert.equal(polls.length, 1, 'and one poll for the frame');
+
+  // a later frame with a poll still outstanding does not stack another one
+  wnd.emit('event', hinted(4, 4));
+  await releaseFences(fences);
+  assert.equal(polls.length, 1, 'still just the one in flight');
+
+  // once it answers, the frame that follows picks the re-arm back up
+  polls[0](null, pointerAt(5, 5));
+  await releaseFences(fences);
+  assert.equal(polls.length, 2);
+  wnd.destroy();
+});
+
+test('setMouseHintOnly writes the bit, and clearing it drops a pending re-arm', async () => {
+  const { app, polls, masks } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  wnd.on('mousemove', () => {});
+  masks.length = 0;
+
+  wnd.setMouseHintOnly(true);
+  assert.equal(masks.length, 1);
+  assert.ok(masks[0] & x11.eventMask.PointerMotionHint, 'the hint bit is selected');
+  assert.equal(wnd.setMouseHintOnly(true), wnd, 'idempotent, and chainable');
+  assert.equal(masks.length, 1, 'a bit already set is not written again');
+
+  // a hint arrives, and the caller turns the hint off before the frame runs
+  wnd.emit('event', hinted(10, 20));
+  wnd.setMouseHintOnly(false);
+  assert.equal(masks.length, 2);
+  assert.ok(!(masks[1] & x11.eventMask.PointerMotionHint), 'and cleared again');
+  await tick();
+  assert.equal(polls.length, 0, 'nothing is waiting on an answer any more');
+  wnd.destroy();
+});
+
+test('with coalescing off there is no frame to pace the poll, so it goes out at once', async () => {
+  const { app, polls } = makeMockApp();
+  const wnd = new Window(app, { coalesceEvents: false });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', hinted(10, 20));
+  assert.deepEqual(
+    got.map((ev) => [ev.x, ev.y]),
+    [[10, 20]],
+    'delivered immediately, as an uncoalesced window promises'
+  );
+  assert.equal(polls.length, 1);
+  polls[0](null, pointerAt(11, 21));
+  assert.deepEqual(got.map((ev) => [ev.x, ev.y]), [
+    [10, 20],
+    [11, 21]
+  ]);
+  wnd.destroy();
+});
+
+test('a destroyed window neither polls nor delivers a poll already in flight', async () => {
+  const { app, polls } = makeMockApp();
+  const wnd = new Window(app, { frameInterval: 0 });
+  const got = [];
+  wnd.on('mousemove', (ev) => got.push(ev));
+
+  wnd.emit('event', hinted(10, 20));
+  await tick();
+  assert.equal(polls.length, 1);
+  wnd.destroy();
+  polls[0](null, pointerAt(33, 44));
+  await tick();
+  assert.equal(got.length, 1, 'the reply outlived the window it was about');
+});


### PR DESCRIPTION
`setMouseHintOnly(true)` selected X's `PointerMotionHint` and did nothing
else. But the hint is a two-party protocol: with it selected the server
may send a single `MotionNotify` carrying detail `NotifyHint` and then
say nothing more about the pointer until the client asks where it went.
ntk never asked, so a window that turned the hint on received exactly
one motion event and then silence. Fixes #319.

Measured on XQuartz before this change, 200 pointer warps inside the
window: 200 `MotionNotify` without the hint, **1** with it. Through
ntk's own API, `mousemove` handlers saw 35 events without the hint and 1
with it.

## Holding up the other end

A hinted `MotionNotify` still carries the position it was generated at,
so it is delivered like any other move. What is new is the answer: the
paced frame that takes the move sends the `QueryPointer` that lets the
server speak again — one poll per frame, at most one in flight, which is
the rate the coalescer already reduces a frame's motion to. The reply
re-arms the server, and it is delivered as a `mousemove` of its own when
it finds the pointer somewhere no event reported, marked `synthetic`.

That second half is not redundant. Between the hint being generated and
the server processing the poll the pointer may move again, and that
motion produces no event — it is exactly what the hint suppressed. Drop
the reply and the final position of a gesture that ends mid-flight is
lost, leaving the window's idea of where the pointer is wrong until it
moves next. The reply is deduped against the last position delivered, so
a pointer that sat still emits nothing.

One detail worth writing down for the next reader: node-x11 parses a
`MotionNotify`'s detail byte into `keycode`, the field that carries a
button number on `ButtonPress`. Motion events have no `ev.detail`, so
the check is `ev.keycode === 1`.

## The trade, now documented

Motion stops being paced by the input device and starts being paced by
the connection. Server-to-client traffic for 600 pointer moves on
XQuartz, same number of events reaching the handler either way:

| window selects | bytes from server | delivered |
|---|---|---|
| `PointerMotion` | 21.9 KB | 84 |
| `PointerMotion` + `PointerMotionHint` | 8.4 KB | 88 |

The saving grows with the round-trip time, because the round trip is
what now sets the sampling rate — and so does the staleness: a handler
acts on a position up to one round trip old. Good on a bandwidth-bound
link such as X over ssh, bad on a latency-bound one, which is the
opposite of what "reduces motion events" suggests. docs/window.md now
says so, next to the coalescing it complements, along with the two
things the hint is not: it does not select motion, and it has nothing to
thin on a window that took its input from XI2.

## Tests

- `test/motion-hint.test.js` — the client half against a mock X: the
  hint is delivered and answered, the poll's position is delivered when
  it moved and dropped when it did not, a burst costs one round trip
  rather than one each, a poll is never stacked on one in flight,
  clearing the bit drops a pending re-arm, and an uncoalesced window
  polls without a frame to pace it
- `test/motion-hint-live.test.js` — the half no mock can supply, that a
  real server does go quiet: five hinted warps across the window are all
  reported. Without the fix only the first arrives. Skipped where there
  is no DISPLAY
