### PR TITLE
feat(text): drive the opsz axis from the size text is set at

### DIFF
--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -914,6 +914,11 @@ no per-size server cache — see
   variable font. The `wght` axis needs none of this: a numeric weight in the
   `font` shorthand already drives it (`ctx.font = '460 40px Inter'`). Set
   either before or after `font` — see [fonts.md](fonts.md#variable-fonts)
+- `fontOpticalSizing` — `'auto'` (default) sets a variable face's `opsz`
+  axis at the size the text is drawn at, as CSS's `font-optical-sizing`
+  does; `'none'` leaves it at the font file's own default. Order-independent
+  like `fontVariationSettings` — see
+  [fonts.md](fonts.md#optical-size-follows-the-size)
 - `layoutText(content, options)` → `TextLayout` — ntk extension: wrap text
   (or styled spans) to a target width without drawing, inspect lines and
   metrics, then `layout.draw(ctx, x, y)`

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -351,6 +351,47 @@ Settings for axes a font does not have are ignored and values are clamped to
 each axis's range, so any of this is safe to set without checking first —
 and `font.variationAxes` is there when you want to (`{}` for a static face).
 
+### Optical size follows the size
+
+`opsz` is the second axis a style drives without naming it. A face with an
+optical-size axis is drawn at the size it is *set* at — small text in the
+family's Text cut, headlines in its Display cut — which is what CSS does
+with `font-optical-sizing: auto`, its initial value:
+
+```js
+ctx.font = '13px "SF Pro"'; // opsz 13, clamped into the axis
+ctx.font = '96px "SF Pro"'; // opsz 96
+```
+
+This matters more than it sounds like it does. The only San Francisco
+fontconfig can see on a stock macOS box is `SFNS.ttf`, a variable file whose
+`opsz` axis runs 17–96 and **defaults to 28** — a display cut. Without a
+coordinate, every 13px menu label, button and list row was set in display
+letterforms: tighter tracking, smaller apertures, lighter stems, visibly not
+what the same font looks like in a native menu beside it. Inter, Roboto
+Flex, Newsreader and most recent variable text families ship the axis too.
+
+Three ways to take it over, in the order they win:
+
+```js
+// 1. name the axis, as CSS's font-variation-settings does
+ctx.fontVariationSettings = { opsz: 17 };
+// 2. turn it off — the face stays at whatever its file defaults to
+ctx.fontOpticalSizing = 'none';
+// 3. give the axis a different size from the glyphs
+app.fonts.match('Inter', { size: 26, opticalSize: 13 });
+```
+
+The third is for callers that have already multiplied by a device scale.
+`size` on the lookup path is CSS px, so a 13px label pre-scaled for a 2×
+display arrives as 26 and would pick a display cut; pass the unscaled size
+as `opticalSize` and keep the scaled one for the glyphs. `opticalSize` and
+`opticalSizing` are style fields like `variations` — a `TextLayout` span may
+carry either.
+
+Clamping does the rest, and does it well: 13 against SF's `17..96` lands on
+17, which is exactly where Apple's own Text cut sits.
+
 ### What it costs
 
 An instance is a font in its own right: its own shaping, its own rasterized
@@ -393,7 +434,9 @@ this is only about instantiating an axis.
   and `null`/`undefined` pass through
 - `StaticFontSource`: `add(bytes, opts)`, `alias(generic, family)`,
   `inferGenerics()`, `aliases`, `skipped` (files a spec could not parse)
-- `app.fonts.match(family, { weight, style, variations })` → `Font`
+- `app.fonts.match(family, { weight, style, size, variations, opticalSize,
+  opticalSizing })` → `Font` — `size` drives `opsz` (CSS px);
+  `opticalSizing: 'none'` leaves that axis alone
 - `app.fonts.fallbackFor(codepoint, family, opts)` → `Font | null` — best
   installed font covering a codepoint (fontconfig coverage data, confirmed
   against the parsed font)

--- a/docs/text.md
+++ b/docs/text.md
@@ -267,9 +267,11 @@ ctx.drawGlyphs(ctx.Render.PictOp.Over, ctx.createSolidPicture(1, 1, 1, 1), [
 
 ### `app.fonts` → FontManager
 
-- `match(family, { weight, style })` → `Font` — system-font resolution
-  (fontconfig by default) with registered fonts first. `family` may be a
-  comma-separated list.
+- `match(family, { weight, style, size, variations, opticalSize,
+  opticalSizing })` → `Font` — system-font resolution (fontconfig by
+  default) with registered fonts first. `family` may be a comma-separated
+  list. On a variable face `weight` drives the `wght` axis and `size` drives
+  `opsz` — see [fonts.md](fonts.md#variable-fonts).
 - `load(pathOrData, { postscriptName, family, weight, style })` → `Font` —
   register a font file, given a path or its bytes (bundled/custom fonts;
   issue-16-style usage):
@@ -484,6 +486,8 @@ Conventions:
 ### 2d context
 
 - `ctx.font` — CSS shorthand; `ctx.textAlign`, `ctx.textBaseline`
+- `ctx.fontVariationSettings`, `ctx.fontOpticalSizing` — variable-font axes;
+  see [fonts.md](fonts.md#variable-fonts)
 - `ctx.fillText(text, x, y)` / `ctx.measureText(text)` (canvas-style
   TextMetrics: `width`, `actualBoundingBox*`, `fontBoundingBox*`)
 - `ctx.layoutText(content, options)` → `TextLayout` with the current

--- a/lib/renderingcontext_2d.js
+++ b/lib/renderingcontext_2d.js
@@ -1057,6 +1057,7 @@ class RenderingContext2d {
       textStyle: this._textStyle,
       fontString: this._lastFontString,
       fontVariations: this._fontVariations,
+      fontOpticalSizing: this._fontOpticalSizing,
       textRendering: this._textRendering,
       textAlign: this.textAlign,
       textBaseline: this.textBaseline,
@@ -1086,6 +1087,7 @@ class RenderingContext2d {
     this._textStyle = s.textStyle;
     this._lastFontString = s.fontString;
     this._fontVariations = s.fontVariations;
+    this._fontOpticalSizing = s.fontOpticalSizing;
     this._textRendering = s.textRendering;
     this.textAlign = s.textAlign;
     this.textBaseline = s.textBaseline;
@@ -1249,6 +1251,7 @@ class RenderingContext2d {
     sctx._textStyle = this._textStyle;
     sctx._lastFontString = this._lastFontString;
     sctx._fontVariations = this._fontVariations;
+    sctx._fontOpticalSizing = this._fontOpticalSizing;
     sctx._textRendering = this._textRendering;
     sctx.textAlign = this.textAlign;
     sctx.textBaseline = this.textBaseline;
@@ -4029,6 +4032,7 @@ class RenderingContext2d {
       style: parsed.style,
       size: parsed.size,
       variations: this._fontVariations,
+      opticalSizing: this._fontOpticalSizing,
     };
     style.font = this.window.app.fonts.match(style.family, style);
     this._lastFontString = val;
@@ -4059,6 +4063,32 @@ class RenderingContext2d {
 
   get fontVariationSettings() {
     return this._fontVariations ?? null;
+  }
+
+  /**
+   * CSS's `font-optical-sizing`: `'auto'` (the default) sets a face's `opsz`
+   * axis at the size the text is drawn at, `'none'` leaves it wherever the
+   * font file's default is.
+   *
+   * `'auto'` is what the CSS initial value has always been and what a
+   * reader expects — small text set in the family's Text cut, headlines in
+   * its Display cut — so this is the escape hatch, not the switch that
+   * turns the feature on. Reach for it when the size the canvas is drawing
+   * at is not the size the text is *read* at (a canvas scaled up by a
+   * transform, glyphs measured for something else), and pin the axis with
+   * `fontVariationSettings = { opsz: … }` when the answer is a specific
+   * optical size rather than the file's default.
+   *
+   * Order-independent, like `fontVariationSettings`: setting it re-resolves
+   * the face already in force.
+   */
+  set fontOpticalSizing(val) {
+    this._fontOpticalSizing = val === "none" ? "none" : "auto";
+    if (this._textStyle) this.font = this._lastFontString;
+  }
+
+  get fontOpticalSizing() {
+    return this._fontOpticalSizing ?? "auto";
   }
 
   /**

--- a/lib/text/fontmanager.js
+++ b/lib/text/fontmanager.js
@@ -21,25 +21,68 @@ function variationsKeyOf(variations) {
 }
 
 /**
+ * The optical size a style is set at, or `undefined` for "leave `opsz`
+ * alone" — see `instantiate()`.
+ *
+ * `opsz` is the one axis whose coordinate is not a design choice but a
+ * consequence of the size, so it defaults from `size` and needs an escape
+ * hatch for each way that default can be wrong:
+ *
+ * - `opticalSizing: 'none'` is CSS's `font-optical-sizing: none` — the face
+ *   stays at its own default optical size;
+ * - `opticalSize` is the typographic size to use when it is not `size`.
+ *   `size` on this path is CSS px, and a caller that has already multiplied
+ *   by a device scale is holding device pixels: a 13px label on a 2×
+ *   display arrives here as 26 and would pick a display cut. Such a caller
+ *   passes the unscaled size as `opticalSize` and keeps the scaled one for
+ *   the glyphs.
+ */
+function opticalSizeFor(style) {
+  if (!style || style.opticalSizing === 'none') return undefined;
+  const size = style.opticalSize ?? style.size;
+  return typeof size === 'number' && Number.isFinite(size) ? size : undefined;
+}
+
+/** Cache-key fragment for the optical size, `''` when the axis is left alone. */
+function opticalKeyOf(style) {
+  return opticalSizeFor(style) ?? '';
+}
+
+/**
  * Put a resolved face at the point in its design space the style asked for.
  *
- * The interesting half is `weight`. CSS has said for years that
- * `font-weight: 460` on a variable font means the `wght` axis at 460, not
- * "the nearest face"; a face with a `wght` axis therefore takes the
- * requested weight as a coordinate, and an app that hands ntk a variable
- * file gets the weight it asked for without knowing an axis exists. An
- * explicit `variations.wght` wins, because a caller naming the axis
- * directly is being more specific than one naming a weight.
+ * Two axes get a coordinate from a style that never names them, because CSS
+ * says both are consequences of properties the style does name:
+ *
+ * - `weight`. `font-weight: 460` on a variable font means the `wght` axis at
+ *   460, not "the nearest face", so an app that hands ntk a variable file
+ *   gets the weight it asked for without knowing an axis exists.
+ * - `size`. `font-optical-sizing: auto` has been the initial value since
+ *   optical sizing was specified: `opsz` tracks `font-size` unless the
+ *   author says otherwise. Without this a face is drawn at whatever optical
+ *   size its file happens to default to — on macOS the only San Francisco
+ *   fontconfig can see is a variable file defaulting to `opsz` 28, a
+ *   *display* cut, so every 13px menu label was set in display-sized
+ *   letterforms. Clamping does the rest: 13 against SF's `17..96` lands on
+ *   17, which is exactly Apple's Text end.
+ *
+ * An explicit `variations.wght` / `variations.opsz` wins in both cases,
+ * because a caller naming the axis directly is being more specific than one
+ * naming a weight or a size — the same order CSS gives
+ * `font-variation-settings` over the properties it overlaps.
  *
  * Everything here is a no-op for a static face: `variation()` returns the
  * font unchanged when the settings do not apply, so this costs one property
  * read on the path every non-variable app is already on.
  */
-function instantiate(font, weight, variations) {
+function instantiate(font, weight, variations, opticalSize) {
   const axes = font.variationAxes;
-  if (!axes || (!axes.wght && !variations)) return font;
+  if (!axes || (!axes.wght && !axes.opsz && !variations)) return font;
   const settings = { ...variations };
   if (axes.wght && settings.wght === undefined) settings.wght = weight;
+  if (axes.opsz && settings.opsz === undefined && opticalSize !== undefined) {
+    settings.opsz = opticalSize;
+  }
   return font.variation(settings);
 }
 
@@ -151,19 +194,30 @@ export default class FontManager {
    * Resolve a family (or CSS-style comma-separated family list) to a Font.
    * Registered fonts are consulted first, then fontconfig.
    *
+   * What is cached here is the *face* the pattern resolved to — the
+   * expensive half, since it is an fc-match and a file parse — and not the
+   * instance `instantiate()` cuts out of it. Two things follow. The map
+   * stays one entry per family/weight/style however many points of an axis
+   * an app asks for, so a slider animating `wght`, or a tree of labels at a
+   * dozen sizes, walks a face's own bounded instance cache rather than
+   * evicting other families out of this one. And `size` can drive `opsz`
+   * without joining the key: the coordinate is applied per call, so the
+   * first size asked for does not become every later one's.
+   *
    * @param {string} family e.g. `'Ubuntu Mono', monospace`
-   * @param {object} [opts] { weight: 400|'bold'|…, style: 'normal'|'italic' }
+   * @param {object} [opts] { weight: 400|'bold'|…, style: 'normal'|'italic',
+   *   size, variations, opticalSize, opticalSizing: 'auto'|'none' }
    */
   match(family = 'sans-serif', opts = {}) {
     const weight = numWeight(opts.weight);
     const italic = !!(opts.style && opts.style.includes('italic'));
-    const cacheKey = `${family}|${weight}|${italic}|${variationsKeyOf(opts.variations)}`;
-    let font = this._matches.get(cacheKey);
-    if (font) {
+    const cacheKey = `${family}|${weight}|${italic}`;
+    let face = this._matches.get(cacheKey);
+    if (face) {
       // insertion order is LRU order; re-inserting a hit moves it to the tail
       this._matches.delete(cacheKey);
-      this._matches.set(cacheKey, font);
-      return font;
+      this._matches.set(cacheKey, face);
+      return instantiate(face, weight, opts.variations, opticalSizeFor(opts));
     }
 
     const families = String(family)
@@ -171,26 +225,23 @@ export default class FontManager {
       .map((f) => f.trim().replace(/^["']|["']$/g, ''))
       .filter(Boolean);
 
-    font = this._matchRegistered(
+    face = this._matchRegistered(
       families.map((f) => f.toLowerCase()),
       weight,
       italic
     );
-    if (!font) {
+    if (!face) {
       // sources understand comma-separated family lists natively
       const candidates = this.source.matchSorted({
         family: families.join(','),
         weight,
         style: italic ? 'italic' : 'normal'
       });
-      font = this._open(candidates[0]);
+      face = this._open(candidates[0]);
     }
-    font = instantiate(font, weight, opts.variations);
-    this._matches.set(cacheKey, font);
-    // The key now carries a point in a continuous space rather than one of a
-    // handful of weights, so an app animating an axis walks this map instead
-    // of hitting it. Same sweep as the shaping memo: drop the stale half in
-    // one pass rather than one entry per insert.
+    this._matches.set(cacheKey, face);
+    // A long-lived app can name a lot of families. Same sweep as the shaping
+    // memo: drop the stale half in one pass rather than one entry per insert.
     if (this._matches.size > MAX_MATCHES) {
       let drop = this._matches.size >> 1;
       for (const key of this._matches.keys()) {
@@ -198,7 +249,7 @@ export default class FontManager {
         this._matches.delete(key);
       }
     }
-    return font;
+    return instantiate(face, weight, opts.variations, opticalSizeFor(opts));
   }
 
   /**
@@ -292,14 +343,14 @@ export default class FontManager {
   _shapeCached(text, style, levelsKey = '0') {
     const font = style.font;
     // A resolved `font` already carries its coordinates in its key, so the
-    // variations fragment only earns its keep on the family path — where two
-    // points of one axis would otherwise share a shaped run, and the second
-    // would be drawn with the first's advances.
+    // variations and optical-size fragments only earn their keep on the
+    // family path — where two points of one axis would otherwise share a
+    // shaped run, and the second would be drawn with the first's advances.
     const key = font
       ? `${font.key}|${style.size}|${style.weight}|${style.style}|${levelsKey}|${text}`
       : `${style.family}|${style.size}|${style.weight}|${style.style}|${variationsKeyOf(
           style.variations
-        )}|${levelsKey}|${text}`;
+        )}|${opticalKeyOf(style)}|${levelsKey}|${text}`;
     let shaped = this._shapeCache.get(key);
     if (shaped) {
       // Map iterates in insertion order: re-inserting a hit moves it to the

--- a/lib/text/layout.js
+++ b/lib/text/layout.js
@@ -67,6 +67,8 @@ export class TextLayout {
         weight: s.weight ?? style.weight,
         style: s.style ?? style.style,
         variations: s.variations ?? style.variations,
+        opticalSize: s.opticalSize ?? style.opticalSize,
+        opticalSizing: s.opticalSizing ?? style.opticalSizing,
         textRendering: s.textRendering ?? style.textRendering,
         features: s.features ?? style.features,
         language: s.language ?? style.language,

--- a/lib/text/shape.js
+++ b/lib/text/shape.js
@@ -69,7 +69,10 @@ export function normalizedLevels(levels, start, end) {
 export function shapeText(fonts, text, style, levels) {
   const size = style.size ?? 16;
   const family = style.family ?? 'sans-serif';
-  const baseFont = style.font ?? fonts.match(family, style);
+  // `size` is what drives the `opsz` axis, so a style that leaves it out
+  // hands `match()` the size this actually sets at rather than nothing
+  const baseFont =
+    style.font ?? fonts.match(family, style.size === undefined ? { ...style, size } : style);
 
   let baseLevel = 0;
   if (!levels) {

--- a/test/helpers/opsz-fixture.js
+++ b/test/helpers/opsz-fixture.js
@@ -1,0 +1,36 @@
+// A variable face with a real `opsz` axis, for the optical-sizing tests.
+//
+// Nothing in the tree ships one, and a second variable file for one axis is
+// not worth its kilobytes, so `test/fixtures/MonelogicsSubset[wght].ttf` is
+// relabelled in memory: `fvar` is what names an axis, `gvar` only numbers
+// them, so the deltas are the same deltas and every layer below the label
+// sees a genuine optical-size axis.
+//
+// The range is San Francisco's — 17..28..96 — because the default sitting
+// well above every UI size is the whole shape of the bug (issue #332): with
+// no coordinate applied, a 13px menu label is set in a display cut.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const VF = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures', 'MonelogicsSubset[wght].ttf');
+
+/** the fixture's bytes with its axis relabelled `opsz`, ranged like SF */
+export function opszFixture() {
+  const b = Buffer.from(readFileSync(VF));
+  const numTables = b.readUInt16BE(4);
+  let fvar = -1;
+  for (let i = 0; i < numTables; i++) {
+    const rec = 12 + i * 16; // sfnt table record: tag, checksum, offset, length
+    if (b.toString('latin1', rec, rec + 4) === 'fvar') fvar = b.readUInt32BE(rec + 8);
+  }
+  assert.ok(fvar > 0, 'the fixture has an fvar table');
+  const axes = fvar + b.readUInt16BE(fvar + 4); // axisTag, min, default, max (16.16)
+  b.write('opsz', axes, 'latin1');
+  b.writeInt32BE(17 * 65536, axes + 4);
+  b.writeInt32BE(28 * 65536, axes + 8);
+  b.writeInt32BE(96 * 65536, axes + 12);
+  b.writeUInt16BE(0, fvar + 12); // drop the named instances: they name weights
+  return b;
+}

--- a/test/variable-fonts-canvas.test.js
+++ b/test/variable-fonts-canvas.test.js
@@ -12,6 +12,7 @@ import { after, before, test } from 'node:test';
 
 import { StaticFontSource, createClient } from '../lib/index.js';
 import { withTimeout } from './helpers/async.js';
+import { opszFixture } from './helpers/opsz-fixture.js';
 
 const fixtures = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 const VF = join(fixtures, 'MonelogicsSubset[wght].ttf');
@@ -30,6 +31,7 @@ before(async () => {
   try {
     const fontSource = new StaticFontSource();
     fontSource.add(readFileSync(VF), { family: 'Test VF' });
+    fontSource.add(opszFixture(), { family: 'Test OPSZ' });
     fontSource.alias('sans-serif', 'test vf');
     app = await withTimeout(
       createClient({ fontSource }),
@@ -57,20 +59,20 @@ const widthAt = (font) => {
 
 test('a numeric weight in the font shorthand drives the wght axis', (t) => {
   if (skip) return t.skip(skip);
-  const light = widthAt('200 40px Test VF');
-  const black = widthAt('900 40px Test VF');
+  const light = widthAt('200 40px "Test VF"');
+  const black = widthAt('900 40px "Test VF"');
   assert.ok(black > light, `900 (${black}) should set wider than 200 (${light})`);
 });
 
 test('weights between the named instances measure between them', (t) => {
   if (skip) return t.skip(skip);
-  const widths = [400, 500, 600].map((w) => widthAt(`${w} 40px Test VF`));
+  const widths = [400, 500, 600].map((w) => widthAt(`${w} 40px "Test VF"`));
   assert.ok(widths[0] < widths[1] && widths[1] < widths[2], `monotonic, got ${widths}`);
 });
 
 test('fontVariationSettings takes the CSS string and an object alike', (t) => {
   if (skip) return t.skip(skip);
-  ctx.font = '40px Test VF';
+  ctx.font = '40px "Test VF"';
   ctx.fontVariationSettings = '"wght" 900';
   const fromString = ctx.measureText(SAMPLE).width;
 
@@ -85,14 +87,14 @@ test('order does not matter: settings before or after font', (t) => {
   if (skip) return t.skip(skip);
   ctx.fontVariationSettings = null;
 
-  ctx.font = '40px Test VF';
+  ctx.font = '40px "Test VF"';
   ctx.fontVariationSettings = { wght: 800 };
   const afterFont = ctx.measureText(SAMPLE).width;
 
   ctx.fontVariationSettings = null;
-  ctx.font = '16px Test VF'; // something else entirely in between
+  ctx.font = '16px "Test VF"'; // something else entirely in between
   ctx.fontVariationSettings = { wght: 800 };
-  ctx.font = '40px Test VF';
+  ctx.font = '40px "Test VF"';
   const beforeFont = ctx.measureText(SAMPLE).width;
 
   assert.equal(beforeFont, afterFont);
@@ -102,7 +104,7 @@ test('order does not matter: settings before or after font', (t) => {
 test('save/restore carries the axis with the rest of the text state', (t) => {
   if (skip) return t.skip(skip);
   ctx.fontVariationSettings = null;
-  ctx.font = '40px Test VF';
+  ctx.font = '40px "Test VF"';
   const flat = ctx.measureText(SAMPLE).width;
 
   ctx.save();
@@ -117,9 +119,60 @@ test('save/restore carries the axis with the rest of the text state', (t) => {
 test('an axis the font does not have is ignored, not an error', (t) => {
   if (skip) return t.skip(skip);
   ctx.fontVariationSettings = null;
-  ctx.font = '40px Test VF';
+  ctx.font = '40px "Test VF"';
   const flat = ctx.measureText(SAMPLE).width;
   ctx.fontVariationSettings = '"wdth" 75';
   assert.equal(ctx.measureText(SAMPLE).width, flat);
+  ctx.fontVariationSettings = null;
+});
+
+test('opsz follows the font shorthand\'s size, without anything being set', (t) => {
+  if (skip) return t.skip(skip);
+  ctx.fontVariationSettings = null;
+  ctx.font = '13px "Test OPSZ"';
+  const label = ctx._resolvedTextStyle().font;
+  assert.deepEqual(label.variationCoords, { opsz: 17 }, '13px clamps to the Text end');
+  ctx.font = '96px "Test OPSZ"';
+  assert.deepEqual(ctx._resolvedTextStyle().font.variationCoords, { opsz: 96 });
+});
+
+test("fontOpticalSizing 'none' hands the axis back to the file", (t) => {
+  if (skip) return t.skip(skip);
+  ctx.fontVariationSettings = null;
+  ctx.font = '13px "Test OPSZ"';
+  const auto = ctx.measureText(SAMPLE).width;
+
+  ctx.fontOpticalSizing = 'none';
+  assert.equal(ctx.fontOpticalSizing, 'none');
+  // order-independent, like fontVariationSettings: the face in force re-resolves
+  assert.equal(ctx._resolvedTextStyle().font.variationCoords, undefined);
+  const off = ctx.measureText(SAMPLE).width;
+  assert.notEqual(off, auto, `opsz 28 (${off}) is not opsz 17 (${auto})`);
+
+  ctx.fontOpticalSizing = 'auto';
+  assert.equal(ctx.measureText(SAMPLE).width, auto);
+});
+
+test('optical sizing rides save/restore with the rest of the text state', (t) => {
+  if (skip) return t.skip(skip);
+  ctx.fontOpticalSizing = 'auto';
+  ctx.font = '13px "Test OPSZ"';
+  const auto = ctx.measureText(SAMPLE).width;
+
+  ctx.save();
+  ctx.fontOpticalSizing = 'none';
+  assert.notEqual(ctx.measureText(SAMPLE).width, auto);
+  ctx.restore();
+
+  assert.equal(ctx.fontOpticalSizing, 'auto');
+  assert.equal(ctx.measureText(SAMPLE).width, auto, 'restore put the axis back');
+});
+
+test('an explicit opsz still wins over the size it is drawn at', (t) => {
+  if (skip) return t.skip(skip);
+  ctx.fontOpticalSizing = 'auto';
+  ctx.font = '13px "Test OPSZ"';
+  ctx.fontVariationSettings = { opsz: 96 };
+  assert.deepEqual(ctx._resolvedTextStyle().font.variationCoords, { opsz: 96 });
   ctx.fontVariationSettings = null;
 });

--- a/test/variable-fonts.test.js
+++ b/test/variable-fonts.test.js
@@ -12,6 +12,7 @@ import { test } from 'node:test';
 import Font, { normalizeVariations, variationKey } from '../lib/text/font.js';
 import FontManager from '../lib/text/fontmanager.js';
 import { StaticFontSource } from '../lib/text/fontsource.js';
+import { opszFixture } from './helpers/opsz-fixture.js';
 
 const fixtures = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 const VF = join(fixtures, 'MonelogicsSubset[wght].ttf');
@@ -193,4 +194,106 @@ test('two points of one axis do not share a shaped run', () => {
   const thin = fonts.shape(SAMPLE, { ...style, variations: { wght: 100 } });
   const black = fonts.shape(SAMPLE, { ...style, variations: { wght: 900 } });
   assert.ok(black.width > thin.width, 'the shaping memo keys on the coordinate');
+});
+
+// --- optical size is the size ------------------------------------------------
+//
+// `opsz` is the axis a style never names and always sets: CSS has had
+// `font-optical-sizing: auto` as the initial value since optical sizing was
+// specified, so the coordinate follows `font-size` unless the author takes
+// it over. The face here is the fixture with its axis relabelled — see
+// helpers/opsz-fixture.js for why that is a real axis and not a fiction.
+
+function opszManager() {
+  const source = new StaticFontSource();
+  source.add(opszFixture(), { family: 'Test OPSZ' });
+  return new FontManager({ source });
+}
+
+test('the fixture relabelled for these tests really does carry an opsz axis', () => {
+  const fonts = opszManager();
+  const axes = fonts.match('Test OPSZ', { opticalSizing: 'none' }).variationAxes;
+  assert.deepEqual(Object.keys(axes), ['opsz']);
+  assert.deepEqual([axes.opsz.min, axes.opsz.default, axes.opsz.max], [17, 28, 96]);
+});
+
+test('the size text is set at drives the opsz axis', () => {
+  const fonts = opszManager();
+  assert.deepEqual(fonts.match('Test OPSZ', { size: 40 }).variationCoords, { opsz: 40 });
+  assert.deepEqual(fonts.match('Test OPSZ', { size: 96 }).variationCoords, { opsz: 96 });
+});
+
+test('a UI size below the axis clamps to its Text end, not the file default', () => {
+  const fonts = opszManager();
+  const label = fonts.match('Test OPSZ', { size: 13 });
+  assert.deepEqual(label.variationCoords, { opsz: 17 });
+  assert.equal(label, fonts.match('Test OPSZ', { size: 17 }));
+  // the bug: 13px text set in the display cut the file happens to default to
+  assert.notEqual(label, fonts.match('Test OPSZ', { opticalSizing: 'none' }));
+});
+
+test('each size gets its own instance — the match cache is not keyed on the first', () => {
+  const fonts = opszManager();
+  const small = fonts.match('Test OPSZ', { size: 24 });
+  const large = fonts.match('Test OPSZ', { size: 72 });
+  assert.notEqual(small.key, large.key);
+  assert.equal(small, fonts.match('Test OPSZ', { size: 24 }), 'and still cached per size');
+  assert.ok(widthOf(large) > widthOf(small), 'a display cut sets wider at one size');
+});
+
+test('an explicit opsz beats the size, as font-variation-settings does in CSS', () => {
+  const fonts = opszManager();
+  const pinned = fonts.match('Test OPSZ', { size: 13, variations: { opsz: 72 } });
+  assert.deepEqual(pinned.variationCoords, { opsz: 72 });
+  assert.equal(pinned, fonts.match('Test OPSZ', { size: 72 }));
+});
+
+test("opticalSizing 'none' leaves the axis where the file put it", () => {
+  const fonts = opszManager();
+  const off = fonts.match('Test OPSZ', { size: 13, opticalSizing: 'none' });
+  assert.equal(off.variationCoords, undefined, 'the base face, not an instance of it');
+  assert.notEqual(off, fonts.match('Test OPSZ', { size: 13 }));
+  // and it is the switch, not a pin: an explicit coordinate still applies
+  assert.deepEqual(
+    fonts.match('Test OPSZ', { size: 13, opticalSizing: 'none', variations: { opsz: 40 } })
+      .variationCoords,
+    { opsz: 40 }
+  );
+});
+
+test('opticalSize is the size for the axis when it is not the size for the glyphs', () => {
+  const fonts = opszManager();
+  // a caller that pre-multiplied by a 2x device scale: 26 device pixels of
+  // glyph, still a 13px label to whoever is reading it
+  const scaled = fonts.match('Test OPSZ', { size: 26, opticalSize: 13 });
+  assert.deepEqual(scaled.variationCoords, { opsz: 17 });
+  assert.equal(scaled, fonts.match('Test OPSZ', { size: 13 }));
+});
+
+test('a face without an opsz axis is not touched by any of this', () => {
+  const fonts = manager();
+  const small = fonts.match('Test VF', { weight: 500, size: 13 });
+  const large = fonts.match('Test VF', { weight: 500, size: 96 });
+  assert.equal(small, large, 'one instance, whatever size it is drawn at');
+  assert.deepEqual(small.variationCoords, { wght: 500 }, 'the weight still lands');
+});
+
+test('shaping follows the axis: the same string is not just scaled up', () => {
+  const fonts = opszManager();
+  const style = { family: 'Test OPSZ' };
+  const small = fonts.shape(SAMPLE, { ...style, size: 13 });
+  const large = fonts.shape(SAMPLE, { ...style, size: 96 });
+  // both come from the memo's family path, which has to tell the two apart
+  assert.ok(
+    large.width / 96 > small.width / 13,
+    `the display cut sets relatively wider, got ${large.width / 96} vs ${small.width / 13}`
+  );
+});
+
+test('a span turns optical sizing off for itself', () => {
+  const fonts = opszManager();
+  const style = { family: 'Test OPSZ', size: 96 };
+  const auto = fonts.layout([{ text: SAMPLE }], style, {});
+  const off = fonts.layout([{ text: SAMPLE, opticalSizing: 'none' }], style, {});
+  assert.ok(auto.width > off.width, `${auto.width} (opsz 96) should exceed ${off.width} (opsz 28)`);
 });


### PR DESCRIPTION
Fixes #332.

A variable face with an `opsz` axis was drawn at whatever optical size its file happens to default to, whatever size the text was actually set at. `instantiate()` gave `wght` a coordinate from the CSS weight and gave `opsz` nothing — so ntk matched half of what CSS has done since `font-optical-sizing: auto` became the initial value.

It is loudest on macOS: the only San Francisco fontconfig can see on a stock box is `SFNS.ttf`, whose `opsz` runs 17 to 96 and defaults to 28, a *display* cut. Every 13px menu label, button and list row was therefore set in display letterforms — tighter tracking, smaller apertures, lighter stems. Inter, Roboto Flex and Newsreader ship the axis too.

`opsz` now defaults from the size, and clamping does the rest: 13 against SF's `17..96` lands on 17, exactly where Apple's Text cut sits.

<img width="980" alt="SFNS at UI sizes: opsz at the file default vs opsz tracking the size" src="https://github.com/user-attachments/assets/ce2e79e8-f5ed-47f1-a3f9-458b1e0e4b4c" />

Same file, same sizes, same colour; only `opsz` differs. Rendered by this branch: `ctx.fontOpticalSizing = 'none'` on the left is today's behaviour, `'auto'` on the right is the default this PR introduces.

## The two decisions the issue asked for

**The cache key.** `match()` now caches the *face* a pattern resolved to — the expensive half, an fc-match plus a file parse — and cuts the instance per call, rather than caching the instance. That is what lets `size` drive a coordinate without joining the key. It also stops an app animating an axis from walking the map: 500 points of `wght` used to be 500 entries in a 512-entry cache, evicting every other family; they are now one entry, plus a face's own bounded instance cache underneath.

**Which size.** `size` on the lookup path is documented as CSS px and drives the axis. Everything else is an override, in the order it wins:

```js
app.fonts.match('Inter', { size: 13 });                      // opsz 13, the new default
app.fonts.match('Inter', { size: 13, variations: { opsz: 72 } });  // an explicit axis wins
app.fonts.match('Inter', { size: 13, opticalSizing: 'none' });     // off; the file's default
app.fonts.match('Inter', { size: 26, opticalSize: 13 });     // device pixels, typographic opsz
ctx.fontOpticalSizing = 'none';                              // the same switch on the 2d context
```

`opticalSize` is the answer for callers that pre-multiply by a device scale — react-x11 does — where `size` arrives here as device pixels and would pick a display cut on a 2× screen. `opticalSize` and `opticalSizing` are ordinary style fields, so a `TextLayout` span may carry either.

## Tests

`test/helpers/opsz-fixture.js` relabels the existing `wght` fixture's axis as `opsz` in memory, ranged 17..28..96 like SF. `fvar` is what names an axis and `gvar` only numbers them, so the deltas are the same deltas and every layer below the label sees a genuine optical-size axis — no second font file for one axis. New coverage: the size drives the axis, a UI size clamps to the Text end, each size gets its own instance, an explicit `opsz` wins, `opticalSizing: 'none'` hands the axis back to the file, `opticalSize` decouples it from the glyph size, a face without the axis is untouched, shaping is not merely scaled up, and a span can turn it off for itself — plus the 2d-context half: the shorthand's size, `fontOpticalSizing`, and save/restore.

Docs updated in `docs/fonts.md`, `docs/text.md` and `docs/context-2d.md`.
