### PR TITLE
fix(gl): answer the multisample request instead of dropping it

### DIFF
--- a/docs/context-gles.md
+++ b/docs/context-gles.md
@@ -202,10 +202,14 @@ the one available — useful when the code wants no silent substitution.
 Direct contexts also carry `gl.flavor` (`'dri3'` or `'appledri'`) for the
 rare code that cares which pipeline is under it.
 
-The ES 2 surface is whatever `x11-dri` exposes, which is the core of ES 2
-(shaders, programs, uniforms, buffers, attributes, draws, `readPixels`) and
-**not yet textures, framebuffer objects, blending or scissoring**. Adding an
-entry point is a small wrapper in that package.
+The ES 2 surface is whatever `x11-dri` exposes: the core of ES 2 — shaders,
+programs, uniforms, buffers, attributes, draws, textures, framebuffer
+objects, renderbuffers, blending, scissoring, `readPixels` — plus the ES 3
+entry points a driver has (VAOs, instancing, 3D textures), which
+`gl.getFeatures()` reports. Still absent, and the reason
+[Multisampling](#multisampling) has nothing to resolve by hand:
+`renderbufferStorageMultisample` and `blitFramebuffer`. Adding an entry point
+is a small wrapper in that package.
 
 ### Context lifetime
 
@@ -334,15 +338,58 @@ be written twice:
 ```js
 const config = await app.chooseGLConfig({ DEPTH_SIZE: 24 });
 // { backend: 'direct', visual, depth, class, doubleBuffer, depthSize,
-//   screen, fbconfig: null, device, config: {} }
+//   samples, screen, fbconfig: null, device, config: {} }
 ```
 
 On the direct backend it needs no round trip — there are no fbconfigs, only a
 window whose depth the GPU's buffers can be read as. `DEPTH_SIZE` becomes the
 EGL depth-buffer size; `ALPHA_SIZE` picks a 32-bit ARGB visual (whose alpha a
-compositor blends) instead of the root's 24-bit one. Everything else in the
-spec is ignored there, and honoured by
+compositor blends) instead of the root's 24-bit one. `SAMPLES` and
+`SAMPLE_BUFFERS` are answered rather than honoured — see
+[Multisampling](#multisampling) below. Everything else in the spec is ignored
+there, and honoured by
 [`chooseGLXConfig`](context-opengl.md#choosing-a-visual) on the indirect one.
+
+`samples` is on the answer from either backend, and is the one field to
+branch on: the colour samples per pixel the config really has, `0` for none.
+(`chooseGLXConfig` reports `null` in the one case where it cannot know —
+a spec that pins `visual`, where no fbconfig is looked at.)
+
+## Multisampling
+
+**The direct backend cannot give a window a multisampled buffer today**, on
+either flavor, and `chooseGLConfig` says so instead of dropping the request:
+the config it returns has `samples: 0`, and a spec that asked for more warns
+once per connection.
+
+```js
+const config = await app.chooseGLConfig({ SAMPLES: 4 });
+if (config.samples < 4) {
+  // draw at 2x into an FBO and downsample, or accept aliased edges
+}
+```
+
+The reason is one layer below ntk. A sample count belongs to the pixel format
+the `x11-dri` addon builds — `EGL_SAMPLES` on the EGLConfig behind the GBM
+surface (`dri3`), `kCGLPFASamples` on the CGL pixel format (`appledri`) — and
+the addon takes a depth size and no sample count, so there is nothing here to
+ask with. Its GL table has neither `renderbufferStorageMultisample` nor
+`blitFramebuffer` either, so ntk cannot resolve a multisampled framebuffer by
+hand in place of the driver. When the addon grows the option, `samples`
+becomes what it reports and the same spec starts meaning what it says
+(`DIRECT_SAMPLES` in `lib/gl.js` is the single place that changes).
+
+What works today:
+
+- **Indirect GLX honours it.** `SAMPLES`/`SAMPLE_BUFFERS` are fbconfig
+  attributes there, matched as minimums, so a server with multisample
+  fbconfigs gives real MSAA — and a server without one now *fails* the call
+  rather than quietly returning a visual with no sample buffers.
+- **Supersample in your own draw code.** Render to an FBO at 2x and
+  downsample. One bilinear tap resolves a 2x supersample and no more, so past
+  2x this needs a mip chain or a multi-tap filter to keep gaining.
+- **`gl.samples`** carries the same number on the context — `'opengl'`,
+  `'gles'` and `'cgl'` alike — for draw code that has no config in hand.
 
 ## Testing
 

--- a/docs/context-opengl.md
+++ b/docs/context-opengl.md
@@ -42,7 +42,7 @@ gl.SwapBuffers();
 `app.chooseGLXConfig(spec)` resolves with
 
 ```js
-{ visual, depth, class, doubleBuffer, depthSize, fbconfig, screen, config }
+{ visual, depth, class, doubleBuffer, depthSize, samples, fbconfig, screen, config }
 ```
 
 `visual` and `depth` go to `createWindow` (which also creates a matching
@@ -58,7 +58,17 @@ id and skip the search).
 
 The search asks the server: `GetFBConfigs` first, falling back to the GLX 1.2
 `GetVisualConfigs` — no `glxinfo` shell-out, so it works headlessly and in CI.
-It rejects with a message naming the constraints when nothing matches.
+It rejects with a message naming the constraints when nothing matches. Both
+paths filter on every attribute the server reports, multisampling included:
+a `SAMPLES: 4` this display has no config for is a rejection, never a config
+without sample buffers handed back as though the request had been met.
+
+`samples` on the result is the colour samples per pixel that config has — 0
+for none, and `null` only when the spec pinned `visual`, where no fbconfig
+was consulted to know. `gl.samples` carries the same number on the context.
+The direct backend answers the same question with the same field, where the
+answer is always 0 for now: see
+[Multisampling](context-gles.md#multisampling).
 
 `getContext('opengl')` without a config picks one itself, preferring a config
 for the visual the window already has. That keeps the short form working, but
@@ -81,6 +91,7 @@ await gl.ready; // resolves with the context, rejects if setup failed
 gl.contextTag; // the tag MakeCurrent returned (0 until ready)
 gl.contextId; // the GLX context XID
 gl.config; // the config in use
+gl.samples; // its samples per pixel (0 until the config is resolved)
 ```
 
 A failed setup rejects `gl.ready`, records `gl.error`, drops the queued

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,7 +1,17 @@
 import { connectionGone } from './cleanup.js';
 import Clipboard from './clipboard.js';
 import { CursorCache } from './cursor.js';
-import { GLError, backendFor, glCapabilities, glError, nativeRefreshRate, resolveGLPolicy } from './gl.js';
+import {
+  DIRECT_SAMPLES,
+  GLError,
+  backendFor,
+  glCapabilities,
+  glError,
+  nativeRefreshRate,
+  requestedSamples,
+  resolveGLPolicy,
+  warnDirectSamples
+} from './gl.js';
 import { chooseGLXConfig } from './glx.js';
 import Picture from './picture.js';
 import Pixmap from './pixmap.js';
@@ -620,6 +630,13 @@ export default class App {
    * fbconfig with an alpha channel. Direct needs no round trip to answer —
    * there are no fbconfigs in it, only a window the GPU draws for.
    *
+   * What a backend cannot do, the answer says rather than drops: `samples`
+   * is the colour samples per pixel the returned config really has, which
+   * on the direct backend is 0 today whatever the spec asked for (issue
+   * #341, `DIRECT_SAMPLES` in lib/gl.js). A `SAMPLES`/`SAMPLE_BUFFERS`
+   * request that cannot be met also warns once per connection, because an
+   * aliased edge is otherwise found months later in a screenshot.
+   *
    * @param {object} [spec] GLX attributes, e.g. `{ DEPTH_SIZE: 24 }`
    */
   async chooseGLConfig(spec = {}) {
@@ -638,6 +655,11 @@ export default class App {
         `direct rendering: screen ${screenNum} has no 32-bit visual, so a GL window cannot have an alpha channel`
       );
     }
+    // asked for multisampling this backend cannot give? say so once, then
+    // answer honestly below rather than dropping the attribute (issue #341)
+    const wantSamples = requestedSamples(spec);
+    if (wantSamples > DIRECT_SAMPLES) warnDirectSamples(this, caps.flavor, wantSamples);
+
     return {
       backend: 'direct',
       // which direct pipeline this connection runs: 'dri3' or 'appledri'
@@ -649,6 +671,9 @@ export default class App {
       class: 4, // TrueColor; the only class these buffers can be read as
       doubleBuffer: true, // a swap chain, always
       depthSize: spec.DEPTH_SIZE ?? 16,
+      // no flavor can allocate a multisampled window buffer yet; said out
+      // loud so a caller can supersample instead of assuming MSAA
+      samples: DIRECT_SAMPLES,
       screen: screenNum,
       fbconfig: null,
       device: caps.device,

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -468,6 +468,68 @@ export function glCapabilities(app) {
 }
 
 /**
+ * How many colour samples per pixel a direct-backend window has. Zero, on
+ * both flavors, and this is the one place that says so.
+ *
+ * Not because multisampling is exotic on a GPU — it is nearly free there —
+ * but because the sample count belongs to the pixel format the `x11-dri`
+ * addon builds one layer below ntk: `EGL_SAMPLES` on the EGLConfig behind
+ * the GBM surface (`dri3`), `kCGLPFASamples`/`kCGLPFASampleBuffers` on the
+ * CGL pixel format (`appledri`). Its `Gpu` and `apple.Context` take a depth
+ * size and no sample count, and its GL table has neither
+ * `renderbufferStorageMultisample` nor `blitFramebuffer`, so there is not a
+ * multisampled framebuffer for ntk to resolve by hand either. Nothing here
+ * can conjure one — what it can do is not pretend, which is why
+ * `chooseGLConfig` reports `samples` on every backend and says so out loud
+ * when the spec asked for more than it got (issue #341).
+ *
+ * When the addon grows the option this becomes what it reports, and the
+ * request travels the rest of the way without another change here.
+ */
+export const DIRECT_SAMPLES = 0;
+
+/**
+ * The sample count a GLX-vocabulary spec asks for: `SAMPLES` when it names
+ * one, 1 for a bare `SAMPLE_BUFFERS` (multisample, width up to the driver),
+ * and 0 when it asks for no multisampling at all — which is also what a
+ * config object from `chooseGLConfig` reads as, since it carries neither.
+ */
+export function requestedSamples(spec = {}) {
+  const samples = Number(spec.SAMPLES) || 0;
+  if (samples > 0) return samples;
+  return Number(spec.SAMPLE_BUFFERS) > 0 ? 1 : 0;
+}
+
+/**
+ * Say — once per connection, on the console — that a multisample request
+ * cannot be honoured here.
+ *
+ * A downgrade rather than a failure: the window renders, its edges alias.
+ * That is exactly the kind of thing an app finds out about six months later
+ * from a screenshot, so it is worth one warning and a `samples` field to
+ * branch on. Once per connection because every window would otherwise say
+ * it again.
+ */
+export function warnDirectSamples(app, flavor, wanted) {
+  if (app._warnedDirectSamples) return;
+  app._warnedDirectSamples = true;
+  console.warn(
+    `ntk: this GL request asks for SAMPLES=${wanted}, and the direct backend` +
+      `${flavor ? ` (${flavor} flavor)` : ''} cannot give a window a multisampled buffer, so it has ` +
+      'samples: 0 and its edges will alias.\n' +
+      '\n' +
+      '  The sample count belongs to the pixel format x11-dri builds one layer below\n' +
+      '  ntk (EGL_SAMPLES on dri3, kCGLPFASamples on appledri), and it takes no such\n' +
+      '  option yet — there is nothing here to ask with.\n' +
+      '\n' +
+      '  Branch on config.samples (or gl.samples) rather than on having asked. For\n' +
+      "  multisampling today: indirect GLX honours SAMPLES (glPolicy: 'indirect'),\n" +
+      '  where the server picks an fbconfig that has it — or supersample in your own\n' +
+      '  draw code. See docs/context-gles.md#multisampling.'
+  );
+}
+
+/**
  * The backend `getContext('opengl')` should use right now, synchronously.
  *
  * Synchronous because `getContext` is, and the async part (two extension

--- a/lib/glx.js
+++ b/lib/glx.js
@@ -131,7 +131,15 @@ const legacyProps = {
   BLUE_SIZE: 'blueBits',
   ALPHA_SIZE: 'alphaBits',
   AUX_BUFFERS: 'numAuxBuffers',
-  LEVEL: 'level'
+  LEVEL: 'level',
+  // Not among GetVisualConfigs' fixed properties, but a server that has
+  // multisample visuals sends these as (tag, value) pairs after them, which
+  // x11 decodes under their attribute names. Mapped to themselves so a
+  // SAMPLES request is filtered on this path too rather than passing
+  // through unexamined — a spec that asks for multisampling and gets a
+  // visual without it is the failure this whole field exists to stop.
+  SAMPLE_BUFFERS: 'SAMPLE_BUFFERS',
+  SAMPLES: 'SAMPLES'
 };
 
 // attributes compared as "at least this much"; the rest must match exactly
@@ -219,8 +227,11 @@ function matchLegacy(configs, spec) {
  *   `null` means "don't care". `screen` picks the X screen (default 0),
  *   `visual` pins a specific visual id and skips the search.
  * @returns {Promise<{visual: number, depth: number, class: number,
- *   doubleBuffer: boolean, depthSize: number, fbconfig: number|null,
- *   config: object}>}
+ *   doubleBuffer: boolean, depthSize: number, samples: number|null,
+ *   fbconfig: number|null, config: object}>} `samples` is the colour
+ *   samples per pixel the chosen config has — 0 for no multisampling, and
+ *   `null` only in the pinned-`visual` case, where no fbconfig was looked
+ *   at to know.
  */
 export async function chooseGLXConfig(app, spec = {}) {
   const GLX = app.display.GLX;
@@ -255,6 +266,9 @@ export async function chooseGLXConfig(app, spec = {}) {
       class: info.visual.class,
       doubleBuffer: !!toNumber(want.DOUBLEBUFFER),
       depthSize: toNumber(want.DEPTH_SIZE) || 0,
+      // the caller pinned the visual, so nothing was chosen and no fbconfig
+      // was read: unknown, which is not the same claim as "none"
+      samples: null,
       screen: screenNum,
       fbconfig: null,
       config: {}
@@ -272,6 +286,7 @@ export async function chooseGLXConfig(app, spec = {}) {
       class: info.visual.class,
       doubleBuffer: !!cfg.DOUBLEBUFFER,
       depthSize: cfg.DEPTH_SIZE || 0,
+      samples: cfg.SAMPLES || 0,
       screen: screenNum,
       fbconfig: cfg.FBCONFIG_ID,
       config: cfg
@@ -292,6 +307,7 @@ export async function chooseGLXConfig(app, spec = {}) {
       class: info.visual.class,
       doubleBuffer: !!cfg.doubleBufferMode,
       depthSize: cfg.depthBits || 0,
+      samples: cfg.SAMPLES || 0,
       screen: screenNum,
       fbconfig: null,
       config: cfg

--- a/lib/renderingcontext_cgl.js
+++ b/lib/renderingcontext_cgl.js
@@ -43,7 +43,15 @@
 
 import { connectionGone } from './cleanup.js';
 import Drawable from './drawable.js';
-import { GLError, backendFor, glError, loadDriAddon } from './gl.js';
+import {
+  DIRECT_SAMPLES,
+  GLError,
+  backendFor,
+  glError,
+  loadDriAddon,
+  requestedSamples,
+  warnDirectSamples
+} from './gl.js';
 
 /** pacing fallback where the display's rate is not known (see App#frameInterval) */
 const FALLBACK_FRAME_INTERVAL = 1000 / 60;
@@ -115,6 +123,17 @@ does not make it retroactive. Either:
       );
     }
     this.depth = depth;
+
+    /**
+     * Colour samples per pixel — 0 here, as on every direct flavor
+     * (`DIRECT_SAMPLES`). A config asking for more is a request this
+     * pipeline cannot pass on, so it is answered rather than dropped: the
+     * warning fires once per connection, and draw code branches on this.
+     */
+    this.samples = DIRECT_SAMPLES;
+    const wantSamples = Math.max(requestedSamples(config), Number(config.samples) || 0);
+    if (wantSamples > DIRECT_SAMPLES) warnDirectSamples(app, 'appledri', wantSamples);
+
     this._screen = config.screen ?? 0;
     this._clientId = caps.appleClientId ?? dri.apple.clientId();
 

--- a/lib/renderingcontext_gles.js
+++ b/lib/renderingcontext_gles.js
@@ -17,7 +17,15 @@
 // is proven.
 
 import Drawable from './drawable.js';
-import { GLError, backendFor, glError, loadDriAddon } from './gl.js';
+import {
+  DIRECT_SAMPLES,
+  GLError,
+  backendFor,
+  glError,
+  loadDriAddon,
+  requestedSamples,
+  warnDirectSamples
+} from './gl.js';
 import { GLSwapchain } from './glswapchain.js';
 
 /**
@@ -97,6 +105,16 @@ does not make it retroactive. Either:
       );
     }
     this.depth = depth;
+
+    /**
+     * Colour samples per pixel — 0 here, as on every direct flavor
+     * (`DIRECT_SAMPLES`). A config asking for more is a request this
+     * pipeline cannot pass on, so it is answered rather than dropped: the
+     * warning fires once per connection, and draw code branches on this.
+     */
+    this.samples = DIRECT_SAMPLES;
+    const wantSamples = Math.max(requestedSamples(config), Number(config.samples) || 0);
+    if (wantSamples > DIRECT_SAMPLES) warnDirectSamples(app, caps.flavor, wantSamples);
 
     const policy = app.glPolicy;
     this.gpu = sharedGpu(app, dri, {

--- a/lib/renderingcontext_opengl.js
+++ b/lib/renderingcontext_opengl.js
@@ -30,6 +30,14 @@ class RenderingContextOpenGL {
     this.contextId = 0;
     /** the config chosen (or passed in), see app.chooseGLXConfig */
     this.config = null;
+    /**
+     * Colour samples per pixel the config in use has: 0 until the config is
+     * resolved, and 0 afterwards unless the spec asked for multisampling and
+     * the server had an fbconfig with it. The direct contexts carry the same
+     * field, so draw code can decide whether to antialias itself without
+     * knowing which backend it is on.
+     */
+    this.samples = 0;
     this.visual = 0;
     this.error = null;
 
@@ -75,6 +83,9 @@ class RenderingContextOpenGL {
     this.ready = (async () => {
       const cfg = await this._resolveConfig(config);
       this.config = cfg;
+      // a config passed in by hand may be the fbconfig itself rather than a
+      // chooseGLXConfig result, so read either shape
+      this.samples = cfg.samples ?? cfg.config?.SAMPLES ?? cfg.SAMPLES ?? 0;
       this.visual = cfg.visual;
       if (window.visual && window.visual !== cfg.visual) {
         console.warn(

--- a/test/gl-policy.test.js
+++ b/test/gl-policy.test.js
@@ -521,6 +521,29 @@ describe("getContext('opengl') dispatch", () => {
     });
   });
 
+  // getContext is the other door a spec can come in through — the direct
+  // contexts read DEPTH_SIZE off the config object they are handed, so a
+  // hand-written `{ DEPTH_SIZE: 24, SAMPLES: 4 }` reaches them without
+  // passing chooseGLConfig at all (issue #341)
+  test('a config asking for samples is answered on the context, not dropped', () => {
+    withEnv(undefined, () => {
+      setDriAddon({ ...darwinAddon, apple: { ...darwinAddon.apple, Context: appleContextStub } });
+      const window = fakeAppleWindow();
+      const said = [];
+      const warn = console.warn;
+      console.warn = (...args) => said.push(args.join(' '));
+      let gl;
+      try {
+        gl = Drawable.renderingContextFactory['opengl'](window, { DEPTH_SIZE: 24, SAMPLES: 4 });
+      } finally {
+        console.warn = warn;
+      }
+      assert.equal(gl.samples, 0, 'what the context has, whatever the config asked for');
+      assert.equal(said.length, 1);
+      assert.match(said[0], /SAMPLES=4/);
+    });
+  });
+
   test("'cgl' by name on the dri3 flavor points back the same way", () => {
     withEnv(undefined, () => {
       setDriAddon(workingAddon);

--- a/test/gl-samples.test.js
+++ b/test/gl-samples.test.js
@@ -1,0 +1,149 @@
+// Multisampling, and what happens to a request for it that a backend cannot
+// meet (issue #341). `chooseGLConfig` speaks GLX's vocabulary on both
+// backends, so `SAMPLES`/`SAMPLE_BUFFERS` has to mean something on both —
+// and where it cannot mean 4x MSAA it has to say so rather than drop the
+// attribute and leave the app to find aliased edges in a screenshot.
+//
+// Hermetic: node-x11's pure-JS X server with its GLX emulator for the
+// indirect half, and a stubbed capability answer for the direct one, so this
+// runs with no display and no GPU.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { after, before, describe, test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+
+import { DIRECT_SAMPLES, requestedSamples } from '../lib/gl.js';
+import { GLXError } from '../lib/glx.js';
+import { createClient, StaticFontSource } from '../lib/index.js';
+
+const require = createRequire(import.meta.url);
+const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
+const { createServer, createStreamPair } = xserver;
+
+let app = null;
+
+// what the console said while `fn` ran, so the downgrade warning can be
+// asserted on the way a caller actually meets it
+async function captured(fn) {
+  const said = [];
+  const warn = console.warn;
+  console.warn = (...args) => said.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.warn = warn;
+  }
+  return said;
+}
+
+// the direct backend's answer, stubbed onto a real App: the capability probe
+// is what these tests are not about
+function asDirect(flavor = 'dri3') {
+  app.options.glPolicy = 'auto';
+  app._glCapsResolved = { direct: true, indirect: true, flavor, device: null, reason: null };
+  app._warnedDirectSamples = false;
+}
+
+function asIndirect() {
+  app.options.glPolicy = 'indirect';
+  app._glCapsResolved = undefined;
+}
+
+before(async () => {
+  const server = createServer({ width: 320, height: 240 });
+  server.registerExtension(
+    'GLX',
+    createGlxExtension({ backend: new RecordingBackend(), getDrawableSurface: () => null })
+  );
+  const [serverEnd, clientEnd] = createStreamPair();
+  server.addClientStream(serverEnd);
+  app = await createClient({ stream: clientEnd, fontSource: new StaticFontSource() });
+});
+
+after(async () => {
+  if (app) await app.close();
+});
+
+describe('requestedSamples', () => {
+  test('reads the count, the bare sample buffer, and the absence of both', () => {
+    assert.equal(requestedSamples({ SAMPLES: 4 }), 4);
+    assert.equal(requestedSamples({ SAMPLE_BUFFERS: 1, SAMPLES: 8 }), 8);
+    // "multisample, width up to the driver" still counts as having asked
+    assert.equal(requestedSamples({ SAMPLE_BUFFERS: 1 }), 1);
+    assert.equal(requestedSamples({ DEPTH_SIZE: 24 }), 0);
+    assert.equal(requestedSamples({ SAMPLES: 0, SAMPLE_BUFFERS: 0 }), 0);
+    assert.equal(requestedSamples(), 0);
+    // a config handed back from chooseGLConfig carries neither attribute
+    assert.equal(requestedSamples({ backend: 'direct', samples: 0 }), 0);
+  });
+});
+
+describe('the indirect backend answers with what the fbconfig has', () => {
+  before(() => asIndirect());
+
+  test('a config says its sample count, so nothing has to assume', async () => {
+    const config = await app.chooseGLConfig();
+    assert.equal(config.backend, 'indirect');
+    assert.equal(config.samples, 0, 'this server publishes one fbconfig, and it has no sample buffers');
+  });
+
+  test('a multisample request it cannot meet fails, and names the constraint', async () => {
+    // The GLX 1.2 fallback used to ignore SAMPLES — GetVisualConfigs does not
+    // carry it among its fixed properties — so a spec asking for 4x came back
+    // as an ordinary visual and the request evaporated on the way through.
+    const said = await captured(() =>
+      assert.rejects(() => app.chooseGLConfig({ SAMPLES: 4 }), (err) => {
+        assert.equal(err.code, GLXError.NO_CONFIG);
+        assert.match(err.message, /SAMPLES=4/);
+        return true;
+      })
+    );
+    assert.deepEqual(said, [], 'the indirect backend has nothing to warn about — it throws');
+  });
+});
+
+describe('the direct backend answers with zero, out loud', () => {
+  test('a spec that asks for samples gets a config that reports what it got', async () => {
+    asDirect();
+    const config = await app.chooseGLConfig({ SAMPLES: 4 });
+    assert.equal(config.backend, 'direct');
+    assert.equal(config.samples, DIRECT_SAMPLES);
+    assert.equal(config.samples, 0, 'no direct flavor can allocate a multisampled window buffer yet');
+    assert.equal(config.depthSize, 16, 'the attributes it does honour are unaffected');
+  });
+
+  test('and says so on the console, with what to do instead', async () => {
+    asDirect('appledri');
+    const said = await captured(() => app.chooseGLConfig({ SAMPLES: 4 }));
+    assert.equal(said.length, 1);
+    assert.match(said[0], /SAMPLES=4/);
+    assert.match(said[0], /appledri/, 'names the flavor that cannot do it');
+    assert.match(said[0], /samples: 0/, 'names the field to branch on');
+    assert.match(said[0], /docs\/context-gles\.md#multisampling/);
+  });
+
+  test('once per connection, not once per window', async () => {
+    asDirect();
+    const first = await captured(() => app.chooseGLConfig({ SAMPLE_BUFFERS: 1 }));
+    const second = await captured(() => app.chooseGLConfig({ SAMPLES: 4 }));
+    assert.equal(first.length, 1, 'a bare SAMPLE_BUFFERS is a multisample request too');
+    assert.deepEqual(second, [], 'the second window would only repeat it');
+  });
+
+  test('a spec that never asked is not warned at, and still reports samples', async () => {
+    asDirect();
+    const said = await captured(async () => {
+      const config = await app.chooseGLConfig({ DEPTH_SIZE: 24 });
+      assert.equal(config.samples, 0);
+      assert.equal(config.depthSize, 24);
+    });
+    assert.deepEqual(said, []);
+  });
+});
+
+test('the remedy the warning points at is a heading that exists', () => {
+  const docs = readFileSync(new URL('../docs/context-gles.md', import.meta.url), 'utf8');
+  assert.ok(/^## Multisampling$/m.test(docs), 'docs/context-gles.md#multisampling');
+});

--- a/test/glx.test.js
+++ b/test/glx.test.js
@@ -108,6 +108,13 @@ describe('GLX config discovery', () => {
     );
   });
 
+  test('the config reports the samples it has, not the samples that were asked for', async () => {
+    // chooseGLXConfig's answer is the direct backend's too (issue #341): a
+    // caller that has to antialias for itself reads one field on either
+    const config = await app.chooseGLXConfig();
+    assert.equal(config.samples, 0, 'the emulator publishes one fbconfig, and it has no sample buffers');
+  });
+
   test('an unknown attribute name is reported, not silently ignored', async () => {
     await assert.rejects(() => app.chooseGLXConfig({ DEPTH_SIZEE: 24 }), /unknown GLX attribute/);
   });


### PR DESCRIPTION
Fixes #341.

`chooseGLConfig` documents GLX's attribute vocabulary as the request on either backend, then read `DEPTH_SIZE` and `ALPHA_SIZE` on direct and dropped the rest — so `{ SAMPLES: 4 }` on the backend with the GPU on it produced aliased edges and no diagnostic. Chasing that turned up the same silence one layer over: the GLX 1.2 fallback never filtered on `SAMPLES` either, because `GetVisualConfigs` does not carry it among its fixed properties, so a request that fell through to that path came back as an ordinary visual.

## What changed

- **Every config reports `samples`** — the colour samples per pixel it really has. The fbconfig's count on indirect, `0` on direct whatever the spec asked for, `null` only where a pinned `visual` means no fbconfig was consulted to know.
- **A request direct cannot meet warns once per connection**, naming the flavor, the field to branch on and what to do instead — through `getContext` too, since the direct contexts read spec-shaped configs handed straight to them.
- **The GLX 1.2 path filters on `SAMPLE_BUFFERS`/`SAMPLES`**, which servers do send after the fixed properties as tag pairs. An unmeetable request now fails there with a message naming the constraint, instead of passing through unexamined.
- **`gl.samples`** on all three contexts, for draw code that has no config in hand.

```js
const config = await app.chooseGLConfig({ SAMPLES: 4 });
if (config.samples < 4) supersample(); // no longer a guess
```

## Why direct still answers 0

Suggestion 1 in the issue is not reachable from here yet, and the reason is a layer down rather than a decision. A sample count belongs to the pixel format `x11-dri` builds — `EGL_SAMPLES` on the EGLConfig behind the GBM surface, `kCGLPFASamples` on the CGL pixel format — and `Gpu`/`apple.Context` take a depth size and no sample count (checked against 0.6.0). Its GL table has neither `renderbufferStorageMultisample` nor `blitFramebuffer`, so ntk cannot stand in for the driver by resolving a multisampled FBO itself either. `DIRECT_SAMPLES` in `lib/gl.js` is the single place that changes when the addon grows the option; the request then travels the rest of the way with no further change here. Happy to open the companion issue on node-x11-dri.

So this PR is suggestion 2, plus the discovery that indirect had a quiet half of the same bug.

## Tests

`test/gl-samples.test.js` — new, hermetic (node-x11's pure-JS server with its GLX emulator for the indirect half, a stubbed capability answer for the direct one): the spec parse, the indirect config's count, the unmeetable request rejecting rather than downgrading, the direct config's `samples: 0`, the warning's content, that it fires once per connection and not at all when nothing was asked, and that the doc anchor it points at exists. Plus one in `test/gl-policy.test.js` for the same request arriving through `getContext`, and one in `test/glx.test.js` for the field on the indirect answer.

`npm test`: 1165 tests, all passing except four that fail the same way on `master` here (two XQuartz Damage timeouts, two `pict-format` ones).

Docs: `docs/context-gles.md` gains a Multisampling section (and its "Choosing a window" section no longer says the rest of the spec is simply ignored); `docs/context-opengl.md` documents the field and the now-filtered legacy path. While in there, the "ES 2 surface" paragraph was still saying textures, FBOs, blending and scissoring were missing from the addon — they have all been there for several releases, and the corrected list is what the Multisampling section's supersampling advice leans on.
