### PR TITLE
feat(shadow): run a wide blur on shrunk coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,10 +94,11 @@ lib/region.js              XFIXES Region wrapper: the server-side rectangle
 lib/shadow.js              canvas shadows: the blur (sigma = shadowBlur/2,
                            run as two separable passes), the coverage
                            surfaces it needs and their per-connection cache.
-                           The bake and its maths (blurCoverage, shadowSigma,
-                           shadowReach, gaussianKernel1d) are public API —
-                           a picture filter re-convolves per composite, this
-                           does not (issue #335)
+                           The bake and its maths (blurCoverage, blurScale,
+                           shadowSigma, shadowReach, gaussianKernel1d) are
+                           public API — a picture filter re-convolves per
+                           composite, this does not (issue #335); a wide blur
+                           runs on shrunk coverage (issue #338)
 lib/glyphset.js            XRender GlyphSet wrapper (+ referenceTo: alias an
                            existing set, possibly another client's)
 lib/sharedglyphs.js        cross-process shared glyph cache, client half:

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ matching file here (see AGENTS.md).
 - [Surface](surface.md) — draw once, composite many times; a8 coverage
   surfaces for drawings that take their colour from the caller, and
   `blurCoverage`, the blur baked into pixels rather than left as a filter the
-  server re-runs per composite
+  server re-runs per composite — and, past σ 8, run at reduced scale
 - [Fonts](fonts.md) — font lookup, loading, rasterization pipeline
 - [Text](text.md) — shaping (kerning/bidi/fallback), TextLayout,
   wire-efficiency design, the vector (trapezoid) path for large/animated sizes

--- a/docs/context-2d.md
+++ b/docs/context-2d.md
@@ -818,6 +818,18 @@ passes cost 2k. At `shadowBlur: 30` that is 8281 against 182. It also runs
 re-applied by the server on every composite, so a cached blurred picture
 re-runs its whole kernel every frame it is drawn.
 
+**A wide blur does not run at full resolution.** Two passes still cost
+`2 * taps * w * h`, and both factors grow with the blur, so a large soft
+shadow is most of what a first paint spends — ten of them on react-x11's
+configurator came to 118M multiply-accumulates, 73% of it in two (issue
+#338). A gaussian carries no detail finer than about σ/2 px, so past σ 8 the
+coverage is shrunk by 2 or 4, blurred at `sigma / scale`, and resolved back:
+`scale` off the kernel, `scale²` off the area, and a difference from the
+exact blur of at most three levels of 8-bit alpha. Nothing downstream sees it —
+the surface is the size it always was and still carries no filter, so a
+cached shadow composites exactly as before. `scaleSigma` and `maxScale` in
+the policy below tune it, and `maxScale: 1` turns it off.
+
 Step (2) is the one piece worth having on its own, and it is exported as
 [`blurCoverage(coverage, sigma)`](surface.md#baking-a-blur) for a toolkit
 that draws its own shapes and wants only the blur — the padding rule, the
@@ -856,6 +868,13 @@ defaults):
   stall. This is the one place a shadow stops matching a browser
 - `maxPixels` (8 M) — the largest coverage surface built for one shadow;
   past it the shadow is dropped and the drawing is unaffected
+- `scaleSigma` (4) — the σ a reduced-scale blur may not fall below. The
+  coverage is shrunk by the largest power of two that keeps `sigma / scale`
+  at or above this, so a blur under σ 8 runs exactly as before. The error is
+  a property of that reduced σ rather than of the ratio: three alpha levels
+  at 4, four at 3, seven at 2
+- `maxScale` (4) — how far that shrink may go whatever the floor allows.
+  `maxScale: 1` blurs everything at full resolution, which is what 8.6 did
 
 Only what could be seen is rendered: a shape's ink is clipped to the part
 whose shadow can land on the target at all (its own bounds, moved back by

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -82,6 +82,59 @@ the padding, the clipping and the caching too. `blurCoverage` is for a caller
 that draws its own shapes and keeps its own paint cache (a widget toolkit
 drawing a `box-shadow`, say) and only wants the blur.
 
+**A wide blur runs small.** Past σ 8 `blurCoverage` shrinks the coverage by
+2 or 4 first, blurs at `sigma / scale`, and resolves the result back to the
+size you handed it — `scale` off the kernel and `scale²` off the area it runs
+over, so `scale³` off the work. A gaussian carries no detail finer than about
+σ/2 px, which is why this is nearly free visually: the difference from an
+exact blur is at most three levels of 8-bit alpha, on a shape whose own edges
+are already soft. It is worth a great deal in time — the two widest shadows
+on react-x11's configurator, 55.5M and 31.2M multiply-accumulates, become
+0.9M and 4.0M — which measured against XQuartz's software RENDER is 1.24s of
+a first paint against 37ms (issue #338; `scripts/bench-shadow-blur.mjs` is
+the measurement, on whatever server you point it at).
+
+Nothing about the call changes: the surface that comes back is the size it
+always was, and carries no filter, so compositing it is the same plain mask
+it was before. What changes is tunable per app:
+
+```js
+app.shadowPolicy = { scaleSigma: 4, maxScale: 4 }; // the defaults
+blurCoverage(shape, sigma, { scale: 1 });          // or per call: exact
+```
+
+`scaleSigma` is the σ a reduced-scale blur may not fall below — the scale is
+the largest power of two keeping `sigma / scale` at or above it, so σ under
+`2 * scaleSigma` is not shrunk at all. That floor is what bounds the error,
+and it is the reduced σ that matters rather than how far you came down to it:
+three alpha levels at σ 4, four at 3, seven at 2. `maxScale: 1` (or
+`{ scale: 1 }`) blurs everything at full resolution.
+
+**Drawing small yourself is better still**, when you can: `blurScale(sigma)`
+names the scale, so a caller that owns the geometry can draw the shape into a
+surface `1 / scale` the size — padding scaled with it — blur at
+`sigma / scale`, and composite through a `1 / scale` picture transform, which
+XRender resamples in the same pass it was already compositing. That skips the
+shrink, the full-size allocation and the resolve; the cost is that the mask
+is resampled on every composite rather than once.
+
+```js
+const scale = blurScale(sigma);
+const small = new Surface(app, {
+  width: Math.ceil((w + 2 * pad) / scale),
+  height: Math.ceil((h + 2 * pad) / scale),
+  format: 'a8'
+});
+small.render((c) => {
+  c.scale(1 / scale, 1 / scale);
+  c.fillStyle = '#fff';
+  c.roundRect(pad, pad, w, h, radius);
+  c.fill();
+});
+const blurred = blurCoverage(small, sigma / scale); // already small: scale 1
+ctx.drawImage(blurred, x - pad, y - pad, blurred.width * scale, blurred.height * scale);
+```
+
 **Bake, don't filter.** The other way to blur a picture is
 `picture().setBlurFilter(size, sigma)` — and a picture's filter is a property
 of the picture, so the server re-runs the whole kernel *every time it is
@@ -182,11 +235,16 @@ caller's normal job.
 The blur primitives, imported from `ntk` itself rather than hung off a
 surface (see [Baking a blur](#baking-a-blur)):
 
-- `blurCoverage(coverage, sigma)` → `Surface` — blur an a8 surface into a new
-  a8 surface of the same size, as two separable passes run **once**. The
-  input is destroyed; the output carries no filter, so compositing it is an
-  ordinary masked composite. Throws when `sigma` is not a finite number above
-  zero, or when the surface is not `'a8'`
+- `blurCoverage(coverage, sigma[, { scale }])` → `Surface` — blur an a8
+  surface into a new a8 surface of the same size, as two separable passes run
+  **once**. The input is destroyed; the output carries no filter, so
+  compositing it is an ordinary masked composite. A wide blur is run at
+  reduced scale (above); `scale` overrides the policy's choice and `1` is the
+  exact kernel. Throws when `sigma` is not a finite number above zero, when
+  `scale` is under 1, or when the surface is not `'a8'`
+- `blurScale(sigma[, policy])` → number — the power-of-two scale that blur
+  runs at: 1 (full resolution), 2 or 4. For a caller sizing its own coverage
+  surface
 - `shadowSigma(blur[, policy])` → number — the σ a canvas/CSS blur *diameter*
   names, which is half of it, capped at the policy's `maxSigma`
 - `shadowReach(sigma)` → number — `ceil(3σ)`: the kernel's half-width, and
@@ -194,7 +252,7 @@ surface (see [Baking a blur](#baking-a-blur)):
 - `gaussianKernel1d(sigma[, reach])` → number[] — the normalized 1d kernel,
   `2 * reach + 1` taps wide
 - `DEFAULT_SHADOW_POLICY` — the defaults `app.shadowPolicy` merges over
-  (`cacheBytes`, `maxSigma`, `maxPixels`; see
+  (`cacheBytes`, `maxSigma`, `maxPixels`, `scaleSigma`, `maxScale`; see
   [Shadows](context-2d.md#shadows))
 
 ## Drawing sources in general

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,7 @@ import { DEFAULT_MASK_POLICY } from './maskcluster.js';
 import {
   DEFAULT_SHADOW_POLICY,
   blurCoverage,
+  blurScale,
   gaussianKernel1d,
   shadowReach,
   shadowSigma
@@ -286,9 +287,12 @@ export {
   // caller drawing shapes ntk's shadow properties never see. `blurCoverage`
   // *bakes* the two separable passes into a surface's pixels — unlike
   // `picture().setBlurFilter()`, whose kernel the server re-runs on every
-  // composite, which a cached shadow pays for once per frame
+  // composite, which a cached shadow pays for once per frame — and runs a
+  // wide one at reduced scale, which `blurScale` names for a caller that
+  // would rather draw its shape small in the first place (issue #338)
   DEFAULT_SHADOW_POLICY,
   blurCoverage,
+  blurScale,
   gaussianKernel1d,
   shadowReach,
   shadowSigma,

--- a/lib/shadow.js
+++ b/lib/shadow.js
@@ -33,17 +33,31 @@
 // cached copy composites as a plain mask rather than re-running a kernel on
 // every frame.
 //
+// ## Why a wide one runs small
+//
+// Two passes still cost `2 * taps * w * h`, and both grow with sigma: the
+// ten shadows on react-x11's configurator come to 118M multiply-accumulates,
+// which is 596ms of a first paint on software RENDER, and 73% of it is two
+// wide ones (issue #338). A gaussian carries no detail finer than about σ/2
+// px, so that work is spent resolving what the result cannot hold — past
+// σ 8 the coverage is shrunk by 2 or 4 first, blurred at `sigma / scale`,
+// and resolved back, which is `scale` off the kernel and `scale²` off the
+// area for a difference of three levels of 8-bit alpha at worst.
+// `blurScale` picks it, `scaleSigma` / `maxScale` bound it, and the surface
+// that comes back is the size it always was, still with no filter on it.
+//
 // ## What of this is public
 //
-// The bake and the maths around it — `blurCoverage`, `shadowSigma`,
-// `shadowReach`, `gaussianKernel1d` and `DEFAULT_SHADOW_POLICY` — are
-// re-exported from `lib/index.js` (issue #335). A toolkit that draws its own
-// shapes (react-x11 paints a `<box>`'s `boxShadow` itself, because the
-// rounded rect is a path it already has and the result goes through its own
-// paint cache) needs exactly this and nothing else: the alternative on the
-// public surface, `picture().setBlurFilter()`, sets a k×k filter that the
-// server re-runs on *every* composite, which is invisible until someone
-// profiles a real display. The surfaces and the cache below stay private —
+// The bake and the maths around it — `blurCoverage`, `blurScale`,
+// `shadowSigma`, `shadowReach`, `gaussianKernel1d` and
+// `DEFAULT_SHADOW_POLICY` — are re-exported from `lib/index.js` (issues
+// #335 and #338). A toolkit that draws its own shapes (react-x11 paints a
+// `<box>`'s `boxShadow` itself, because the rounded rect is a path it
+// already has and the result goes through its own paint cache) needs exactly
+// this and nothing else: the alternative on the public surface,
+// `picture().setBlurFilter()`, sets a k×k filter that the server re-runs on
+// *every* composite, which is invisible until someone profiles a real
+// display. The surfaces and the cache below stay private —
 // they are the 2d context's bookkeeping, not a primitive.
 import { Surface } from './surface.js';
 
@@ -61,11 +75,26 @@ import { Surface } from './surface.js';
  * - `maxPixels` — the largest coverage surface built for one shadow. Beyond
  *   it the shadow is dropped rather than turning one drawing into a
  *   multi-megabyte allocation; the drawing itself is unaffected.
+ * - `scaleSigma` — the σ a reduced-scale blur is not allowed to fall below.
+ *   A gaussian carries no detail finer than about σ/2 px, so a wide one does
+ *   not need full resolution to resolve it: past twice this, coverage is
+ *   shrunk by the largest power of two that keeps σ/scale at or above it,
+ *   blurred there, and resolved back — `scale` off the kernel and `scale²`
+ *   off the area, which is where a first paint's time goes (issue #338).
+ *   What the shrink costs is set by that reduced σ and not by the ratio: 4
+ *   holds the difference from an exact blur inside three levels of 8-bit
+ *   alpha, where 3 is worth four levels and 2 is worth seven.
+ * - `maxScale` — how far the shrink may go whatever the floor allows, so a
+ *   `maxSigma`-wide blur cannot resample its way down to a thumbnail.
+ *   `maxScale: 1` blurs everything at full resolution, which is what 8.6
+ *   did, and is the setting for a caller that needs the exact kernel.
  */
 export const DEFAULT_SHADOW_POLICY = {
   cacheBytes: 4 << 20,
   maxSigma: 32,
-  maxPixels: 8 << 20
+  maxPixels: 8 << 20,
+  scaleSigma: 4,
+  maxScale: 4
 };
 
 /** the policy for one app, merged over the defaults */
@@ -124,40 +153,110 @@ export function gaussianKernel1d(sigma, reach = shadowReach(sigma)) {
 }
 
 /**
- * Blur an a8 coverage surface, returning a new one holding the result.
+ * The scale a blur of this sigma is run at: 1, 2 or 4 by default, meaning
+ * "shrink the coverage by this much, blur at `sigma / scale`, resolve back".
  *
- * The input is destroyed: a caller has no use for the sharp copy afterwards,
- * and leaving it alive would double what the cache is holding. The output
- * carries no filter of its own, so compositing it is an ordinary masked
- * composite no matter how wide the blur was.
+ * A gaussian is a low-pass filter — it carries nothing finer than about σ/2
+ * px — so resolving a wide one at full resolution spends most of its time on
+ * detail the result cannot hold. Shrinking first takes `scale` off the
+ * kernel and `scale²` off the area it runs over: at σ 21 over 552×396, k = 4
+ * turns 55.5M multiply-accumulates into 0.9M, which on a software-RENDER
+ * server (XQuartz) is most of a first paint (issue #338).
  *
- * Public, and the reason is that half of it: a *filter* is re-applied by the
- * server on every composite, so a caller who blurs a picture with
- * `setBlurFilter` and then caches it re-runs the kernel per frame — 244M
- * multiply-accumulates for one 489×134 shadow at σ 10 (issue #335). This
- * bakes instead. `shape` must be a coverage surface with the blur's reach as
- * padding on all four sides, or the result ends in a straight line where the
- * kernel ran out of pixels; see docs/surface.md.
+ * The scale is a power of two so that each shrink is an exact 2×2 average,
+ * and it is capped both by `maxScale` and by the σ floor `scaleSigma`, which
+ * is what keeps the reduced blur wide enough to still be a gaussian — the
+ * difference from an exact blur is set by that reduced σ, and stays inside
+ * three levels of 8-bit alpha at the 4 the policy defaults to. σ under
+ * `2 * scaleSigma` gets 1: below that the two resampling composites cost
+ * more than the kernel they save.
+ *
+ * Exported for a caller that draws its own shapes and can therefore skip the
+ * shrink entirely: draw the shape into a surface `1 / scale` the size (its
+ * padding scaled with it), blur at `sigma / scale`, and composite through a
+ * `1 / scale` picture transform. See docs/surface.md#baking-a-blur.
  */
-export function blurCoverage(shape, sigma) {
-  if (!(sigma > 0) || !Number.isFinite(sigma)) {
-    throw new Error(
-      `blurCoverage: sigma must be a finite number above 0, got ${sigma}. ` +
-        'A canvas blur radius is a diameter, not a sigma — pass ' +
-        'shadowSigma(blur), which halves it and applies the policy cap. ' +
-        'σ = 0 is no blur at all: composite the coverage as it is.'
-    );
-  }
-  if (shape.format !== 'a8') {
-    throw new Error(
-      `blurCoverage: needs a coverage surface, got format ${JSON.stringify(shape.format)}. ` +
-        "Draw the shape into new Surface(app, { width, height, format: 'a8' }) — " +
-        'the blur runs on alpha, so an argb32 surface would lose its colour.'
-    );
-  }
-  const app = shape.app;
-  const R = app.display.Render;
-  const { width, height } = shape;
+export function blurScale(sigma, policy = DEFAULT_SHADOW_POLICY) {
+  const floor = policy.scaleSigma ?? DEFAULT_SHADOW_POLICY.scaleSigma;
+  const max = policy.maxScale ?? DEFAULT_SHADOW_POLICY.maxScale;
+  if (!(sigma > 0) || !(floor > 0) || !(max > 1)) return 1;
+  let scale = 1;
+  while (scale * 2 <= max && sigma / (scale * 2) >= floor) scale *= 2;
+  return scale;
+}
+
+/**
+ * The smallest a shrunk coverage surface is allowed to get on either side.
+ *
+ * Nothing a shadow builds comes near it — a blur wide enough to be scaled at
+ * all pads by 24px a side — but `blurCoverage` takes any a8 surface, and a
+ * hand-built sliver shrunk to a couple of pixels would come back as a smear
+ * rather than a blur.
+ */
+const MIN_SCALED_SIDE = 16;
+
+/** the scale `blurCoverage` will actually use: the policy's (or the
+ * caller's), snapped down to a power of two and to what the surface can be
+ * shrunk to without losing its shape */
+function resolveScale(shape, sigma, requested) {
+  const wanted =
+    requested === undefined ? blurScale(sigma, shadowPolicyOf(shape.app)) : requested;
+  let scale = 2 ** Math.floor(Math.log2(wanted));
+  const side = Math.min(shape.width, shape.height);
+  while (scale > 1 && side / scale < MIN_SCALED_SIDE) scale /= 2;
+  return scale;
+}
+
+/**
+ * Shrink coverage by exactly 2, server-side, destroying the input.
+ *
+ * The transform maps a destination pixel centre to `2 * (i + 0.5)` in the
+ * source, which lands the bilinear sample exactly between two texels in each
+ * axis: the 2×2 box average, with no weight of the original left out. Which
+ * is why the scale is a power of two — one bilinear tap of a 4× shrink would
+ * sample every fourth texel and simply not see the pixels in between.
+ */
+function halveCoverage(surface, R) {
+  const width = Math.max(1, Math.ceil(surface.width / 2));
+  const height = Math.max(1, Math.ceil(surface.height / 2));
+  const small = new Surface(surface.app, { width, height, format: 'a8' });
+  const picture = surface.picture();
+  picture.setFilter('bilinear');
+  R.SetPictureTransform(picture.id, [2, 0, 0, 0, 2, 0, 0, 0, 1]);
+  R.Composite(R.PictOp.Src, picture.id, 0, small.picture().id, 0, 0, 0, 0, 0, 0, width, height);
+  surface.destroy();
+  return small;
+}
+
+/**
+ * Resolve shrunk coverage back to `width` × `height`, destroying the input.
+ *
+ * Bilinear again, and this is where the error of the whole scheme lives: the
+ * blurred coverage is reconstructed linearly between samples `scale` px
+ * apart, and what a straight line misses between two samples of a gaussian
+ * goes as the curvature there — `1 / σ'²`, in the reduced surface's own
+ * sigma. So the bound is a property of the σ the blur ran at, which is what
+ * `scaleSigma` pins: three alpha levels at σ' 4, seven at σ' 2 (measured
+ * against Xorg; a server whose bilinear rounds less is a level better).
+ *
+ * It happens once, into an ordinary surface: what comes back carries no
+ * filter and no transform, so every composite of it afterwards is a plain
+ * mask, exactly as it was before the shrink existed.
+ */
+function expandCoverage(small, width, height, scale, R) {
+  const out = new Surface(small.app, { width, height, format: 'a8' });
+  const picture = small.picture();
+  picture.setFilter('bilinear');
+  R.SetPictureTransform(picture.id, [1 / scale, 0, 0, 0, 1 / scale, 0, 0, 0, 1]);
+  R.Composite(R.PictOp.Src, picture.id, 0, out.picture().id, 0, 0, 0, 0, 0, 0, width, height);
+  small.destroy();
+  return out;
+}
+
+/** the two separable passes themselves, at whatever scale they are run —
+ * `shape` in, blurred copy out, input destroyed */
+function bakeBlur(shape, sigma, R) {
+  const { app, width, height } = shape;
   const kernel = gaussianKernel1d(sigma);
   const scratch = new Surface(app, { width, height, format: 'a8' });
   const out = new Surface(app, { width, height, format: 'a8' });
@@ -175,6 +274,65 @@ export function blurCoverage(shape, sigma) {
   shape.destroy();
   scratch.destroy();
   return out;
+}
+
+/**
+ * Blur an a8 coverage surface, returning a new one holding the result.
+ *
+ * The input is destroyed: a caller has no use for the sharp copy afterwards,
+ * and leaving it alive would double what the cache is holding. The output
+ * carries no filter of its own, so compositing it is an ordinary masked
+ * composite no matter how wide the blur was.
+ *
+ * Public, and the reason is that half of it: a *filter* is re-applied by the
+ * server on every composite, so a caller who blurs a picture with
+ * `setBlurFilter` and then caches it re-runs the kernel per frame — 244M
+ * multiply-accumulates for one 489×134 shadow at σ 10 (issue #335). This
+ * bakes instead. `shape` must be a coverage surface with the blur's reach as
+ * padding on all four sides, or the result ends in a straight line where the
+ * kernel ran out of pixels; see docs/surface.md.
+ *
+ * A wide blur does not run at full resolution. Past σ 8 the coverage is
+ * shrunk by a power of two, blurred at `sigma / scale` and resolved back —
+ * `scale³` off the work, for a difference of at most three levels of 8-bit
+ * alpha (issue #338). `scale` overrides that: `{ scale: 1 }` is the exact
+ * path 8.6 took, and a larger one is snapped down to a power of two. Which
+ * scale the policy picks is `blurScale(sigma)`; the size of what comes back
+ * never changes with it.
+ */
+export function blurCoverage(shape, sigma, { scale } = {}) {
+  if (!(sigma > 0) || !Number.isFinite(sigma)) {
+    throw new Error(
+      `blurCoverage: sigma must be a finite number above 0, got ${sigma}. ` +
+        'A canvas blur radius is a diameter, not a sigma — pass ' +
+        'shadowSigma(blur), which halves it and applies the policy cap. ' +
+        'σ = 0 is no blur at all: composite the coverage as it is.'
+    );
+  }
+  if (shape.format !== 'a8') {
+    throw new Error(
+      `blurCoverage: needs a coverage surface, got format ${JSON.stringify(shape.format)}. ` +
+        "Draw the shape into new Surface(app, { width, height, format: 'a8' }) — " +
+        'the blur runs on alpha, so an argb32 surface would lose its colour.'
+    );
+  }
+  if (scale !== undefined && (!Number.isFinite(scale) || scale < 1)) {
+    throw new Error(
+      `blurCoverage: scale must be a finite number of 1 or more, got ${scale}. ` +
+        'It is how much the coverage is shrunk before the blur runs on it, ' +
+        'so 1 is "blur at full resolution"; anything else is snapped down to ' +
+        'a power of two. Leave it out to take the scale from the app\'s ' +
+        'shadowPolicy (scaleSigma / maxScale).'
+    );
+  }
+  const R = shape.app.display.Render;
+  const { width, height } = shape;
+  const k = resolveScale(shape, sigma, scale);
+  if (k === 1) return bakeBlur(shape, sigma, R);
+
+  let small = shape;
+  for (let step = k; step > 1; step /= 2) small = halveCoverage(small, R);
+  return expandCoverage(bakeBlur(small, sigma / k, R), width, height, k, R);
 }
 
 /**

--- a/scripts/bench-shadow-blur.mjs
+++ b/scripts/bench-shadow-blur.mjs
@@ -1,0 +1,113 @@
+// Benchmark for the reduced-scale blur (issue #338): bakes the coverage
+// surfaces a real UI's first frame asks for — the ones react-x11's
+// `examples/configurator` draws, as tabulated in the issue — at full
+// resolution and shrunk first, and reports both.
+//
+//   node scripts/bench-shadow-blur.mjs [repeats] [--js]
+//
+// Runs against $DISPLAY by default, which is the measurement that matters:
+// the whole cost is server-side, and it is worst where RENDER is software
+// (XQuartz, Xvfb, any remote display). `--js` uses node-x11's in-process JS
+// X server instead — hermetic, and it prices the same requests in one
+// process. Each bake is fenced with a round trip, so the wall time is the
+// server's, not the socket's.
+//
+// The model next to it is `2 * taps * w * h` multiply-accumulates: two
+// separable passes, every tap of a `2 * ceil(3σ) + 1` kernel, per pixel.
+// That is the number the shrink divides by `scale³` — `scale` off the taps,
+// `scale²` off the area.
+import { performance } from 'node:perf_hooks';
+
+import { blurCoverage, blurScale, createClient, StaticFontSource, Surface } from '../lib/index.js';
+import { shadowReach } from '../lib/shadow.js';
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const flags = new Set(process.argv.slice(2).filter((a) => a.startsWith('--')));
+const REPEATS = Math.max(1, Number(args[0]) || 5);
+
+// the coverage surfaces one first paint of the configurator builds, biggest
+// first — `width x height` of the padded a8 surface, and the sigma the blur
+// runs at (issue #338)
+const SHADOWS = [
+  { width: 552, height: 396, sigma: 21 },
+  { width: 1294, height: 165, sigma: 12 },
+  { width: 462, height: 306, sigma: 6 },
+  { width: 495, height: 133, sigma: 11 },
+  { width: 564, height: 81, sigma: 11 },
+  { width: 196, height: 154, sigma: 11 }
+];
+
+async function connect() {
+  if (flags.has('--js') || !process.env.DISPLAY) {
+    const { default: xserver } = await import('x11/lib/xserver/index.js');
+    const server = xserver.createServer({ width: 1600, height: 1200 });
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    const app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+    return { app, target: 'in-process JS X server' };
+  }
+  const app = await createClient();
+  return { app, target: `X server on ${process.env.DISPLAY}` };
+}
+
+const { app, target } = await connect();
+const root = app.display.screen[0].root;
+/** a round trip, so the time measured is the server's work and not the wire */
+const fence = () => new Promise((resolve) => app.X.GetGeometry(root, resolve));
+
+/** the shape whose shadow this is: a rounded rect inset by the blur's reach,
+ * which is what a `box-shadow` casts */
+function coverage({ width, height, sigma }) {
+  const pad = shadowReach(sigma);
+  const surface = new Surface(app, { width, height, format: 'a8' });
+  surface.render((ctx) => {
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.roundRect(pad, pad, width - 2 * pad, height - 2 * pad, 8);
+    ctx.fill();
+  });
+  return surface;
+}
+
+const macs = ({ width, height, sigma }, scale) => {
+  const taps = 2 * shadowReach(sigma / scale) + 1;
+  return (2 * taps * Math.ceil(width / scale) * Math.ceil(height / scale)) / 1e6;
+};
+
+async function time(shadow, scale) {
+  let best = Infinity;
+  for (let i = 0; i < REPEATS; i++) {
+    const shape = coverage(shadow);
+    await fence();
+    const t0 = performance.now();
+    const out = blurCoverage(shape, shadow.sigma, { scale });
+    await fence();
+    best = Math.min(best, performance.now() - t0);
+    out.destroy();
+  }
+  return best;
+}
+
+console.log(`ntk shadow blur — ${target}, best of ${REPEATS}\n`);
+console.log('surface        sigma  scale     exact       scaled    saved   MAC exact -> scaled');
+let exactTotal = 0;
+let scaledTotal = 0;
+for (const shadow of SHADOWS) {
+  const scale = blurScale(shadow.sigma);
+  const exact = await time(shadow, 1);
+  const scaled = scale === 1 ? exact : await time(shadow, undefined);
+  exactTotal += exact;
+  scaledTotal += scaled;
+  console.log(
+    `${`${shadow.width}x${shadow.height}`.padEnd(13)} ${String(shadow.sigma).padStart(4)}  ` +
+      `${scale === 1 ? '   -' : `  ${scale}x`}  ${exact.toFixed(1).padStart(8)}ms ` +
+      `${scaled.toFixed(1).padStart(8)}ms ${`${(100 - (100 * scaled) / exact).toFixed(0)}%`.padStart(7)}   ` +
+      `${macs(shadow, 1).toFixed(1)}M -> ${macs(shadow, scale).toFixed(1)}M`
+  );
+}
+console.log(
+  `\nfirst paint: ${exactTotal.toFixed(1)}ms -> ${scaledTotal.toFixed(1)}ms ` +
+    `(${(100 - (100 * scaledTotal) / exactTotal).toFixed(0)}% off ${SHADOWS.length} shadows)`
+);
+
+await app.close();

--- a/test/shadow.test.js
+++ b/test/shadow.test.js
@@ -14,7 +14,13 @@ import { after, before, describe, test } from 'node:test';
 
 import xserver from 'x11/lib/xserver/index.js';
 
-import { blurCoverage, createClient, StaticFontSource, Surface } from '../lib/index.js';
+import {
+  blurCoverage,
+  blurScale,
+  createClient,
+  StaticFontSource,
+  Surface
+} from '../lib/index.js';
 import {
   DEFAULT_SHADOW_POLICY,
   gaussianKernel1d,
@@ -565,6 +571,213 @@ describe('how strong a blurred shadow gets', () => {
     // which is why a test that looks for `shadowColor` itself finds nothing
     assert.ok(peak < 165, 'nothing on the canvas is within 90 of the colour');
     ctx.destroy();
+  });
+});
+
+// ------------------------------------------------------------------
+// the same blur, run on less of it (issue #338)
+
+describe('a wide blur runs at reduced scale', () => {
+  /** the alpha a coverage surface would paint, straight out of the server */
+  const coverageAlpha = async (surface) => {
+    const ctx = target(surface.width, surface.height);
+    ctx.fillStyle = '#000000';
+    ctx.drawImage(surface, 0, 0);
+    const img = await ctx.getImageData(0, 0, surface.width, surface.height);
+    ctx.destroy();
+    const alpha = new Uint8Array(surface.width * surface.height);
+    for (let i = 0; i < alpha.length; i++) alpha[i] = img.data[i * 4 + 3];
+    return alpha;
+  };
+
+  /** a rect's coverage, padded by the blur's reach as the blur requires */
+  const shapeFor = (sigma, w = 60, h = 40) => {
+    const pad = shadowReach(sigma);
+    const surface = new Surface(app, {
+      width: w + 2 * pad,
+      height: h + 2 * pad,
+      format: 'a8'
+    });
+    surface.render((c) => {
+      c.fillStyle = '#ffffff';
+      c.fillRect(pad, pad, w, h);
+    });
+    return surface;
+  };
+
+  /** what went to the server: the kernels hung on pictures, and the
+   * transforms, which are the whole visible signature of the shrink */
+  const record = (fn) => {
+    const R = app.display.Render;
+    const filters = [];
+    const transforms = [];
+    const setFilter = R.SetPictureFilter;
+    const setTransform = R.SetPictureTransform;
+    R.SetPictureFilter = function (id, name, params) {
+      filters.push({ name, params });
+      return setFilter.apply(this, arguments);
+    };
+    R.SetPictureTransform = function (id, matrix) {
+      transforms.push(matrix[0]);
+      return setTransform.apply(this, arguments);
+    };
+    try {
+      return { value: fn(), filters, transforms };
+    } finally {
+      R.SetPictureFilter = setFilter;
+      R.SetPictureTransform = setTransform;
+    }
+  };
+
+  const taps = (filters) => {
+    const convolution = filters.filter((f) => f.name === 'convolution');
+    assert.equal(convolution.length, 2, 'two separable passes, whatever the scale');
+    // params are [width, height, ...kernel]: one pass is k x 1, the other 1 x k
+    return Math.max(convolution[0].params[0], convolution[0].params[1]);
+  };
+
+  test('the scale is a power of two, bounded by a sigma floor and a cap', () => {
+    // Nothing below 2 * scaleSigma moves: the two resampling composites
+    // would cost more than the kernel they save.
+    for (const sigma of [0.5, 2, 4, 6, 7.9]) assert.equal(blurScale(sigma), 1, `sigma ${sigma}`);
+    for (const sigma of [8, 10, 12, 15.9]) assert.equal(blurScale(sigma), 2, `sigma ${sigma}`);
+    for (const sigma of [16, 21, 32]) assert.equal(blurScale(sigma), 4, `sigma ${sigma}`);
+    // the reduced sigma is what the floor is about, so it never goes under it
+    for (const sigma of [8, 12, 21, 32]) {
+      assert.ok(sigma / blurScale(sigma) >= DEFAULT_SHADOW_POLICY.scaleSigma);
+    }
+    // and the cap holds whatever the floor would allow
+    assert.equal(blurScale(64, { ...DEFAULT_SHADOW_POLICY, maxScale: 8 }), 8);
+    assert.equal(blurScale(64, { ...DEFAULT_SHADOW_POLICY, maxScale: 1 }), 1);
+    assert.equal(blurScale(12, { ...DEFAULT_SHADOW_POLICY, scaleSigma: 12 }), 1);
+    assert.equal(blurScale(12, { ...DEFAULT_SHADOW_POLICY, scaleSigma: 1 }), 4);
+    assert.equal(blurScale(0), 1, 'no blur, nothing to scale');
+  });
+
+  test('a wide blur shrinks the coverage, blurs small, and resolves back', () => {
+    const sigma = 21;
+    const shape = shapeFor(sigma);
+    const { width, height } = shape;
+    const { value: blurred, filters, transforms } = record(() => blurCoverage(shape, sigma));
+    // 4x: two halvings on the way down, one 1/4 on the way back up
+    assert.deepEqual(transforms, [2, 2, 0.25]);
+    assert.equal(
+      filters.filter((f) => f.name === 'bilinear').length,
+      3,
+      'every resampling composite is bilinear'
+    );
+    // the kernel is the reduced one — 2 * ceil(3 * 21/4) + 1, not 127
+    assert.equal(taps(filters), 2 * shadowReach(sigma / 4) + 1);
+    assert.equal(taps(filters), 33);
+    // and none of that is visible in what comes back
+    assert.equal(blurred.width, width);
+    assert.equal(blurred.height, height);
+    assert.equal(blurred.format, 'a8');
+    blurred.destroy();
+  });
+
+  test('and it is the same blur: three levels of alpha, at most', async () => {
+    // The claim the whole thing rests on. A gaussian carries no detail finer
+    // than about sigma/2 px, so resolving it at full resolution is work the
+    // result cannot hold — but "cannot hold" has to mean pixels, not theory.
+    // Three levels is the bound on a real server (test/smoke-canvas.test.js
+    // asserts the same thing against Xorg); this one, whose bilinear is
+    // exact arithmetic rather than fixed point, comes in at two.
+    for (const sigma of [10, 15, 21, 32]) {
+      const scale = blurScale(sigma);
+      assert.ok(scale > 1, `sigma ${sigma} is scaled at all`);
+      const exact = await coverageAlpha(blurCoverage(shapeFor(sigma), sigma, { scale: 1 }));
+      const scaled = await coverageAlpha(blurCoverage(shapeFor(sigma), sigma));
+      assert.equal(exact.length, scaled.length);
+      let worst = 0;
+      for (let i = 0; i < exact.length; i++) {
+        worst = Math.max(worst, Math.abs(exact[i] - scaled[i]));
+      }
+      assert.ok(worst <= 3, `sigma ${sigma} at ${scale}x differs by ${worst} of 255`);
+    }
+  });
+
+  test('the exact kernel is one option away, and one policy away', () => {
+    const sigma = 21;
+    const exact = record(() => blurCoverage(shapeFor(sigma), sigma, { scale: 1 }));
+    assert.deepEqual(exact.transforms, [], 'nothing is resampled');
+    assert.equal(taps(exact.filters), 2 * shadowReach(sigma) + 1, 'every tap of it');
+    exact.value.destroy();
+
+    app.shadowPolicy = { maxScale: 1 };
+    try {
+      const policy = record(() => blurCoverage(shapeFor(sigma), sigma));
+      assert.deepEqual(policy.transforms, []);
+      assert.equal(taps(policy.filters), 2 * shadowReach(sigma) + 1);
+      policy.value.destroy();
+    } finally {
+      delete app.shadowPolicy;
+    }
+  });
+
+  test('what comes back is a plain mask, exactly as it was before', async () => {
+    // The output of a *scaled* bake must be as ordinary as the output of an
+    // exact one: no filter, no transform left on it, or every composite of
+    // the cached shadow afterwards would pay to resample it again.
+    const sigma = 21;
+    const blurred = blurCoverage(shapeFor(sigma), sigma);
+    const drawn = record(() => {
+      const ctx = target(blurred.width, blurred.height);
+      ctx.fillStyle = '#000000';
+      ctx.drawImage(blurred, 0, 0);
+      ctx.destroy();
+    });
+    assert.deepEqual(drawn.filters, [], 'compositing it sets no filter');
+    assert.deepEqual(drawn.transforms, [], 'and no transform');
+    blurred.destroy();
+  });
+
+  test('a sliver is not shrunk into a smear', () => {
+    // Nothing a shadow builds is this thin — a blur wide enough to be scaled
+    // pads by 24px a side — but the primitive takes any a8 surface.
+    const sliver = new Surface(app, { width: 400, height: 9, format: 'a8' });
+    const { value, transforms } = record(() => blurCoverage(sliver, 21));
+    assert.deepEqual(transforms, [], '9 rows have nothing to give up');
+    assert.equal(value.width, 400);
+    assert.equal(value.height, 9);
+    value.destroy();
+  });
+
+  test('a scale that is not one is refused, and an odd one is snapped down', () => {
+    const coverage = new Surface(app, { width: 64, height: 64, format: 'a8' });
+    for (const bad of [0, -2, NaN, Infinity, 0.5]) {
+      assert.throws(() => blurCoverage(coverage, 8, { scale: bad }), /scale/, `scale ${bad}`);
+    }
+    assert.equal(coverage._destroyed, undefined, 'a refused call destroys nothing');
+    coverage.destroy();
+    // 3 is not a power of two, and a bilinear tap of a 3x shrink would skip
+    // pixels rather than average them: it shrinks by 2 instead
+    const { value, transforms } = record(() => blurCoverage(shapeFor(21), 21, { scale: 3 }));
+    assert.deepEqual(transforms, [2, 0.5]);
+    value.destroy();
+  });
+
+  test('the 2d context gets it without asking', async () => {
+    // The shadow properties call blurCoverage, so the reduced kernel is what
+    // the server sees for a wide `shadowBlur` — and the shadow still lands.
+    const ctx = target(160, 140);
+    const { filters } = record(() => {
+      ctx.shadowColor = '#ff0000';
+      ctx.shadowBlur = 42; // sigma 21
+      ctx.fillStyle = 'rgba(0, 0, 0, 0)';
+      ctx.fillRect(50, 50, 60, 40);
+    });
+    assert.equal(taps(filters), 2 * shadowReach(21 / 4) + 1);
+    const at = await readAll(ctx, 160, 140);
+    assert.ok(at(80, 70)[3] > 100, `the shadow is there (alpha ${at(80, 70)[3]})`);
+    ctx.destroy();
+  });
+
+  test('blurScale reaches a consumer too', async () => {
+    const ntk = await import('ntk');
+    assert.equal(ntk.blurScale, blurScale);
+    assert.equal(ntk.DEFAULT_SHADOW_POLICY.scaleSigma, 4);
+    assert.equal(ntk.DEFAULT_SHADOW_POLICY.maxScale, 4);
   });
 });
 

--- a/test/smoke-canvas.test.js
+++ b/test/smoke-canvas.test.js
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict';
 import { after, before, test } from 'node:test';
 
-import { createClient, Path2D, Surface, SvgView } from '../lib/index.js';
+import { blurCoverage, blurScale, createClient, Path2D, Surface, SvgView } from '../lib/index.js';
 import { withTimeout } from './helpers/async.js';
 
 let app = null;
@@ -418,4 +418,69 @@ test('shadows: a wide blur keeps the same fraction of its colour here (#287)', a
     `the middle of the shadow is ${alpha.toFixed(3)} of the colour, expected ~0.784`
   );
   pixmap.destroy();
+});
+
+test('shadows: blurring shrunk coverage draws the same pixels here (#338)', async (t) => {
+  if (skip) return t.skip(skip);
+  // A wide blur is run on coverage shrunk by 2 or 4 and resolved back, which
+  // trades three levels of 8-bit alpha for most of a first paint's server
+  // time — and three is the number *here*, where pixman's bilinear works in
+  // fixed point, against the two the JS server's exact arithmetic gives.
+  // The hermetic run asserts the trade against node-x11's JS server; this
+  // asserts that a real RENDER — where the resampling is pixman's bilinear
+  // and not ours — agrees, because the whole scheme is the server's arithmetic
+  // and none of it is visible from the client.
+  const sigma = 21;
+  const pad = 3 * sigma; // shadowReach: the blur's full spread, on all sides
+  const width = 60 + 2 * pad;
+  // tall enough that the middle row is 3 sigma clear of the rect's own top
+  // and bottom, so the profile there is one edge's rather than a small
+  // rect's two — which is what makes the CDF below the exact prediction
+  const height = 160 + 2 * pad;
+
+  const bake = (scale) => {
+    const shape = new Surface(app, { width, height, format: 'a8' });
+    shape.render((c) => {
+      c.fillStyle = '#ffffff';
+      c.fillRect(pad, pad, 60, 160);
+    });
+    return blurCoverage(shape, sigma, { scale });
+  };
+  const paint = async (coverage) => {
+    const pixmap = app.createPixmap({ width, height, depth: 24 });
+    const ctx = pixmap.getContext('2d');
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, width, height);
+    ctx.fillStyle = 'black';
+    ctx.drawImage(coverage, 0, 0);
+    const image = await readPixels(ctx, width, height);
+    coverage.destroy();
+    pixmap.destroy();
+    return image;
+  };
+
+  assert.equal(blurScale(sigma), 4, 'sigma 21 is worth a 4x shrink');
+  const exact = await paint(bake(1));
+  const scaled = await paint(bake(undefined));
+  let worst = 0;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      worst = Math.max(worst, Math.abs(px(exact, width, x, y)[0] - px(scaled, width, x, y)[0]));
+    }
+  }
+  assert.ok(worst <= 3, `the shrunk blur differs by ${worst} of 255, expected 3 or less`);
+  // and it is a blur, not a smear: the profile of the edge at x = pad still
+  // follows the gaussian's CDF
+  const coverage = (x) => 1 - px(scaled, width, x, height >> 1)[0] / 255;
+  for (const [x, want] of [
+    [pad - sigma, 0.159],
+    [pad, 0.5],
+    [pad + sigma, 0.841]
+  ]) {
+    const got = coverage(Math.round(x));
+    assert.ok(
+      Math.abs(got - want) < 0.03,
+      `coverage at x=${x} is ${got.toFixed(3)}, expected ~${want}`
+    );
+  }
 });


### PR DESCRIPTION
A gaussian carries no detail finer than about half its sigma, so baking a
wide one at the coverage surface's full resolution spends most of its time
resolving what the result cannot hold. Past sigma 8 `blurCoverage` now
shrinks the coverage by 2 or 4, blurs at `sigma / scale`, and resolves it
back: `scale` off the kernel and `scale` squared off the area it runs over.

Nothing above it changes. The surface that comes back is the size it always
was and still carries no filter, so a cached shadow composites exactly as it
did, and the 2d context's shadow properties pick this up without a line of
their own — react-x11, which calls `blurCoverage` directly, gets it on
upgrade with no change at all.

![three panels: the same three shadowed cards blurred at full resolution and on shrunk coverage, and their difference amplified 32x](https://github.com/user-attachments/assets/4014fcaa-8cf4-4f43-9c2b-1e3e5a9110ab)

Left, full resolution; middle, blurred on coverage shrunk 2-4x; right, the
difference between them amplified 32 times. Rendered by this branch, headless
into a pixmap and read back with `getImageData`. The worst channel difference
in that scene is 2 of 255.

## What it costs

Set by the sigma the blur ends up running at, not by how far it came down,
which is what the new `scaleSigma` policy entry pins at 4: three levels of
8-bit alpha against an exact blur, measured over rects, discs, rounded boxes
and glyph-thin stems on Xorg. At a floor of 3 it is four levels, at 2 seven.

## What it saves

Measured on XQuartz's software RENDER with the coverage surfaces the issue
tabulates, via the new `scripts/bench-shadow-blur.mjs`:

| surface | sigma | scale | exact | scaled | MAC |
| --- | --- | --- | --- | --- | --- |
| 552x396 | 21 | 4x | 842.5ms | **15.8ms** | 55.5M -> 0.9M |
| 1294x165 | 12 | 2x | 398.1ms | **20.9ms** | 31.2M -> 4.0M |
| 462x306 | 6 | - | 51.3ms | 51.3ms | 10.5M |
| 495x133 | 11 | 2x | 42.0ms | **6.4ms** | 8.8M -> 1.2M |
| 564x81 | 11 | 2x | 29.2ms | **4.3ms** | 6.1M -> 0.8M |
| 196x154 | 11 | 2x | 19.4ms | **3.0ms** | 4.0M -> 0.5M |

Six shadows of a first paint: 1382ms -> 102ms.

## The escape hatches

- `blurCoverage(shape, sigma, { scale: 1 })` — the exact kernel, per call
- `app.shadowPolicy = { maxScale: 1 }` — the exact kernel, per app; this is
  what 8.6 did
- `blurScale(sigma)` — the scale, exported, for a caller that would rather
  draw its shape small in the first place: draw into a surface `1 / scale`
  the size, blur at `sigma / scale`, composite through a `1 / scale` picture
  transform. That skips the shrink, the full-size allocation and the resolve;
  the cost is a mask resampled per composite rather than once

## Tests

The scale's arithmetic and its bounds; that the shrink is what actually goes
to the server, as two halvings and a resolve; that the pixels match an exact
blur within three levels at sigma 10 through 32; that what comes back carries
no filter or transform, so compositing it stays a plain mask; that a sliver
is not shrunk into a smear; that a bad scale is refused and an odd one snaps
down. The same pixel comparison runs against a real server in the smoke
suite, where pixman's fixed-point bilinear is a level coarser than the JS
server's exact arithmetic.

Closes #338
