### PR TITLE
fix(gl): Bun passes descriptors now, so stop reporting that it cannot

### DIFF
--- a/docs/context-gles.md
+++ b/docs/context-gles.md
@@ -147,7 +147,7 @@ not the message:
 | `GL_NO_DRIVER` | the platform libraries are missing — `libgbm`/`libEGL`/`libGLESv2` on Linux, libXplugin/OpenGL.framework on macOS — or the platform has no direct path | install Mesa / install XQuartz; elsewhere direct rendering does not exist |
 | `GL_NO_DEVICE` | no readable `/dev/dri/renderD*` (Linux) | map the device into the container, or join the `render` group |
 | `GL_REMOTE_DISPLAY` | a TCP or forwarded display | direct rendering is local-only; use indirect over a network |
-| `GL_NO_FD_PASSING` | local display, but this runtime cannot pass a descriptor (`dri3` flavor only) | run under Node — Bun does not implement the internal x11 uses |
+| `GL_NO_FD_PASSING` | local display, but this connection cannot pass a descriptor (`dri3` flavor only) | under Bun, `npm install x11@^4.1.0` — Node and Bun both pass descriptors, Deno neither |
 | `GL_NO_DRI3` | the server has no DRI3/Present | Xvfb, Xephyr and XQuartz have none (XQuartz has [its own path](#macos)) |
 | `GL_NO_APPLEDRI` | macOS, and the server has no usable Apple-DRI | is the display an XQuartz server? |
 | `GL_NO_WINDOWSERVER` | macOS, but no WindowServer session — SSH | run from the logged-in GUI session |
@@ -165,17 +165,21 @@ be created.
 ### Runtimes
 
 The `dri3` flavor needs a runtime that can send a file descriptor over a
-unix socket, because that is how DRI3 hands the server a buffer. `x11` does
-it through Node's internal `process.binding('pipe_wrap')`, so:
+unix socket, because that is how DRI3 hands the server a buffer. `x11` has a
+transport for each: Node's internal `process.binding('pipe_wrap')`, and
+`bun:ffi` calling `sendmsg(2)` under Bun, which arrived in `x11` 4.1.0 and is
+on by default. So:
 
 | runtime | direct (`dri3`) | direct (`appledri`) | indirect |
 | --- | --- | --- | --- |
 | Node | yes | yes | yes |
-| Bun | **no** — `process.binding('pipe_wrap')` is not implemented | yes — no descriptor ever crosses the socket | yes |
+| Bun | yes — `bun:ffi` `sendmsg(2)`, from `x11` 4.1.0 | yes — no descriptor ever crosses the socket | yes |
 
-Under Bun on Linux the capability probe reports `GL_NO_FD_PASSING` and
-`'auto'` falls back to indirect GLX, which needs no descriptor passing at
-all. Nothing else about the display has to change.
+ntk depends on `x11` `^4.1.0`, so a fresh install has that transport. An
+older `x11` resolved into the tree some other way still reports
+`GL_NO_FD_PASSING` under Bun, and so does a runtime with neither transport —
+Deno, today. `'auto'` then falls back to indirect GLX, which needs no
+descriptor passing at all, and nothing else about the display has to change.
 
 ## The API is not the GLX one
 

--- a/lib/gl.js
+++ b/lib/gl.js
@@ -44,10 +44,13 @@ import { nodeRequire } from './builtin.js';
  *   Linux only, macOS needs no device node.
  * - `GL_REMOTE_DISPLAY` — a TCP or forwarded display; both flavors are
  *   local-only by construction.
- * - `GL_NO_FD_PASSING` — the display is local, but this JavaScript runtime
- *   cannot send a descriptor over the socket. Bun is the case in the field;
- *   x11 does it through a Node internal Bun does not implement. Linux only —
- *   Apple-DRI passes no descriptors.
+ * - `GL_NO_FD_PASSING` — the display is local, but this connection cannot
+ *   send a descriptor over the socket. x11 has a transport for each runtime
+ *   it supports — `process.binding('pipe_wrap')` under Node, `bun:ffi`
+ *   calling `sendmsg(2)` under Bun since x11 4.1.0 — so what is left here is
+ *   an x11 below that under Bun, a runtime with neither path (Deno), or a
+ *   transport that would not initialise. Linux only — Apple-DRI passes no
+ *   descriptors.
  * - `GL_NO_DRI3` — the server has no DRI3/Present (Xvfb, Xephyr, XQuartz —
  *   though XQuartz has its own path, see `GL_NO_APPLEDRI`).
  * - `GL_NO_APPLEDRI` — macOS, and the server has no Apple-DRI extension:
@@ -418,17 +421,20 @@ export function glCapabilities(app) {
 
     if (!canPassDescriptors(app.display)) {
       // The socket is local; what is missing is the ability to send a
-      // descriptor along it. x11 does that through Node's internal
-      // `process.binding('pipe_wrap')`, so a runtime that does not implement
-      // it lands here — Bun, today. Saying "not a local socket" would send
-      // the reader off to check their DISPLAY, which is fine.
+      // descriptor along it. x11 carries one through Node's internal
+      // `process.binding('pipe_wrap')`, and under Bun through `bun:ffi`
+      // calling `sendmsg(2)` — the latter since x11 4.1.0, so an x11 below
+      // that under Bun lands here, as does a runtime with neither path and a
+      // transport that would not initialise. Saying "not a local socket"
+      // would send the reader off to check their DISPLAY, which is fine.
       return fail(
         GLError.NO_FD_PASSING,
-        `this ${runtimeName()} cannot pass file descriptors over the X socket, and DRI3 works by passing one`,
-        'The connection is local; the runtime is what cannot carry the descriptor.\n' +
-          "x11 sends one through Node's process.binding('pipe_wrap'), which Bun does\n" +
-          'not implement. Run under Node for direct rendering, or leave glPolicy at its\n' +
-          'default and use indirect GLX, which needs no descriptor passing at all.'
+        `this connection cannot pass file descriptors over the X socket under ${runtimeName()}, and DRI3 works by passing one`,
+        'The connection is local; the descriptor transport is what is missing.\n' +
+          "x11 carries one through Node's process.binding('pipe_wrap') under Node, and\n" +
+          'through bun:ffi sendmsg(2) under Bun from x11 4.1.0 on. Under Bun on an older\n' +
+          'x11, `npm install x11@^4.1.0` is the whole fix. Otherwise leave glPolicy at\n' +
+          'its default and use indirect GLX, which needs no descriptor passing at all.'
       );
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "linebreak": "^1.1.0",
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
-        "x11": "^4.0.1"
+        "x11": "^4.1.0"
       },
       "devDependencies": {
         "@conventional-commits/parser": "^0.4.1",
@@ -464,9 +464,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-4.0.1.tgz",
-      "integrity": "sha512-24vEriWj4eu2fQxM+SP4wyTKaM8ZCG43BaFskjEy7teHE5I0skQrMuvIpv/4p6DOZFNcWEZHh6DaWQ1rWnibbA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-4.1.0.tgz",
+      "integrity": "sha512-3QU0LZjAH8tIkDxosqmW8MPfJngGqGRmmzIFxnBQLuVqLSy64XMfSWnPX4IELlLiq8CJhQ6+GpFohsQVDOAGyw==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "linebreak": "^1.1.0",
     "parse-color": "^1.0.0",
     "pngjs": "^7.0.0",
-    "x11": "^4.0.1"
+    "x11": "^4.1.0"
   },
   "optionalDependencies": {
     "x11-dri": ">=0.5.0 <1"

--- a/test/gl-policy.test.js
+++ b/test/gl-policy.test.js
@@ -294,18 +294,19 @@ describe('glCapabilities', () => {
     assert.equal(asked, false, 'a connection that cannot pass an fd needs no round trip');
   });
 
-  test('a local socket the runtime cannot pass an fd down is a different answer', async () => {
-    // Bun is the case in the field: the display is local and perfectly
-    // usable, and x11 reaches for a Node internal Bun does not implement.
-    // Reporting "not a local socket" would send the reader off to check
-    // DISPLAY, which is fine.
+  test('a local socket that cannot carry an fd is a different answer', async () => {
+    // The display is local and perfectly usable; what is absent is the
+    // descriptor transport. x11 has one for Node (`process.binding`) and one
+    // for Bun (`bun:ffi` sendmsg, from x11 4.1.0), so this is an older x11
+    // under Bun, or a runtime with neither. Reporting "not a local socket"
+    // would send the reader off to check DISPLAY, which is fine.
     setDriAddon(workingAddon);
     const caps = await glCapabilities(
       fakeApp({ local: true, fdCapable: false, options: { glPolicy: 'auto' } })
     );
     assert.equal(caps.reason.code, GLError.NO_FD_PASSING);
     assert.match(caps.reason.message, /file descriptors/);
-    assert.match(caps.reason.hint, /Bun/, 'and names the runtime that does this');
+    assert.match(caps.reason.hint, /x11@\^4\.1\.0/, 'and names the upgrade that fixes it');
     assert.doesNotMatch(
       caps.reason.message,
       /not a local socket/,


### PR DESCRIPTION
`sidorares/node-x11#290`, merged 2026-08-27 and released as x11 4.1.0, added
`lib/fdpass-bun.js`: fd passing under Bun through a `bun:ffi` dlopen on
sendmsg. Sending works by default, with no opt-in. Four places in ntk still
said the opposite, and sent Bun users to Node for a problem they no longer
have.

## Verified before rewriting

Against a real X socket on this machine, with Bun 1.4.0 and Node 26:

| | `_fdCapable` | `sendFds` | `canPassDescriptors` |
| --- | --- | --- | --- |
| x11 4.0.1 + Bun | false | undefined | **false** |
| x11 4.1.0 + Bun | true | function | **true** |
| x11 4.0.1 + Node | true | function | true |
| x11 4.1.0 + Node | true | function | true |

The published 4.1.0 tarball confirms the shape: `lib/fdpass.js` probes for the
`Bun` global and delegates to `fdpass-bun.js`, which dlopens sendmsg through
`bun:ffi`. Send-only is the default path, and `receiveFds: true` is a separate
opt-in for the receive direction that ntk does not need.

## What changed

- the `GL_NO_FD_PASSING` bullet in the `GLError` catalogue
- the branch comment and the `fail` hint in `glCapabilities`
- the `GLError` table row in `docs/context-gles.md`
- the runtime capability table and the paragraph under it

The code and the branch are untouched. `GL_NO_FD_PASSING` stays a real code,
and the text now names what is actually left: an x11 below 4.1.0 under Bun, a
runtime with neither transport such as Deno, or a transport that would not
initialise.

Following the errors policy in `AGENTS.md` — recommend the cheapest real fix
first — the hint leads with `npm install x11@^4.1.0` rather than "run under
Node".

One phrasing change beyond the four. The message blamed the runtime by name
for what is now usually a version problem, so it now reads "this connection
cannot pass file descriptors over the X socket under ...", keeping the runtime
in the diagnostic without making it the accusation.

## Dependency floor

`x11` moves from `^4.0.1` to `^4.1.0`, with `package-lock.json` regenerated in
the same commit. The docs now promise the Bun transport, and `^4.0.1` would
let a stale lock resolve to 4.0.1 and make that promise false. That is also
why this is typed `fix` and not `docs`: the floor has to be released to reach
consumers.

## Test

`test/gl-policy.test.js` carried the same stale claim in a comment, and its
hint assertion matched on the string `Bun`, labelled "names the runtime that
does this". That would have kept passing against the new text while asserting
a premise that no longer holds, so it is retargeted to the remedy and
mutation-checked: breaking the hint drops the suite to 41 pass, 1 fail.

`npm test`: 1169 pass, 0 fail, 3 skipped. No prettier run.

No visual surface, so no screenshots.
