### PR TITLE
feat(window): deselectInput, the inverse of selectInput

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -659,6 +659,14 @@ wnd.requestAnimationFrame(step); // now runs at the display's rate
   so a window capped below the display's rate never measures it
 - `wnd.droppedFrames` — vertical blanks the display went through without a
   frame from this window, where the server's counter can tell
+- `wnd.eventMask` — the X event mask this connection has selected on the
+  window. Raised by `.on(...)`, the `onXxx` creation arguments and
+  `selectInput`; lowered only by
+  [`deselectInput`](#lowering-a-selection--deselectinputmask)
+- `wnd.heldEventMask` — the bits of it something in this process still
+  needs: every event name with a live listener, plus what ntk's own
+  machinery requires. `mask & wnd.heldEventMask` is what `deselectInput`
+  would refuse to clear
 - `wnd.app`, `wnd.X`, `wnd.display` — owning app / raw client shortcuts
 
 ## Methods
@@ -707,6 +715,11 @@ All return `this` unless noted.
 - `setMouseHintOnly(isOn)` — trade motion events for round trips on a
   bandwidth-constrained connection, see
   [Hinted motion](#hinted-motion--setmousehintonlyison)
+- `deselectInput(mask)` — stop selecting `mask`; a promise for the bits it
+  kept because a listener still needs them, `0` when it cleared everything
+  asked for. The inverse of `selectInput`, and the only way the mask goes
+  down — see
+  [Lowering a selection](#lowering-a-selection--deselectinputmask)
 - `selectXI2(types, options)` — take this window's input from XInput 2:
   smooth scrolling, per-device ids, touch. Returns a promise for whether the
   server has XI2, not `this` — see
@@ -731,6 +744,7 @@ All return `this` unless noted.
 - `getProperty(name, options)`, `setProperty(name, value, options)`,
   `deleteProperty(name)`, `getTitle()`, `getSizeHints()`, `getWmHints()`,
   `getTransientFor()`, `getAttributes()`, `atom(name)`, `selectInput(mask)`,
+  `deselectInput(mask)`,
   `addToSaveSet()`, `sendConfigureNotify(geometry)`, `close()`,
   `grabButton(options)` — the window manager side, see
   [Being the window manager](#being-the-window-manager)
@@ -1362,7 +1376,9 @@ const wnd = app.createWindow({ width: 300, height: 200, cursor: app.cursors.get(
 ## Events
 
 DOM-inspired names. Selecting an event via `.on(...)` (or an `onXxx`
-constructor arg) automatically extends the window's X event mask.
+constructor arg) automatically extends the window's X event mask;
+[`deselectInput`](#lowering-a-selection--deselectinputmask) is what narrows
+it again, since `off()` only drops the listener.
 
 | event | X event | notes |
 |---|---|---|
@@ -1423,6 +1439,49 @@ the first event after the switch — spurious work, never missed work. The
 alternative is a `TranslateCoordinates` round trip per event, which is the
 cost these flags exist to avoid; ask for one explicitly if you need the true
 screen origin.
+
+### Lowering a selection — `deselectInput(mask)`
+
+`.on(name, fn)` raises the window's X event mask as a side effect. `off()`
+does not lower it again — it drops the JS listener and leaves the selection,
+so the server goes on sending events nobody reads. `deselectInput` is the
+inverse, and the only thing that takes a bit back out:
+
+```js
+import x11 from 'x11';
+
+wnd.off('mousemove', onHover);
+const kept = await wnd.deselectInput(x11.eventMask.PointerMotion);
+if (kept) {
+  // something in this process is still listening for it
+}
+```
+
+For most masks the difference is invisible: their events are occasional, and
+selecting one nobody reads costs nothing measurable. Motion is the exception,
+because it arrives at frame rate for as long as the pointer is over the
+window — around 2 KB/s of core `MotionNotify` at 60 Hz, and 8 KB/s where the
+motion is XI2's. A viewer that hides its chrome, a toolbar that unmounts, a
+window that goes to a background tab: they know when hover stopped mattering,
+and this is how they say so.
+
+**It refuses to break a live listener.** Several event names share one bit —
+`map`, `unmap`, `resize`, `reparent`, `gravity`, `circulate` and `destroy`
+are all `StructureNotify` — so losing the last `map` listener does not make
+the bit free, and clearing `PointerMotion` out from under an `on('mousemove')`
+is the one bug this API could have. Bits a listener still needs are kept, and
+the promise resolves with them rather than throwing, so "clear everything I
+can" is a single call. `wnd.heldEventMask` answers the same question without
+making the request.
+
+Two selections are therefore never cleared through it: `StructureNotify`,
+which ntk's own map/unmap/destroy bookkeeping listens for on every window,
+and `Exposure` on a [double-buffered](#double-buffering-backing-store) one,
+whose redraw cycle is driven by intercepting it.
+
+A mask that is not selected, or one that is entirely spoken for, resolves
+without a request. XI2 selections are separate and have their own inverse —
+`selectXI2([])`, [below](#wheel-and-smooth-scrolling).
 
 ## Wheel and smooth scrolling
 

--- a/lib/window.js
+++ b/lib/window.js
@@ -3719,6 +3719,9 @@ export default class Window extends Drawable {
    * connection selected and nothing else adds to it behind the caller's
    * back. It resolves rather than returning undefined because the promise is
    * the whole interface: an awaited no-op still has to mean "you have it".
+   *
+   * `deselectInput(mask)` is the inverse, and the only thing that lowers the
+   * mask again — `off()` drops the listener and leaves the selection.
    */
   selectInput(mask) {
     const added = mask & ~this.eventMask;
@@ -3731,6 +3734,92 @@ export default class Window extends Drawable {
         // bits, or the next call would find them held and skip a request
         // that has not happened yet
         this.eventMask &= ~added;
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * The bits of the event mask something in this process still needs: the
+   * union over every event name with a live listener, plus what ntk's own
+   * machinery requires. `deselectInput` refuses exactly these, so
+   * `mask & wnd.heldEventMask` asks "would that be refused?" without making
+   * the request.
+   *
+   * Not a subset of `eventMask`. A listener implies a bit whether or not
+   * this connection ever selected it — an adopted window selects nothing
+   * (issue #322), and ntk's own map/unmap/destroy handlers listen without
+   * asking for anything.
+   */
+  get heldEventMask() {
+    let held = 0;
+    for (const name in xevents.mask) {
+      const bit = xevents.mask[name];
+      // 0 marks an event that arrives regardless of any selection
+      if (bit && this.listenerCount(name) > 0) held |= bit;
+    }
+    // the redraw cycle is driven by intercepting Expose, whether or not
+    // anyone listens for it: a double-buffered window that stops selecting
+    // Exposure stops repainting (see _enableBackingStore)
+    if (this._backing) held |= x11.eventMask.Exposure;
+    return held;
+  }
+
+  /**
+   * Stop selecting `mask` — the inverse of `selectInput`, and the only way a
+   * window's event mask ever goes down (issue #318).
+   *
+   * `on(name, fn)` raises the mask as a side effect and `off()` does not
+   * lower it again, so a window that stops needing an event goes on being
+   * sent it until it is destroyed. For most masks that is invisible; for
+   * PointerMotion it is 32 bytes per motion event — 2 KB/s at 60 Hz, and
+   * 8 KB/s where the motion is XI2's — for as long as the pointer is over
+   * the window. A viewer that hides its chrome, a toolbar that unmounts, a
+   * window that goes to a background tab: they know when they stop needing
+   * hover, and this is how they say so.
+   *
+   * Bits a live listener still needs are kept rather than cleared, because
+   * dropping PointerMotion out from under an `on('mousemove')` is the one
+   * bug this API can have. Several names share one bit — `map`, `unmap`,
+   * `resize`, `reparent`, `gravity`, `circulate` and `destroy` are all
+   * StructureNotify — so losing the last `map` listener does not make the
+   * bit free. It resolves with the bits it kept for that reason, `0` when it
+   * cleared everything it was asked to:
+   *
+   *   const kept = await wnd.deselectInput(x11.eventMask.PointerMotion);
+   *   if (kept) ... // something in this process is still listening
+   *
+   * Two selections it will therefore not clear: StructureNotify, held by
+   * ntk's own map/unmap/destroy bookkeeping on every window, and Exposure on
+   * a double-buffered one. XI2 is selected separately and keeps its own
+   * inverse — `selectXI2([])` (see lib/xi2.js).
+   */
+  deselectInput(mask) {
+    const clear = mask & this.eventMask & ~this.heldEventMask;
+    const kept = mask & this.eventMask & ~clear;
+    // asking to drop what is not selected, or only what is spoken for, is a
+    // request that would change nothing
+    if (clear === 0) return Promise.resolve(kept);
+    this.eventMask &= ~clear;
+    // no motion means no hints, so no frame owes the server the QueryPointer
+    // that re-arms one. A poll already in flight is left alone, as
+    // setMouseHintOnly leaves it: its answer is a real position.
+    if (clear & (x11.eventMask.PointerMotion | x11.eventMask.PointerMotionHint)) {
+      this._hintRearm = false;
+    }
+    // A window the server has already taken, or a connection on its way out:
+    // there is no selection left to lower, and node-x11 throws at a request
+    // from then on (issue #321). The tracked mask is lowered all the same —
+    // it says what this connection holds, and it holds nothing.
+    if (this._destroyed || connectionGone(this.X)) return Promise.resolve(kept);
+    return new Promise((resolve, reject) => {
+      this.X.ChangeWindowAttributes(this.id, { eventMask: this.eventMask }, (err) => {
+        if (!err) return resolve(kept);
+        // the request failed as a whole, so the server kept the mask it had:
+        // take the bits back rather than leave `eventMask` denying a
+        // selection this connection still holds — the next on() reads it to
+        // decide whether a write can be skipped
+        this.eventMask |= clear;
         reject(err);
       });
     });

--- a/test/select-input.test.js
+++ b/test/select-input.test.js
@@ -182,3 +182,141 @@ test('a handler whose selection is refused leaves the mask honest', async () => 
     (err) => err.error === 10
   );
 });
+
+// The other direction (issue #318): `on()` raises the mask and `off()` does
+// not lower it, so until deselectInput there was no way to stop being sent
+// an event — a window that no longer wants hover kept paying for motion for
+// the rest of its life. What the API has to get right is the refusal: bits
+// several event names share, and bits ntk's own machinery needs.
+
+test('deselectInput lowers a selection nothing is listening for', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  await wnd.selectInput(x11.eventMask.PropertyChange);
+  assert.ok((await maskOf(app, wnd.id)) & x11.eventMask.PropertyChange);
+
+  const kept = await wnd.deselectInput(x11.eventMask.PropertyChange);
+
+  assert.equal(kept, 0, 'nothing held it back');
+  assert.equal(wnd.eventMask & x11.eventMask.PropertyChange, 0, 'gone from the tracked mask');
+  assert.equal(
+    (await maskOf(app, wnd.id)) & x11.eventMask.PropertyChange,
+    0,
+    'and from the server'
+  );
+  assert.ok(
+    (await maskOf(app, wnd.id)) & x11.eventMask.StructureNotify,
+    'the bits it was not asked about are untouched'
+  );
+});
+
+test('a bit a live listener still needs is kept and reported, not cleared', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  const hover = () => {};
+  wnd.on('mousemove', hover);
+  await settle(app);
+  assert.ok((await maskOf(app, wnd.id)) & x11.eventMask.PointerMotion, 'on() selected it');
+
+  const kept = await wnd.deselectInput(x11.eventMask.PointerMotion);
+  assert.equal(kept, x11.eventMask.PointerMotion, 'the refusal is the return value');
+  assert.ok(
+    (await maskOf(app, wnd.id)) & x11.eventMask.PointerMotion,
+    'the listener would have stopped working'
+  );
+  assert.equal(
+    x11.eventMask.PointerMotion & wnd.heldEventMask,
+    x11.eventMask.PointerMotion,
+    'and the same answer without making the request'
+  );
+
+  // the listener gone, the same call goes through
+  wnd.off('mousemove', hover);
+  assert.equal(x11.eventMask.PointerMotion & wnd.heldEventMask, 0);
+  assert.equal(await wnd.deselectInput(x11.eventMask.PointerMotion), 0);
+  assert.equal((await maskOf(app, wnd.id)) & x11.eventMask.PointerMotion, 0);
+});
+
+test('a bit several event names share survives until the last of them', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  const click = () => {};
+  const scroll = () => {};
+  // 'wheel' is a click of button 4-7 in the core protocol, so both names
+  // are the same ButtonPress bit
+  wnd.on('mousedown', click);
+  wnd.on('wheel', scroll);
+  await settle(app);
+
+  wnd.off('mousedown', click);
+  assert.equal(
+    await wnd.deselectInput(x11.eventMask.ButtonPress),
+    x11.eventMask.ButtonPress,
+    "the other name's listener still needs it"
+  );
+  assert.ok((await maskOf(app, wnd.id)) & x11.eventMask.ButtonPress);
+
+  wnd.off('wheel', scroll);
+  assert.equal(await wnd.deselectInput(x11.eventMask.ButtonPress), 0);
+  assert.equal((await maskOf(app, wnd.id)) & x11.eventMask.ButtonPress, 0);
+});
+
+test('a deselection that would change nothing is not a request', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.on('mousemove', () => {});
+  await settle(app);
+
+  const writes = countWrites(app);
+  const unselected = await wnd.deselectInput(x11.eventMask.PropertyChange);
+  const held = await wnd.deselectInput(x11.eventMask.PointerMotion);
+  await settle(app);
+  writes.restore();
+
+  assert.equal(writes.n, 0, 'neither a bit that is off nor one that is spoken for');
+  assert.equal(unselected, 0, 'a bit that was never selected is not "kept"');
+  assert.equal(held, x11.eventMask.PointerMotion);
+});
+
+test("StructureNotify is held by ntk's own bookkeeping", async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  await settle(app);
+
+  // map/unmap/destroy tracking listens on every window without asking for a
+  // selection — but it does need the events once they are being sent
+  assert.equal(
+    await wnd.deselectInput(x11.eventMask.StructureNotify),
+    x11.eventMask.StructureNotify
+  );
+  assert.ok((await maskOf(app, wnd.id)) & x11.eventMask.StructureNotify);
+
+  const mapped = new Promise((resolve) => wnd.once('map', resolve));
+  wnd.map();
+  await mapped;
+  assert.equal(wnd._mapped, true);
+});
+
+test('Exposure is held while a backing store drives the redraw', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  wnd.getContext('2d'); // enables double buffering, which selects Exposure
+  await settle(app);
+  assert.ok((await maskOf(app, wnd.id)) & x11.eventMask.Exposure, 'nobody listens, ntk asked');
+
+  assert.equal(
+    await wnd.deselectInput(x11.eventMask.Exposure),
+    x11.eventMask.Exposure,
+    'the redraw cycle would have stopped'
+  );
+  assert.ok((await maskOf(app, wnd.id)) & x11.eventMask.Exposure);
+});
+
+test('a destroyed window lowers its tracked mask without a request', async () => {
+  const wnd = app.createWindow({ width: 40, height: 30 });
+  await wnd.selectInput(x11.eventMask.PropertyChange);
+  wnd.destroy();
+  await settle(app);
+
+  const writes = countWrites(app);
+  const kept = await wnd.deselectInput(x11.eventMask.PropertyChange);
+  writes.restore();
+
+  assert.equal(kept, 0);
+  assert.equal(writes.n, 0, 'the window is gone — there is nothing to tell the server');
+  assert.equal(wnd.eventMask & x11.eventMask.PropertyChange, 0);
+});


### PR DESCRIPTION

Closes #318, the explicit half only — as the issue proposed, `off()` still
does not emit a request, and nothing recomputes a mask behind a caller's
back.

`on(name, fn)` raises a window's server-side event mask and nothing ever put
it back, so a mask was monotonic for the window's whole life. `deselectInput`
is the inverse of `selectInput`:

```js
wnd.off('mousemove', onHover);
const kept = await wnd.deselectInput(x11.eventMask.PointerMotion);
```

## What it refuses, and why

Several event names share one bit — `map`, `unmap`, `resize`, `reparent`,
`gravity`, `circulate` and `destroy` are all StructureNotify — so losing the
last `map` listener does not make the bit free. Bits a live listener still
needs are kept rather than cleared: dropping PointerMotion out from under an
`on('mousemove')` is the one bug this API can have.

Two selections nobody asked for are held the same way, because they are
real dependencies rather than leftovers:

- **StructureNotify**, which ntk's own map/unmap/destroy bookkeeping listens
  for on every window. It listens without *selecting* — issue #322 — but it
  does need the events once they are being sent.
- **Exposure** on a double-buffered window, whose redraw cycle is driven by
  intercepting Expose with no listener behind it.

## The open questions

**Throw, or return the refused bits?** Returns them. The promise resolves
with the bits it kept, `0` when it cleared everything asked for, so "clear
everything I can" is one call and the caller can still notice a refusal.
`wnd.heldEventMask` is the same question asked without making the request,
which is the "would this be refused?" probe the issue wanted.

**Is `_maskPinned` worth exposing?** Not shipped here. With only the explicit
half in, the pinned/derived split has no consumer: what `deselectInput` needs
is `eventMask`, which is what the server holds, and `heldEventMask`, which is
what something still needs. The split is what an automatic recompute needs,
so it belongs with that change rather than as state maintained at five sites
and read by nothing.

**The automatic mode** is not here, per the issue.

## Measured

XQuartz, one 300x300 window, the pointer warped across it 600 times, bytes
read from the socket:

| | bytes in | motion events |
|---|---|---|
| PointerMotion selected | 20288 | 600 |
| after `deselectInput` | 992 | 0 |

32 B per motion event, matching the issue's table. The remaining 992 B is the
warp loop's own sync traffic, which both rows pay.

## Tests

Seven hermetic cases in `test/select-input.test.js`, against node-x11's
in-process X server, reading the resulting mask back with
GetWindowAttributes: a plain lowering, a bit a listener holds and the same
call succeeding once the listener is gone, a shared bit surviving until the
last of its names, StructureNotify and Exposure being held, no request when
nothing would change, and a destroyed window lowering its tracked mask
without one. `npm test` is otherwise unchanged: the 5 failures on this
machine are XQuartz's missing RENDER, DAMAGE and indirect GLX, and they fail
identically on master.

## Docs

`docs/window.md`: a "Lowering a selection" section under Events, the two new
entries in Properties and Methods, and the Events preamble now says what
narrows a mask as well as what widens it.
