### PR TITLE
feat(shadow): export blurCoverage, the blur that bakes instead of re-filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ lib/renderingcontext_cgl.js     direct rendering context, appledri flavor
                            (CGL into the server-exported window surface);
                            wraps 'opengl' above the gles module's dispatch
 lib/renderingcontext_x11.js     raw core-X drawing context
-lib/picture.js             XRender Picture wrapper (+ blur filter)
+lib/picture.js             XRender Picture wrapper (+ setBlurFilter, whose
+                           kernel the server re-runs on every composite —
+                           to blur once, bake with shadow.js's blurCoverage)
 lib/pictformat.js          which RENDER picture format describes a drawable:
                            visual -> format, matched on the channel masks
                            the handshake and QueryPictFormats agree on, with
@@ -91,7 +93,11 @@ lib/region.js              XFIXES Region wrapper: the server-side rectangle
                            ctx.clipRegion() installs on a picture
 lib/shadow.js              canvas shadows: the blur (sigma = shadowBlur/2,
                            run as two separable passes), the coverage
-                           surfaces it needs and their per-connection cache
+                           surfaces it needs and their per-connection cache.
+                           The bake and its maths (blurCoverage, shadowSigma,
+                           shadowReach, gaussianKernel1d) are public API —
+                           a picture filter re-convolves per composite, this
+                           does not (issue #335)
 lib/glyphset.js            XRender GlyphSet wrapper (+ referenceTo: alias an
                            existing set, possibly another client's)
 lib/sharedglyphs.js        cross-process shared glyph cache, client half:

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,9 @@ matching file here (see AGENTS.md).
 - [Images](images.md) — PNG/JPEG loading (`loadImage`), the `Image` object,
   `drawImage`
 - [Surface](surface.md) — draw once, composite many times; a8 coverage
-  surfaces for drawings that take their colour from the caller
+  surfaces for drawings that take their colour from the caller, and
+  `blurCoverage`, the blur baked into pixels rather than left as a filter the
+  server re-runs per composite
 - [Fonts](fonts.md) — font lookup, loading, rasterization pipeline
 - [Text](text.md) — shaping (kerning/bidi/fallback), TextLayout,
   wire-efficiency design, the vector (trapezoid) path for large/animated sizes

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -812,15 +812,25 @@ kernel ran out of pixels. Everything here pads by the blur's full reach.
 Step (2) is two 1d passes rather than one 2d kernel because a gaussian is
 separable, and that is the difference between a shadow you can animate and
 one you cannot: a k-wide 2d kernel costs k² multiplies per pixel where two
-passes cost 2k. At `shadowBlur: 30` that is 8281 against 182.
+passes cost 2k. At `shadowBlur: 30` that is 8281 against 182. It also runs
+**once**: the passes leave the blur in the surface's pixels, where a
+`convolution` filter hung on a picture (`picture().setBlurFilter()`) is
+re-applied by the server on every composite, so a cached blurred picture
+re-runs its whole kernel every frame it is drawn.
+
+Step (2) is the one piece worth having on its own, and it is exported as
+[`blurCoverage(coverage, sigma)`](surface.md#baking-a-blur) for a toolkit
+that draws its own shapes and wants only the blur — the padding rule, the
+sigma-is-half-the-radius rule and the bake-don't-filter rule are all there.
 
 **Text shadows are cached** — keyed by (text, font, blur) on the connection —
 because text is the one drawing with a short, stable name. A label redrawn
 every frame, or a specimen redrawn on every slider tick, builds its coverage
 once and composites it afterwards. Paths, rectangles and images have no such
 key and rebuild their coverage per draw, so a large blurred path shadow in a
-render loop is the shape to watch for; draw it into a `Surface` yourself and
-`drawImage` that instead.
+render loop is the shape to watch for; draw it into a `Surface` yourself —
+with [`blurCoverage`](surface.md#baking-a-blur) if the blur is the expensive
+part — and `drawImage` that instead.
 
 **Laid-out text is cached too**, on the identity of the runs it is made of
 rather than on a string: a whole paragraph is one coverage surface, whatever

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -49,16 +49,73 @@ answers that question for SVG documents.
 `globalAlpha` still applies — it folds into the source colour rather than the
 mask, since the mask slot is taken.
 
-Coverage is also what a *filter* wants, and blur is the filter worth knowing
-about: `surface.picture().setFilter('convolution', [w, h, ...kernel])` is
-applied by the server every time the picture is sampled, so an a8 surface
-blurred this way composites as a soft version of whatever was drawn into it.
-That is exactly how [shadows](context-2d.md#shadows) are built — reach for
-those first — and if you build your own, note the two things that are easy
-to get wrong: the surface needs **padding of the kernel's half-width on every
-side**, or the blur ends in a straight line where it ran out of pixels
-(outside a picture, RepeatNone reads transparent), and a 2d kernel costs k²
-multiplies per pixel where two 1d passes cost 2k.
+## Baking a blur
+
+`blurCoverage(coverage, sigma)` blurs an a8 surface and hands back a new one
+with the blur **in its pixels**:
+
+```js
+import { blurCoverage, shadowReach, shadowSigma } from 'ntk';
+
+const sigma = shadowSigma(blurRadius); // a canvas/CSS blur is a diameter
+const pad = shadowReach(sigma);        // how far coverage can spread: ceil(3σ)
+
+const shape = new Surface(app, {
+  width: w + 2 * pad,
+  height: h + 2 * pad,
+  format: 'a8'
+});
+shape.render((c) => {
+  c.fillStyle = '#fff'; // white on transparent: every pixel is its own alpha
+  c.roundRect(pad, pad, w, h, radius);
+  c.fill();
+});
+
+const blurred = blurCoverage(shape, sigma); // `shape` is destroyed
+ctx.fillStyle = shadowColor;
+ctx.drawImage(blurred, x - pad, y - pad);   // an ordinary masked composite
+```
+
+[Shadows](context-2d.md#shadows) are built exactly this way, and if the four
+`ctx.shadow*` properties cover what you need, reach for those first — they do
+the padding, the clipping and the caching too. `blurCoverage` is for a caller
+that draws its own shapes and keeps its own paint cache (a widget toolkit
+drawing a `box-shadow`, say) and only wants the blur.
+
+**Bake, don't filter.** The other way to blur a picture is
+`picture().setBlurFilter(size, sigma)` — and a picture's filter is a property
+of the picture, so the server re-runs the whole kernel *every time it is
+composited*. Blur once, cache the surface, draw it each frame, and you have
+bought a k×k convolution per frame forever: a 61×61 kernel over a 489×134
+surface is 244M multiply-accumulates per draw (issue #335). `blurCoverage`
+runs two separable 1d passes once — 2k multiplies per pixel instead of k² —
+and the surface it returns carries no filter at all, so compositing it costs
+what compositing any mask costs.
+
+The rest of what is easy to get wrong:
+
+- **Pad by the blur's full reach on all four sides.** A convolution samples
+  outside the picture, where RepeatNone reads transparent, so a shape drawn
+  flush to the edge ends in a straight line where the kernel ran out of
+  pixels. `shadowReach(sigma)` is that padding — the gaussian truncated at
+  3σ, which leaves 0.3% of its weight outside, below one step of 8-bit
+  coverage
+- **`sigma` is not a blur radius.** A canvas `shadowBlur` and a CSS
+  `box-shadow` blur are *diameters*: σ is half of them. `shadowSigma(blur)`
+  does that halving and applies `maxSigma` from
+  [`app.shadowPolicy`](context-2d.md#shadows), the cap that keeps a kernel
+  (and the request carrying it) from growing without bound
+- **The input is destroyed** — the sharp copy has no use afterwards, and
+  keeping it alive would double what a cache holds. The returned surface is
+  the caller's, to `destroy()` when its cache evicts it
+- A blurred shadow only reaches full `shadowColor` where the shape casting it
+  is wide compared with σ; the numbers, and how to write a test that does not
+  assert an exact colour, are in
+  [How strong a shadow gets](context-2d.md#how-strong-a-shadow-gets-and-how-to-test-one)
+
+`gaussianKernel1d(sigma[, reach])` is exported alongside them for a caller
+running the passes itself — normalized over the *truncated* kernel, which is
+what keeps a flat interior at full coverage.
 
 ## Scrolling and panning: `copyWithin`
 
@@ -121,6 +178,24 @@ caller's normal job.
   instead of a pane-sized coverage mask per frame
 - `surface.destroy()` / `Symbol.dispose` — free the pixmap and the picture.
   Both carry finalizers, so a dropped surface still releases
+
+The blur primitives, imported from `ntk` itself rather than hung off a
+surface (see [Baking a blur](#baking-a-blur)):
+
+- `blurCoverage(coverage, sigma)` → `Surface` — blur an a8 surface into a new
+  a8 surface of the same size, as two separable passes run **once**. The
+  input is destroyed; the output carries no filter, so compositing it is an
+  ordinary masked composite. Throws when `sigma` is not a finite number above
+  zero, or when the surface is not `'a8'`
+- `shadowSigma(blur[, policy])` → number — the σ a canvas/CSS blur *diameter*
+  names, which is half of it, capped at the policy's `maxSigma`
+- `shadowReach(sigma)` → number — `ceil(3σ)`: the kernel's half-width, and
+  therefore the padding a coverage surface needs on each side
+- `gaussianKernel1d(sigma[, reach])` → number[] — the normalized 1d kernel,
+  `2 * reach + 1` taps wide
+- `DEFAULT_SHADOW_POLICY` — the defaults `app.shadowPolicy` merges over
+  (`cacheBytes`, `maxSigma`, `maxPixels`; see
+  [Shadows](context-2d.md#shadows))
 
 ## Drawing sources in general
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,13 @@ import {
   setDefaultRasterizer
 } from './rasterize.js';
 import { DEFAULT_MASK_POLICY } from './maskcluster.js';
+import {
+  DEFAULT_SHADOW_POLICY,
+  blurCoverage,
+  gaussianKernel1d,
+  shadowReach,
+  shadowSigma
+} from './shadow.js';
 import { DEFAULT_SHAPE_POLICY } from './shapeglyphs.js';
 import { DEFAULT_SHARED_GLYPHS_POLICY } from './glyphdirectory.js';
 import { warmSharedGlyphs } from './text/glyphs.js';
@@ -275,6 +282,16 @@ export {
   DEFAULT_RASTER_POLICY,
   DEFAULT_MASK_POLICY,
   DEFAULT_SHAPE_POLICY,
+  // the shadow blur as a primitive (docs/surface.md#baking-a-blur), for a
+  // caller drawing shapes ntk's shadow properties never see. `blurCoverage`
+  // *bakes* the two separable passes into a surface's pixels — unlike
+  // `picture().setBlurFilter()`, whose kernel the server re-runs on every
+  // composite, which a cached shadow pays for once per frame
+  DEFAULT_SHADOW_POLICY,
+  blurCoverage,
+  gaussianKernel1d,
+  shadowReach,
+  shadowSigma,
   // cross-process shared glyphs (docs/shared-glyphs.md): the directory-side
   // budget, and the prewarm that makes a first paint of already-shared text
   // rasterize and upload nothing

--- a/lib/picture.js
+++ b/lib/picture.js
@@ -25,10 +25,35 @@ export default class Picture {
     registry.register(this, { Render: this.Render, X, id: this.id }, this);
   }
 
+  /**
+   * Set the picture's filter — a *property of the picture*, not an operation
+   * on its pixels. The server re-applies it every time the picture is
+   * sampled, so the cost is per composite and forever, not once.
+   *
+   * That is what makes it right for resampling (`'bilinear'` under a
+   * transform) and a trap for anything expensive: see `setBlurFilter`.
+   */
   setFilter(name, params) {
     this.Render.SetPictureFilter(this.id, name, params);
   }
 
+  /**
+   * Hang a k×k gaussian `convolution` on the picture.
+   *
+   * **This re-convolves on every composite** — it is a filter, so the server
+   * runs the whole kernel each time the picture is drawn, and the pixels
+   * never change on the client's side of the wire. A picture blurred once and
+   * then composited each frame pays k² multiply-accumulates per pixel per
+   * frame: at radius 61 over 489×134 that is 244M per draw, which is a 1.6s
+   * hover on XQuartz and a 9s window repaint (issue #335).
+   *
+   * Reach for it when the blur really is per-draw and small. To blur
+   * something *once* and composite the result cheaply afterwards — a drop
+   * shadow, a cached soft edge — bake it instead with `blurCoverage` from
+   * ntk's entry point: two separable 1d passes (2k multiplies per pixel, not
+   * k²), run once, leaving a surface with the blur in its pixels and no
+   * filter of its own. See docs/surface.md#baking-a-blur.
+   */
   setBlurFilter(radius, sigma) {
     if (radius === 0) {
       return this.setFilter('convolution', [1, 1, 1]);

--- a/lib/shadow.js
+++ b/lib/shadow.js
@@ -32,6 +32,19 @@
 // second pass leaves a surface with the blur already in its pixels, so the
 // cached copy composites as a plain mask rather than re-running a kernel on
 // every frame.
+//
+// ## What of this is public
+//
+// The bake and the maths around it — `blurCoverage`, `shadowSigma`,
+// `shadowReach`, `gaussianKernel1d` and `DEFAULT_SHADOW_POLICY` — are
+// re-exported from `lib/index.js` (issue #335). A toolkit that draws its own
+// shapes (react-x11 paints a `<box>`'s `boxShadow` itself, because the
+// rounded rect is a path it already has and the result goes through its own
+// paint cache) needs exactly this and nothing else: the alternative on the
+// public surface, `picture().setBlurFilter()`, sets a k×k filter that the
+// server re-runs on *every* composite, which is invisible until someone
+// profiles a real display. The surfaces and the cache below stay private —
+// they are the 2d context's bookkeeping, not a primitive.
 import { Surface } from './surface.js';
 
 /**
@@ -117,8 +130,31 @@ export function gaussianKernel1d(sigma, reach = shadowReach(sigma)) {
  * and leaving it alive would double what the cache is holding. The output
  * carries no filter of its own, so compositing it is an ordinary masked
  * composite no matter how wide the blur was.
+ *
+ * Public, and the reason is that half of it: a *filter* is re-applied by the
+ * server on every composite, so a caller who blurs a picture with
+ * `setBlurFilter` and then caches it re-runs the kernel per frame — 244M
+ * multiply-accumulates for one 489×134 shadow at σ 10 (issue #335). This
+ * bakes instead. `shape` must be a coverage surface with the blur's reach as
+ * padding on all four sides, or the result ends in a straight line where the
+ * kernel ran out of pixels; see docs/surface.md.
  */
 export function blurCoverage(shape, sigma) {
+  if (!(sigma > 0) || !Number.isFinite(sigma)) {
+    throw new Error(
+      `blurCoverage: sigma must be a finite number above 0, got ${sigma}. ` +
+        'A canvas blur radius is a diameter, not a sigma — pass ' +
+        'shadowSigma(blur), which halves it and applies the policy cap. ' +
+        'σ = 0 is no blur at all: composite the coverage as it is.'
+    );
+  }
+  if (shape.format !== 'a8') {
+    throw new Error(
+      `blurCoverage: needs a coverage surface, got format ${JSON.stringify(shape.format)}. ` +
+        "Draw the shape into new Surface(app, { width, height, format: 'a8' }) — " +
+        'the blur runs on alpha, so an argb32 surface would lose its colour.'
+    );
+  }
   const app = shape.app;
   const R = app.display.Render;
   const { width, height } = shape;

--- a/test/shadow.test.js
+++ b/test/shadow.test.js
@@ -14,7 +14,7 @@ import { after, before, describe, test } from 'node:test';
 
 import xserver from 'x11/lib/xserver/index.js';
 
-import { createClient, StaticFontSource, Surface } from '../lib/index.js';
+import { blurCoverage, createClient, StaticFontSource, Surface } from '../lib/index.js';
 import {
   DEFAULT_SHADOW_POLICY,
   gaussianKernel1d,
@@ -565,5 +565,114 @@ describe('how strong a blurred shadow gets', () => {
     // which is why a test that looks for `shadowColor` itself finds nothing
     assert.ok(peak < 165, 'nothing on the canvas is within 90 of the colour');
     ctx.destroy();
+  });
+});
+
+// ------------------------------------------------------------------
+// the blur as a primitive someone else can call (issue #335)
+
+describe('blurCoverage on the public surface', () => {
+  test('the bake and its maths reach a consumer', async () => {
+    // The whole of the issue: the exports map names '.' and './xembed', so a
+    // consumer cannot reach into lib/ — anything they are meant to call has
+    // to leave through the entry point. Self-reference resolves the package
+    // by name here, through the very map an installed copy would use.
+    await assert.rejects(import('ntk/lib/shadow.js'), {
+      code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+    });
+    const ntk = await import('ntk');
+    assert.equal(ntk.blurCoverage, blurCoverage);
+    assert.equal(ntk.shadowSigma, shadowSigma);
+    assert.equal(ntk.shadowReach, shadowReach);
+    assert.equal(ntk.gaussianKernel1d, gaussianKernel1d);
+    assert.deepEqual(ntk.DEFAULT_SHADOW_POLICY, DEFAULT_SHADOW_POLICY);
+  });
+
+  test('the blur lands in the pixels, and the result carries no filter', async () => {
+    // Bake against filter is the point of exporting this: a picture's filter
+    // is re-run by the server on every composite, so a cached blurred picture
+    // pays its kernel per frame. What is asserted is both halves — the
+    // coverage that comes back is blurred, and drawing it sets no filter.
+    const sigma = 4;
+    const pad = shadowReach(sigma);
+    const shape = new Surface(app, {
+      width: 60 + 2 * pad,
+      height: 40 + 2 * pad,
+      format: 'a8'
+    });
+    shape.render((c) => {
+      c.fillStyle = '#ffffff';
+      c.fillRect(pad, pad, 60, 40);
+    });
+
+    const blurred = blurCoverage(shape, sigma);
+    assert.notEqual(blurred, shape, 'a new surface, not the same one filtered');
+    assert.equal(blurred.format, 'a8');
+    assert.equal(blurred.width, shape.width);
+    assert.equal(blurred.height, shape.height);
+    assert.equal(shape._destroyed, true, 'the sharp copy is not left behind');
+
+    const R = app.display.Render;
+    const original = R.SetPictureFilter;
+    let filters = 0;
+    R.SetPictureFilter = function (...args) {
+      filters += 1;
+      return original.apply(this, args);
+    };
+    const ctx = target();
+    try {
+      ctx.fillStyle = '#000000';
+      ctx.drawImage(blurred, 0, 0);
+    } finally {
+      R.SetPictureFilter = original;
+    }
+    assert.equal(filters, 0, 'compositing the bake is a plain masked composite');
+
+    const at = await readAll(ctx);
+    const alphaAt = (x) => at(x, pad + 20)[3] / 255;
+    // the left edge of the rect is at x = pad, so the profile there is the
+    // gaussian's CDF — the same claim the shadow properties make, made by
+    // the primitive on its own
+    for (const [x, want] of [
+      [pad - sigma, 0.159],
+      [pad, 0.5],
+      [pad + sigma, 0.841]
+    ]) {
+      const got = alphaAt(Math.round(x));
+      assert.ok(
+        Math.abs(got - want) < 0.06,
+        `coverage at x=${x} is ${got.toFixed(3)}, expected ~${want}`
+      );
+    }
+    assert.ok(alphaAt(pad + 30) > 0.99, 'the interior of the rect stays covered');
+    // the padding is 3 sigma, so the coverage has all but died by its edge
+    assert.ok(alphaAt(0) < 0.01, `the blur ends inside the padding, got ${alphaAt(0)}`);
+
+    blurred.destroy();
+    ctx.destroy();
+  });
+
+  test('a sigma that is not one, or a surface that is not coverage, is refused', () => {
+    const coverage = new Surface(app, { width: 8, height: 8, format: 'a8' });
+    for (const bad of [0, -1, NaN, Infinity, undefined]) {
+      assert.throws(() => blurCoverage(coverage, bad), /sigma/, `sigma ${bad}`);
+    }
+    // the message names the call that turns a canvas blur into a sigma,
+    // because halving it is exactly what a caller coming from CSS forgets
+    assert.throws(() => blurCoverage(coverage, 0), /shadowSigma/);
+    assert.equal(coverage._destroyed, undefined, 'a refused call destroys nothing');
+
+    const colour = new Surface(app, { width: 8, height: 8 });
+    assert.throws(() => blurCoverage(colour, 2), /a8/);
+    coverage.destroy();
+    colour.destroy();
+  });
+
+  test('the docs section the picture API points at exists', () => {
+    // `setBlurFilter` sends whoever reads it to docs/surface.md#baking-a-blur
+    // for the version that does not re-convolve; nothing else checks that
+    // anchor, and the heading is what makes it one
+    const docs = readFileSync(new URL('../docs/surface.md', import.meta.url), 'utf8');
+    assert.match(docs, /^## Baking a blur$/m);
   });
 });


### PR DESCRIPTION
Closes #335.

`lib/shadow.js` had the right primitive and no way to reach it. The package's
exports map names `.` and `./xembed`, so `import('ntk/lib/shadow.js')` is
`ERR_PACKAGE_PATH_NOT_EXPORTED`, and the only blur on the public surface was
`picture().setBlurFilter()` — which sets a k×k convolution **filter**, a
property of the picture that the server re-applies on every composite. Blur
once, cache the result, draw it each frame, and the whole kernel runs again
every frame: identical pixels, identical request count, 244M
multiply-accumulates for one 489×134 shadow at σ 10. That is the 1.6s hover
and 9s repaint react-x11 measured on XQuartz before copying ntk's two-pass
bake into its own tree.

## What changed

- **`blurCoverage`, `shadowSigma`, `shadowReach`, `gaussianKernel1d` and
  `DEFAULT_SHADOW_POLICY` are exported from `lib/index.js`.** The coverage
  surfaces and the per-connection LRU stay private — they are the 2d
  context's bookkeeping, not a primitive.
- **`blurCoverage` gains the two guards a public entry point needs.** A σ that
  is not a finite number above zero is refused with the fix in the message
  (a canvas/CSS blur is a *diameter* — pass `shadowSigma(blur)`), and so is a
  surface that is not `a8`, whose colour the blur would silently drop.
- **`setBlurFilter` and `setFilter` now say what a filter costs** and point at
  the bake. This was the second half of the issue: the API reads like "blur
  this picture", and nothing about the pixels or the requests reveals that it
  is re-run per composite.
- **Docs** — a new [Baking a blur](https://github.com/sidorares/ntk/blob/681b98d790d6d0232aa9cf77c6ba69e7c2d301c2/docs/surface.md#baking-a-blur)
  section in `docs/surface.md` (the padding rule, the sigma-is-half-the-radius
  rule, the bake-don't-filter rule, the destroys-its-input contract), linked
  from the shadows section of `docs/context-2d.md`.

```js
import { blurCoverage, shadowReach, shadowSigma } from 'ntk';

const sigma = shadowSigma(blurRadius); // a canvas/CSS blur is a diameter
const pad = shadowReach(sigma);        // ceil(3σ): the padding coverage needs

const shape = new Surface(app, { width: w + 2 * pad, height: h + 2 * pad, format: 'a8' });
shape.render(paintTheBoxWhiteOnTransparent);

const blurred = blurCoverage(shape, sigma); // `shape` is destroyed
ctx.fillStyle = shadowColor;
ctx.drawImage(blurred, x - pad, y - pad);   // an ordinary masked composite
```

## Rendered by this branch

The docs snippet run for real, next to the same card drawn with `ctx.shadow*`
— same offset, same softness, because they are the same two passes:

<img width="800" alt="two cards with identical drop shadows: the left drawn with ctx.shadowBlur, the right with a hand-baked blurCoverage surface" src="https://github.com/user-attachments/assets/cf2ecf13-fa9c-413f-9c1b-05fd8073d654" />

## Tests

`test/shadow.test.js` gains a suite for the primitive: the exports reach a
consumer through the package name while `ntk/lib/shadow.js` still does not,
the returned surface follows the gaussian's CDF at ±σ, compositing it issues
no `SetPictureFilter` at all, the input is destroyed, and both guards throw.

`node --test` is green here apart from four pre-existing failures on this
machine's XQuartz (two damage-event timeouts, two picture-format tests on a
connection without RENDER) — both also fail on `master` at eb2fd18.
